### PR TITLE
Fix crash issue at srs_app_encoder

### DIFF
--- a/trunk/src/app/srs_app_async_call.cpp
+++ b/trunk/src/app/srs_app_async_call.cpp
@@ -38,7 +38,7 @@ ISrsAsyncCallTask::~ISrsAsyncCallTask()
 
 SrsAsyncCallWorker::SrsAsyncCallWorker()
 {
-    trd = NULL;
+    trd = new SrsCoroutine("async", this, _srs_context->get_id());
     wait = srs_cond_new();
 }
 

--- a/trunk/src/app/srs_app_edge.cpp
+++ b/trunk/src/app/srs_app_edge.cpp
@@ -166,7 +166,7 @@ SrsEdgeIngester::SrsEdgeIngester()
     
     upstream = new SrsEdgeRtmpUpstream(redirect);
     lb = new SrsLbRoundRobin();
-    trd = NULL;
+    trd = new SrsCoroutine("edge-igs", this);
 }
 
 SrsEdgeIngester::~SrsEdgeIngester()
@@ -423,7 +423,7 @@ SrsEdgeForwarder::SrsEdgeForwarder()
     
     sdk = NULL;
     lb = new SrsLbRoundRobin();
-    trd = NULL;
+    trd = new SrsCoroutine("edge-fwr", this);
     queue = new SrsMessageQueue();
 }
 
@@ -493,6 +493,7 @@ int SrsEdgeForwarder::start()
         return ret;
     }
     
+    srs_freep(trd);
     trd = new SrsCoroutine("edge-fwr", this);
     return trd->start();
 }

--- a/trunk/src/app/srs_app_encoder.cpp
+++ b/trunk/src/app/srs_app_encoder.cpp
@@ -41,7 +41,7 @@ static std::vector<std::string> _transcoded_url;
 
 SrsEncoder::SrsEncoder()
 {
-    trd = NULL;
+    trd = new SrsCoroutine("encoder", this, _srs_context->get_id());
     pprint = SrsPithyPrint::create_encoder();
 }
 

--- a/trunk/src/app/srs_app_forward.cpp
+++ b/trunk/src/app/srs_app_forward.cpp
@@ -55,7 +55,7 @@ SrsForwarder::SrsForwarder(SrsOriginHub* h)
     sh_video = sh_audio = NULL;
     
     sdk = NULL;
-    trd = NULL;
+    trd = new SrsCoroutine("forward", this);
     queue = new SrsMessageQueue();
     jitter = new SrsRtmpJitter();
 }

--- a/trunk/src/app/srs_app_ingest.cpp
+++ b/trunk/src/app/srs_app_ingest.cpp
@@ -105,7 +105,7 @@ SrsIngester::SrsIngester()
     
     expired = false;
     
-    trd = NULL;
+    trd = new SrsCoroutine("ingest", this, _srs_context->get_id());
     pprint = SrsPithyPrint::create_ingester();
 }
 

--- a/trunk/src/app/srs_app_kafka.cpp
+++ b/trunk/src/app/srs_app_kafka.cpp
@@ -365,7 +365,7 @@ SrsKafkaProducer::SrsKafkaProducer()
     metadata_expired = srs_cond_new();
     
     lock = srs_mutex_new();
-    trd = NULL;
+    trd = new SrsCoroutine("kafka", this, _srs_context->get_id());
     worker = new SrsAsyncCallWorker();
     cache = new SrsKafkaCache();
     

--- a/trunk/src/app/srs_app_ng_exec.cpp
+++ b/trunk/src/app/srs_app_ng_exec.cpp
@@ -38,7 +38,7 @@ using namespace std;
 
 SrsNgExec::SrsNgExec()
 {
-    trd = NULL;
+    trd = new SrsCoroutine("encoder", this, _srs_context->get_id());
     pprint = SrsPithyPrint::create_exec();
 }
 

--- a/trunk/src/app/srs_app_recv_thread.cpp
+++ b/trunk/src/app/srs_app_recv_thread.cpp
@@ -61,7 +61,7 @@ SrsRecvThread::SrsRecvThread(ISrsMessagePumper* p, SrsRtmpServer* r, int tm)
     rtmp = r;
     pumper = p;
     timeout = tm;
-    trd = NULL;
+    trd = new SrsCoroutine("recv", this);
 }
 
 SrsRecvThread::~SrsRecvThread()


### PR DESCRIPTION
Root Cause:
On SrsEncoder::on_publish, if ret is equal to ERROR_ENCODER_LOOP and ffmpegs is empty.
It wouldn't create a trd object.
On SrsEncoder::on_unpublish:
Since the trd is NULL, it would crash.