### PR TITLE
Refine srs_app_thread code

### DIFF
--- a/trunk/src/app/srs_app_edge.cpp
+++ b/trunk/src/app/srs_app_edge.cpp
@@ -172,7 +172,7 @@ SrsEdgeIngester::SrsEdgeIngester()
     
     upstream = new SrsEdgeRtmpUpstream(redirect);
     lb = new SrsLbRoundRobin();
-    pthread = new SrsReusableThread2("edge-igs", this, SRS_EDGE_INGESTER_CIMS);
+    pthread = new SrsReusableThread("edge-igs", this, SRS_EDGE_INGESTER_CIMS);
 }
 
 SrsEdgeIngester::~SrsEdgeIngester()
@@ -408,7 +408,7 @@ SrsEdgeForwarder::SrsEdgeForwarder()
     
     sdk = NULL;
     lb = new SrsLbRoundRobin();
-    pthread = new SrsReusableThread2("edge-fwr", this, SRS_EDGE_FORWARDER_CIMS);
+    pthread = new SrsReusableThread("edge-fwr", this, SRS_EDGE_FORWARDER_CIMS);
     queue = new SrsMessageQueue();
 }
 

--- a/trunk/src/app/srs_app_edge.hpp
+++ b/trunk/src/app/srs_app_edge.hpp
@@ -114,13 +114,13 @@ public:
 /**
  * edge used to ingest stream from origin.
  */
-class SrsEdgeIngester : public ISrsReusableThread2Handler
+class SrsEdgeIngester : public ISrsReusableThreadHandler
 {
 private:
     SrsSource* source;
     SrsPlayEdge* edge;
     SrsRequest* req;
-    SrsReusableThread2* pthread;
+    SrsReusableThread* pthread;
     SrsLbRoundRobin* lb;
     SrsEdgeUpstream* upstream;
     // for RTMP 302 redirect.
@@ -144,13 +144,13 @@ private:
 /**
  * edge used to forward stream to origin.
  */
-class SrsEdgeForwarder : public ISrsReusableThread2Handler
+class SrsEdgeForwarder : public ISrsReusableThreadHandler
 {
 private:
     SrsSource* source;
     SrsPublishEdge* edge;
     SrsRequest* req;
-    SrsReusableThread2* pthread;
+    SrsReusableThread* pthread;
     SrsSimpleRtmpClient* sdk;
     SrsLbRoundRobin* lb;
     /**

--- a/trunk/src/app/srs_app_forward.cpp
+++ b/trunk/src/app/srs_app_forward.cpp
@@ -58,7 +58,7 @@ SrsForwarder::SrsForwarder(SrsOriginHub* h)
     sh_video = sh_audio = NULL;
     
     sdk = NULL;
-    pthread = new SrsReusableThread2("forward", this, SRS_FORWARDER_CIMS);
+    pthread = new SrsReusableThread("forward", this, SRS_FORWARDER_CIMS);
     queue = new SrsMessageQueue();
     jitter = new SrsRtmpJitter();
 }

--- a/trunk/src/app/srs_app_forward.hpp
+++ b/trunk/src/app/srs_app_forward.hpp
@@ -47,14 +47,14 @@ class SrsSimpleRtmpClient;
  * forward the stream to other servers.
  */
 // TODO: FIXME: refine the error log, comments it.
-class SrsForwarder : public ISrsReusableThread2Handler
+class SrsForwarder : public ISrsReusableThreadHandler
 {
 private:
     // the ep to forward, server[:port].
     std::string ep_forward;
     SrsRequest* req;
 private:
-    SrsReusableThread2* pthread;
+    SrsReusableThread* pthread;
 private:
     SrsOriginHub* hub;
     SrsSimpleRtmpClient* sdk;

--- a/trunk/src/app/srs_app_recv_thread.cpp
+++ b/trunk/src/app/srs_app_recv_thread.cpp
@@ -60,7 +60,7 @@ SrsRecvThread::SrsRecvThread(ISrsMessagePumper* p, SrsRtmpServer* r, int tm)
     rtmp = r;
     pumper = p;
     timeout = tm;
-    trd = new SrsReusableThread2("recv", this);
+    trd = new SrsReusableThread("recv", this);
 }
 
 SrsRecvThread::~SrsRecvThread()

--- a/trunk/src/app/srs_app_recv_thread.hpp
+++ b/trunk/src/app/srs_app_recv_thread.hpp
@@ -90,10 +90,10 @@ public:
 /**
  * the recv thread, use message handler to handle each received message.
  */
-class SrsRecvThread : public ISrsReusableThread2Handler
+class SrsRecvThread : public ISrsReusableThreadHandler
 {
 protected:
-    SrsReusableThread2* trd;
+    SrsReusableThread* trd;
     ISrsMessagePumper* pumper;
     SrsRtmpServer* rtmp;
     // The recv timeout in ms.

--- a/trunk/src/app/srs_app_thread.cpp
+++ b/trunk/src/app/srs_app_thread.cpp
@@ -247,91 +247,12 @@ void SrsReusableThread::on_thread_stop()
     handler->on_thread_stop();
 }
 
-ISrsReusableThread2Handler::ISrsReusableThread2Handler()
-{
-}
-
-ISrsReusableThread2Handler::~ISrsReusableThread2Handler()
-{
-}
-
-void ISrsReusableThread2Handler::on_thread_start()
-{
-}
-
-int ISrsReusableThread2Handler::on_before_cycle()
-{
-    return ERROR_SUCCESS;
-}
-
-int ISrsReusableThread2Handler::on_end_cycle()
-{
-    return ERROR_SUCCESS;
-}
-
-void ISrsReusableThread2Handler::on_thread_stop()
-{
-}
-
-SrsReusableThread2::SrsReusableThread2(const char* n, ISrsReusableThread2Handler* h, int64_t cims)
-{
-    handler = h;
-    pthread = new internal::SrsThread(n, this, cims, true);
-}
-
-SrsReusableThread2::~SrsReusableThread2()
-{
-    pthread->stop();
-    srs_freep(pthread);
-}
-
-int SrsReusableThread2::start()
-{
-    return pthread->start();
-}
-
-void SrsReusableThread2::stop()
-{
-    pthread->stop();
-}
-
-int SrsReusableThread2::cid()
-{
-    return pthread->cid();
-}
-
-void SrsReusableThread2::interrupt()
+void SrsReusableThread::interrupt()
 {
     pthread->stop_loop();
 }
 
-bool SrsReusableThread2::interrupted()
+bool SrsReusableThread::interrupted()
 {
-    return !pthread->can_loop();
+    return !can_loop();
 }
-
-int SrsReusableThread2::cycle()
-{
-    return handler->cycle();
-}
-
-void SrsReusableThread2::on_thread_start()
-{
-    handler->on_thread_start();
-}
-
-int SrsReusableThread2::on_before_cycle()
-{
-    return handler->on_before_cycle();
-}
-
-int SrsReusableThread2::on_end_cycle()
-{
-    return handler->on_end_cycle();
-}
-
-void SrsReusableThread2::on_thread_stop()
-{
-    handler->on_thread_stop();
-}
-

--- a/trunk/src/app/srs_app_thread.hpp
+++ b/trunk/src/app/srs_app_thread.hpp
@@ -220,89 +220,6 @@ public:
      * @remark when start thread, parent thread will block and wait for this id ready.
      */
     virtual int cid();
-// interface internal::ISrsThreadHandler
-public:
-    virtual int cycle();
-    virtual void on_thread_start();
-    virtual int on_before_cycle();
-    virtual int on_end_cycle();
-    virtual void on_thread_stop();
-};
-
-/**
- * the reuse thread is a thread stop and start by other thread.
- * the version 2, is the thread cycle has its inner loop, which should
- * check the intterrupt, and should interrupt thread when the inner loop want
- * to quit the thread.
- *       user can create thread and stop then start again and again,
- *       generally must provides a start and stop method, @see SrsIngester.
- *       the step to create a thread stop by other thread:
- *       1. create SrsReusableThread field.
- *       2. must manually stop the thread when started it.
- *       for example:
- *           class SrsIngester : public ISrsReusableThreadHandler {
- *               public: SrsIngester() { pthread = new SrsReusableThread("ingest", this, SRS_AUTO_INGESTER_CIMS); }
- *               public: virtual int start() { return pthread->start(); }
- *               public: virtual void stop() { pthread->stop(); }
- *               public: virtual int cycle() {
- *                  while (!pthread->interrupted()) {
- *                      // quit thread when error.
- *                      if (ret != ERROR_SUCCESS) {
- *                          pthread->interrupt();
- *                      }
- *
- *                      // do something.
- *                  }
- *               }
- *           };
- */
-class ISrsReusableThread2Handler
-{
-public:
-    ISrsReusableThread2Handler();
-    virtual ~ISrsReusableThread2Handler();
-public:
-    /**
-     * the cycle method for the one cycle thread.
-     * @remark when the cycle has its inner loop, it must check whether
-     * the thread is interrupted.
-     */
-    virtual int cycle() = 0;
-public:
-    /**
-     * other callback for handler.
-     * @remark all callback is optional, handler can ignore it.
-     */
-    virtual void on_thread_start();
-    virtual int on_before_cycle();
-    virtual int on_end_cycle();
-    virtual void on_thread_stop();
-};
-class SrsReusableThread2 : public internal::ISrsThreadHandler
-{
-private:
-    internal::SrsThread* pthread;
-    ISrsReusableThread2Handler* handler;
-public:
-    SrsReusableThread2(const char* n, ISrsReusableThread2Handler* h, int64_t cims = 0);
-    virtual ~SrsReusableThread2();
-public:
-    /**
-     * for the reusable thread, start and stop by user.
-     */
-    virtual int start();
-    /**
-     * stop the thread, wait for the thread to terminate.
-     * @remark user can stop multiple times, ignore if already stopped.
-     */
-    virtual void stop();
-public:
-    /**
-     * get the context id. @see: ISrsThreadContext.get_id().
-     * used for parent thread to get the id.
-     * @remark when start thread, parent thread will block and wait for this id ready.
-     */
-    virtual int cid();
     /**
      * interrupt the thread to stop loop.
      * we only set the loop flag to false, not really interrupt the thread.
@@ -322,6 +239,5 @@ public:
     virtual int on_end_cycle();
     virtual void on_thread_stop();
 };
-
 #endif
 


### PR DESCRIPTION
SrsReusableThread and SrsReusableThread2 are most indetical.
ISrsReusableThreadHandler and ISrsReusableThread2Handler have same interface declaration.
Merge them into one class and one interface.