### PR TITLE
2.0release-bugfix

### DIFF
--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -871,7 +871,7 @@ int SrsRtmpConn::do_publishing(SrsSource* source, SrsPublishRecvThread* trd)
     
     // initialize the publish timeout.
     publish_1stpkt_timeout = _srs_config->get_publish_1stpkt_timeout(req->vhost);
-    publish_normal_timeout = _srs_config->get_publish_1stpkt_timeout(req->vhost);
+    publish_normal_timeout = _srs_config->get_publish_normal_timeout(req->vhost);
     
     // set the sock options.
     set_sock_options();

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -2202,7 +2202,10 @@ void SrsSource::on_unpublish()
     // donot clear the sequence header, for it maybe not changed,
     // when drop dup sequence header, drop the metadata also.
     gop_cache->clear();
-    
+    srs_freep(cache_metadata);
+    srs_freep(cache_sh_video);
+    srs_freep(cache_sh_audio);    
+
     srs_info("clear cache/metadata when unpublish.");
     srs_trace("cleanup when unpublish");
     


### PR DESCRIPTION
bugfix1: publish_normal_timeout 配置读取错误
bugfix2: atc 开启后，如果客户端重置推流时间撮，会导致consumer wait condition 长时间不触发.