### PR TITLE
Flush the stdout buffer after logging to console

### DIFF
--- a/trunk/src/app/srs_app_log.cpp
+++ b/trunk/src/app/srs_app_log.cpp
@@ -382,6 +382,7 @@ void SrsFastLog::write_log(int& fd, char *str_log, int size, int level)
         } else{
             printf("\033[31m%.*s\033[0m", size, str_log);
         }
+        fflush(stdout);
 
         return;
     }


### PR DESCRIPTION
Normally if the stdout is connected to a PTY, the `stdout` buffer is flushed automatically after each `\n`.
However if I run SRS under Docker (or other container services), the `stdout` is not connected to a PTY (unless I ask it to), causing the last log line to be incomplete (showing only half).
By adding `fflush`, we could make sure each log line is completely shown, whenever the `stdout` is connected to a PTY or not.

P.S. I am working on an SRS Docker image, which allows "one-key installing" SRS on a huge cluster of servers. It is available at <https://hub.docker.com/r/m13253/srs/>, with build script available at <https://github.com/m13253/docker-srs>.