### PR TITLE
srs reusable thread need join

### DIFF
--- a/trunk/src/app/srs_app_thread.cpp
+++ b/trunk/src/app/srs_app_thread.cpp
@@ -235,7 +235,7 @@ namespace internal {
         // when thread terminated normally, also disposed.
         // we must set to disposed before the on_thread_stop, which may free the thread.
         // @see https://github.com/ossrs/srs/issues/546
-        disposed = true;
+        // disposed = true;
         
         handler->on_thread_stop();
         srs_info("thread %s cycle finished", _name);

--- a/trunk/src/app/srs_app_thread.cpp
+++ b/trunk/src/app/srs_app_thread.cpp
@@ -232,11 +232,6 @@ namespace internal {
         // readly terminated now.
         really_terminated = true;
         
-        // when thread terminated normally, also disposed.
-        // we must set to disposed before the on_thread_stop, which may free the thread.
-        // @see https://github.com/ossrs/srs/issues/546
-        // disposed = true;
-        
         handler->on_thread_stop();
         srs_info("thread %s cycle finished", _name);
     }


### PR DESCRIPTION
我详细描述一下问题
在SrsThread::stop()函数中是先loop = false, 然后再执行SrsThread::dispose()函数，
在SrsThread::thread_cycle()中退出loop，变量disposed = true，
这样的话，就有可能在执行SrsThread::dispose()之前变量disposed就赋值为true，导致SrsThread::dispose()函数直接return了

还有个问题，我就注释了一行代码，上面是issue546#546的描述，我觉得#546的出现是因为在handler->on_thread_stop()只后执行了disposed的赋值，因为对于SrsConnection来说在handler->on_thread_stop()中是删除自己的操作，也就是free当前的thread，所以任何在handler->on_thread_stop()之后的任何操作都会出错