### PR TITLE
fix bug, 修复UserControlPacket包的event data 数值

### DIFF
--- a/trunk/src/protocol/srs_rtmp_stack.cpp
+++ b/trunk/src/protocol/srs_rtmp_stack.cpp
@@ -5298,7 +5298,7 @@ int SrsUserControlPacket::encode_packet(SrsStream* stream)
     stream->write_2bytes(event_type);
     
     if (event_type == SrsPCUCFmsEvent0) {
-        stream->write_1bytes(event_data);
+        stream->write_1bytes(1);
     } else {
         stream->write_4bytes(event_data);
     }


### PR DESCRIPTION
the event data in User Control Packet whose type is SrsPCUCFmsEvent0(0x1a) should be 1 not 0