### PR TITLE
bugfix atc 开启后，由于客户端重置时间撮，会导致consumer wait condition 长时间不触发.

### DIFF
--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -2202,7 +2202,10 @@ void SrsSource::on_unpublish()
     // donot clear the sequence header, for it maybe not changed,
     // when drop dup sequence header, drop the metadata also.
     gop_cache->clear();
-    
+    srs_freep(cache_metadata);
+    srs_freep(cache_sh_video);
+    srs_freep(cache_sh_audio);    
+
     srs_info("clear cache/metadata when unpublish.");
     srs_trace("cleanup when unpublish");
     


### PR DESCRIPTION
bugfix : atc 开启后，由于客户端重置时间撮，会导致consumer wait condition 长时间不触发.