### PR TITLE
Return param key on on_publish and on_unpublish

### DIFF
--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -138,6 +138,7 @@ int SrsHttpHooks::on_publish(string url, SrsRequest* req)
         << SRS_JFIELD_STR("ip", req->ip) << SRS_JFIELD_CONT
         << SRS_JFIELD_STR("vhost", req->vhost) << SRS_JFIELD_CONT
         << SRS_JFIELD_STR("app", req->app) << SRS_JFIELD_CONT
+        << SRS_JFIELD_STR("param", req->param) << SRS_JFIELD_CONT
         << SRS_JFIELD_STR("tcUrl", req->tcUrl) << SRS_JFIELD_CONT  // Add tcUrl for auth publish rtmp stream client
         << SRS_JFIELD_STR("stream", req->stream)
         << SRS_JOBJECT_END;
@@ -172,6 +173,7 @@ void SrsHttpHooks::on_unpublish(string url, SrsRequest* req)
         << SRS_JFIELD_STR("ip", req->ip) << SRS_JFIELD_CONT
         << SRS_JFIELD_STR("vhost", req->vhost) << SRS_JFIELD_CONT
         << SRS_JFIELD_STR("app", req->app) << SRS_JFIELD_CONT
+        << SRS_JFIELD_STR("param", req->param) << SRS_JFIELD_CONT
         << SRS_JFIELD_STR("stream", req->stream)
         << SRS_JOBJECT_END;
         


### PR DESCRIPTION
- Add `param` key to the `on_publish` and `on_unpublish` HTTP callbacks
so to manage parameters like authentication token and others easily.

Reference issue: https://github.com/ossrs/srs/issues/787