### PR TITLE
FIX：When stream stopped，Stream API does not remove it。

### DIFF
--- a/trunk/src/app/srs_app_statistic.cpp
+++ b/trunk/src/app/srs_app_statistic.cpp
@@ -358,8 +358,19 @@ void SrsStatistic::on_stream_close(SrsRequest* req)
 {
     SrsStatisticVhost* vhost = create_vhost(req);
     SrsStatisticStream* stream = create_stream(vhost, req);
-
     stream->close();
+	
+	//TODO Is this correct? Something is not released?
+	std::map<int64_t, SrsStatisticStream*>::iterator it;
+	if ((it=streams.find(stream->id)) != streams.end()) {
+		streams.erase(it);
+	}
+
+	std::map<std::string, SrsStatisticStream*>::iterator sit;
+	if ((sit=rstreams.find(stream->url)) != rstreams.end()) {
+		rstreams.erase(sit);
+	}
+
 }
 
 int SrsStatistic::on_client(int id, SrsRequest* req, SrsConnection* conn, SrsRtmpConnType type)


### PR DESCRIPTION
HTTP API for streams is not correct. When stream stopped, API does not
remove it. 
Issue #634