### PR TITLE
Fix the timebase bug, change from us to ms.

### DIFF
--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -152,7 +152,7 @@ int SrsBufferCache::cycle()
         if (count <= 0) {
             srs_info("http: sleep %dms for no msg", SRS_CONSTS_RTMP_PULSE_TMMS);
             // directly use sleep, donot use consumer wait.
-            st_usleep(SRS_CONSTS_RTMP_PULSE_TMMS * 1000);
+            st_usleep(SRS_CONSTS_RTMP_PULSE_TMMS);
             
             // ignore when nothing got.
             continue;

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -152,7 +152,7 @@ int SrsBufferCache::cycle()
         if (count <= 0) {
             srs_info("http: sleep %dms for no msg", SRS_CONSTS_RTMP_PULSE_TMMS);
             // directly use sleep, donot use consumer wait.
-            st_usleep(SRS_CONSTS_RTMP_PULSE_TMMS);
+            st_usleep(SRS_CONSTS_RTMP_PULSE_TMMS * 1000);
             
             // ignore when nothing got.
             continue;
@@ -572,7 +572,7 @@ int SrsLiveStream::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r)
         if (count <= 0) {
             srs_info("http: sleep %dms for no msg", SRS_CONSTS_RTMP_PULSE_TMMS);
             // directly use sleep, donot use consumer wait.
-            st_usleep(SRS_CONSTS_RTMP_PULSE_TMMS);
+            st_usleep(SRS_CONSTS_RTMP_PULSE_TMMS * 1000);
             
             // ignore when nothing got.
             continue;

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -550,7 +550,7 @@ int SrsConsumer::dump_packets(SrsMessageArray* msgs, int& count)
 void SrsConsumer::wait(int nb_msgs, int duration)
 {
     if (paused) {
-        st_usleep(SRS_CONSTS_RTMP_PULSE_TMMS);
+        st_usleep(SRS_CONSTS_RTMP_PULSE_TMMS * 1000);
         return;
     }
     

--- a/trunk/src/kernel/srs_kernel_consts.hpp
+++ b/trunk/src/kernel/srs_kernel_consts.hpp
@@ -77,7 +77,7 @@
 // if timeout, we generally ignore and send the data to client,
 // generally, it's the pulse time for data seding.
 // @remark, recomment to 500ms.
-#define SRS_CONSTS_RTMP_PULSE_TMMS (int64_t)(500*1000LL)
+#define SRS_CONSTS_RTMP_PULSE_TMMS (500)
 
 /**
  * max rtmp header size:

--- a/trunk/src/kernel/srs_kernel_consts.hpp
+++ b/trunk/src/kernel/srs_kernel_consts.hpp
@@ -77,7 +77,7 @@
 // if timeout, we generally ignore and send the data to client,
 // generally, it's the pulse time for data seding.
 // @remark, recomment to 500ms.
-#define SRS_CONSTS_RTMP_PULSE_TMMS (500)
+#define SRS_CONSTS_RTMP_PULSE_TMMS (int64_t)(500*1000LL)
 
 /**
  * max rtmp header size:


### PR DESCRIPTION
修改SRS_CONSTS_RTMP_PULSE_TMMS的定义 从500 改为500*1000，如果是500，在使用http-flv播放时单个cpu会占100%的问题