### PR TITLE
IPv6 support (for 2.0 release)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -26,4 +26,4 @@ CONTRIBUTORS ordered by first contribution.
 * lovecat<littlefawn@163.com> "Bug fixed"
 * panda1986<542638787@qq.com> "Bug fixed"
 * YueHonghui<hongf.yue@hotmail.com> "Bug fixed"
-* Thomas Dreibholz <dreibh@simula.no> "IPv6 support"
+* ThomasDreibholz<dreibh@simula.no> "IPv6 support"

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -26,4 +26,4 @@ CONTRIBUTORS ordered by first contribution.
 * lovecat<littlefawn@163.com> "Bug fixed"
 * panda1986<542638787@qq.com> "Bug fixed"
 * YueHonghui<hongf.yue@hotmail.com> "Bug fixed"
-
+* Thomas Dreibholz <dreibh@simula.no> "IPv6 support"

--- a/trunk/configure
+++ b/trunk/configure
@@ -82,7 +82,7 @@ done
 #####################################################################################
 # build tools or compiler args.
 # enable gdb debug
-GDBDebug=" -g -O0"
+GDBDebug=" -g -O1"
 # the warning level.
 WarnLevel=" -Wall"
 # the compile standard.

--- a/trunk/src/app/srs_app_listener.cpp
+++ b/trunk/src/app/srs_app_listener.cpp
@@ -176,7 +176,7 @@ int SrsUdpListener::cycle()
 
     // TODO: FIXME: support ipv6, @see man 7 ipv6
     sockaddr_storage from;
-    int nb_from = sizeof(sockaddr_in6);
+    int nb_from = sizeof(from);
     int nread = 0;
 
     if ((nread = st_recvfrom(_stfd, buf, nb_buf, (sockaddr*)&from, &nb_from, ST_UTIME_NO_TIMEOUT)) <= 0) {

--- a/trunk/src/app/srs_app_listener.hpp
+++ b/trunk/src/app/srs_app_listener.hpp
@@ -35,7 +35,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <srs_app_st.hpp>
 #include <srs_app_thread.hpp>
 
-struct sockaddr_in;
+struct sockaddr;
 
 /**
 * the udp packet handler.
@@ -61,7 +61,7 @@ public:
     * @param nb_buf, the size of udp packet bytes.
     * @remark user should never use the buf, for it's a shared memory bytes.
     */
-    virtual int on_udp_packet(sockaddr_in* from, char* buf, int nb_buf) = 0;
+    virtual int on_udp_packet(sockaddr* from, char* buf, int nb_buf) = 0;
 };
 
 /**

--- a/trunk/src/app/srs_app_mpegts_udp.cpp
+++ b/trunk/src/app/srs_app_mpegts_udp.cpp
@@ -161,8 +161,8 @@ SrsMpegtsOverUdp::~SrsMpegtsOverUdp()
 
 int SrsMpegtsOverUdp::on_udp_packet(sockaddr_in* from, char* buf, int nb_buf)
 {
-    std::string peer_ip = inet_ntoa(from->sin_addr);
-    int peer_port = ntohs(from->sin_port);
+    std::string peer_ip = inet_ntop(from->sin_addr);
+    int peer_port = ntohs(from->sin6_port);
 
     // append to buffer.
     buffer->append(buf, nb_buf);

--- a/trunk/src/app/srs_app_mpegts_udp.cpp
+++ b/trunk/src/app/srs_app_mpegts_udp.cpp
@@ -159,10 +159,18 @@ SrsMpegtsOverUdp::~SrsMpegtsOverUdp()
     srs_freep(pprint);
 }
 
-int SrsMpegtsOverUdp::on_udp_packet(sockaddr_in* from, char* buf, int nb_buf)
+int SrsMpegtsOverUdp::on_udp_packet(sockaddr* from, char* buf, int nb_buf)
 {
-    std::string peer_ip = inet_ntop(from->sin_addr);
-    int peer_port = ntohs(from->sin6_port);
+    char address_string[64];
+    char port_string[16];
+    if(getnameinfo(from, fromlen, 
+                   (char*)&address_string, sizeof(address_string),
+                   (char*)&port_string, sizeof(port_string),
+                   NI_NUMERICHOST|NI_NUMERICSERV) != 0) {
+        abort();
+    }
+    std::string peer_ip = std::string(address_string);
+    int peer_port = atoi(port_string);
 
     // append to buffer.
     buffer->append(buf, nb_buf);

--- a/trunk/src/app/srs_app_mpegts_udp.hpp
+++ b/trunk/src/app/srs_app_mpegts_udp.hpp
@@ -32,7 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #ifdef SRS_AUTO_STREAM_CASTER
 
-struct sockaddr_in;
+struct sockaddr;
 #include <string>
 #include <map>
 
@@ -108,7 +108,7 @@ public:
     virtual ~SrsMpegtsOverUdp();
 // interface ISrsUdpHandler
 public:
-    virtual int on_udp_packet(sockaddr_in* from, char* buf, int nb_buf);
+    virtual int on_udp_packet(sockaddr* from, char* buf, int nb_buf);
 private:
     virtual int on_udp_bytes(std::string host, int port, char* buf, int nb_buf);
 // interface ISrsTsHandler

--- a/trunk/src/app/srs_app_rtsp.cpp
+++ b/trunk/src/app/srs_app_rtsp.cpp
@@ -51,7 +51,7 @@ SrsRtpConn::SrsRtpConn(SrsRtspConn* r, int p, int sid)
     _port = p;
     stream_id = sid;
     // TODO: support listen at <[ip:]port>
-    listener = new SrsUdpListener(this, "0.0.0.0", p);
+    listener = new SrsUdpListener(this, (srs_check_ipv6() ? "::" : "0.0.0.0"), p);
     cache = new SrsRtpPacket();
     pprint = SrsPithyPrint::create_caster();
 }
@@ -73,7 +73,7 @@ int SrsRtpConn::listen()
     return listener->listen();
 }
 
-int SrsRtpConn::on_udp_packet(sockaddr_in* from, char* buf, int nb_buf)
+int SrsRtpConn::on_udp_packet(sockaddr* from, char* buf, int nb_buf)
 {
     int ret = ERROR_SUCCESS;
 

--- a/trunk/src/app/srs_app_rtsp.hpp
+++ b/trunk/src/app/srs_app_rtsp.hpp
@@ -77,7 +77,7 @@ public:
     virtual int listen();
 // interface ISrsUdpHandler
 public:
-    virtual int on_udp_packet(sockaddr_in* from, char* buf, int nb_buf);
+    virtual int on_udp_packet(sockaddr* from, char* buf, int nb_buf);
 };
 
 /**

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -1189,7 +1189,8 @@ int SrsServer::listen_stream_caster()
         }
         
         // TODO: support listen at <[ip:]port>
-        if ((ret = listener->listen("0.0.0.0", port)) != ERROR_SUCCESS) {
+        if ((ret = listener->listen(srs_check_ipv6() ? "::" : "0.0.0.0";
+                                    port)) != ERROR_SUCCESS) {
             srs_error("StreamCaster listen at port %d failed. ret=%d", port, ret);
             return ret;
         }

--- a/trunk/src/app/srs_app_utility.cpp
+++ b/trunk/src/app/srs_app_utility.cpp
@@ -30,6 +30,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <signal.h>
 #include <sys/wait.h>
 #include <math.h>
+#include <netdb.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
 
 #ifdef SRS_OSX
 #include <sys/sysctl.h>
@@ -54,15 +58,29 @@ using namespace std;
 int srs_socket_connect(string server, int port, int64_t timeout, st_netfd_t* pstfd)
 {
     int ret = ERROR_SUCCESS;
-    
+
     *pstfd = NULL;
     st_netfd_t stfd = NULL;
-    sockaddr_in addr;
+
+    char port_string[8];
+    snprintf(port_string, sizeof(port_string), "%d", port);
+    addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    addrinfo* result  = NULL;
+
+    if(getaddrinfo(server.c_str(), port_string, (const addrinfo*)&hints, &result) != 0) {
+        ret = ERROR_SYSTEM_IP_INVALID;
+        srs_error("dns resolve server error, ip empty. ret=%d", ret);
+        return ret;
+    }
     
-    int sock = socket(AF_INET, SOCK_STREAM, 0);
-    if(sock == -1){
+    int sock = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
+    if(sock == -1) {
         ret = ERROR_SOCKET_CREATE;
         srs_error("create socket error. ret=%d", ret);
+        freeaddrinfo(result);
         return ret;
     }
     
@@ -71,35 +89,21 @@ int srs_socket_connect(string server, int port, int64_t timeout, st_netfd_t* pst
     if(stfd == NULL){
         ret = ERROR_ST_OPEN_SOCKET;
         srs_error("st_netfd_open_socket failed. ret=%d", ret);
+        srs_close_stfd(stfd);
+        freeaddrinfo(result);
         return ret;
     }
     
-    // connect to server.
-    std::string ip = srs_dns_resolve(server);
-    if (ip.empty()) {
-        ret = ERROR_SYSTEM_IP_INVALID;
-        srs_error("dns resolve server error, ip empty. ret=%d", ret);
-        goto failed;
-    }
-    
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
-    addr.sin_addr.s_addr = inet_addr(ip.c_str());
-    
-    if (st_connect(stfd, (const struct sockaddr*)&addr, sizeof(sockaddr_in), timeout) == -1){
+    if (st_connect(stfd, result->ai_addr, result->ai_addrlen, timeout) == -1){
         ret = ERROR_ST_CONNECT;
-        srs_error("connect to server error. ip=%s, port=%d, ret=%d", ip.c_str(), port, ret);
-        goto failed;
+        srs_error("connect to server error. server=%s, port=%d, ret=%d", server.c_str(), port, ret);
+        srs_close_stfd(stfd);
+        freeaddrinfo(result);
+        return ret;
     }
-    srs_info("connect ok. server=%s, ip=%s, port=%d", server.c_str(), ip.c_str(), port);
+    srs_info("connect ok. server=%s, port=%d", server.c_str(), port);
     
     *pstfd = stfd;
-    return ret;
-    
-failed:
-    if (stfd) {
-        srs_close_stfd(stfd);
-    }
     return ret;
 }
 
@@ -208,7 +212,8 @@ string srs_path_build_timestamp(string template_path)
 
 void srs_parse_endpoint(string ip_port, string& ip, string& port)
 {
-    ip = "0.0.0.0";
+    ip = srs_check_ipv6() ? "::" : "0.0.0.0";
+    
     port = ip_port;
     
     size_t pos = string::npos;
@@ -1339,76 +1344,84 @@ string srs_get_public_internet_address()
     return "";
 }
 
+int srs_check_ipv6()
+{
+    int sd = socket(AF_INET6, SOCK_DGRAM, 0);
+    if(sd >= 0) {
+        close(sd);
+        return 1;
+    }
+    return 0;
+}
+
 string srs_get_local_ip(int fd)
 {
-    std::string ip;
-
     // discovery client information
-    sockaddr_in addr;
+    sockaddr_storage addr;
     socklen_t addrlen = sizeof(addr);
     if (getsockname(fd, (sockaddr*)&addr, &addrlen) == -1) {
-        return ip;
+        return "";
     }
     srs_verbose("get local ip success.");
 
-    // ip v4 or v6
-    char buf[INET6_ADDRSTRLEN];
-    memset(buf, 0, sizeof(buf));
-
-    if ((inet_ntop(addr.sin_family, &addr.sin_addr, buf, sizeof(buf))) == NULL) {
-        return ip;
+    char address_string[64];
+    const int success = getnameinfo((const sockaddr*)&addr, addrlen, 
+                                    (char*)&address_string, sizeof(address_string),
+                                    NULL, 0,
+                                    NI_NUMERICHOST);    
+    if(success != 0) {
+        return "";
     }
 
-    ip = buf;
-
-    srs_verbose("get local ip of client ip=%s, fd=%d", buf, fd);
-
-    return ip;
+    srs_verbose("get local ip of client ip=%s, fd=%d", address_string, fd);
+    return std::string(address_string);
 }
 
 int srs_get_local_port(int fd)
 {
     // discovery client information
-    sockaddr_in addr;
+    sockaddr_storage addr;
     socklen_t addrlen = sizeof(addr);
     if (getsockname(fd, (sockaddr*)&addr, &addrlen) == -1) {
         return 0;
     }
     srs_verbose("get local ip success.");
-    
-    int port = ntohs(addr.sin_port);
 
-    srs_verbose("get local ip of client port=%s, fd=%d", port, fd);
+    int port = 0;
+    switch(addr.ss_family) {
+        case AF_INET:
+            port = ntohs(((sockaddr_in*)&addr)->sin_port);
+         break;
+        case AF_INET6:
+            port = ntohs(((sockaddr_in6*)&addr)->sin6_port);
+         break;
+    }
 
+    srs_verbose("get local port of client port=%s, fd=%d", port, fd);
     return port;
 }
 
 string srs_get_peer_ip(int fd)
 {
-    std::string ip;
-    
     // discovery client information
-    sockaddr_in addr;
+    sockaddr_storage addr;
     socklen_t addrlen = sizeof(addr);
-    if (getpeername(fd, (sockaddr*)&addr, &addrlen) == -1) {
-        return ip;
+    if (getsockname(fd, (sockaddr*)&addr, &addrlen) == -1) {
+        return "";
     }
-    srs_verbose("get peer name success.");
+    srs_verbose("get peer ip success.");
 
-    // ip v4 or v6
-    char buf[INET6_ADDRSTRLEN];
-    memset(buf, 0, sizeof(buf));
-    
-    if ((inet_ntop(addr.sin_family, &addr.sin_addr, buf, sizeof(buf))) == NULL) {
-        return ip;
+    char address_string[64];
+    const int success = getnameinfo((const sockaddr*)&addr, addrlen, 
+                                    (char*)&address_string, sizeof(address_string),
+                                    NULL, 0,
+                                    NI_NUMERICHOST);    
+    if(success != 0) {
+        return "";
     }
-    srs_verbose("get peer ip of client ip=%s, fd=%d", buf, fd);
-    
-    ip = buf;
-    
-    srs_verbose("get peer ip success. ip=%s, fd=%d", ip.c_str(), fd);
-    
-    return ip;
+
+    srs_verbose("get peer ip of client ip=%s, fd=%d", address_string, fd);
+    return std::string(address_string);
 }
 
 bool srs_string_is_http(string url)

--- a/trunk/src/app/srs_app_utility.cpp
+++ b/trunk/src/app/srs_app_utility.cpp
@@ -212,14 +212,22 @@ string srs_path_build_timestamp(string template_path)
 
 void srs_parse_endpoint(string ip_port, string& ip, string& port)
 {
-    ip = srs_check_ipv6() ? "::" : "0.0.0.0";
-    
-    port = ip_port;
-    
-    size_t pos = string::npos;
-    if ((pos = port.find(":")) != string::npos) {
-        ip = port.substr(0, pos);
-        port = port.substr(pos + 1);
+    const size_t pos = ip_port.rfind(":");   // Look for ":" from the end, to work with IPv6.
+    if (pos != std::string::npos) {
+        if ((pos >= 1) &&
+            (ip_port[0]       == '[') &&
+            (ip_port[pos - 1] == ']')) {
+            // Handle IPv6 in RFC 2732 format, e.g. [3ffe:dead:beef::1]:1935
+            ip = ip_port.substr(1, pos - 2);
+        }
+        else {
+            // Handle IP address
+            ip = ip_port.substr(0, pos);
+        }
+        port = ip_port.substr(pos + 1);
+    } else {
+        ip   = srs_check_ipv6() ? "::" : "0.0.0.0";
+        port = ip_port;
     }
 }
 

--- a/trunk/src/app/srs_app_utility.hpp
+++ b/trunk/src/app/srs_app_utility.hpp
@@ -663,6 +663,9 @@ extern std::vector<std::string>& srs_get_local_ipv4_ips();
 // get local public ip, empty string if no public internet address found.
 extern std::string srs_get_public_internet_address();
 
+// check for IPv6 support
+extern int srs_check_ipv6();
+
 // get local or peer ip.
 // where local ip is the server ip which client connected.
 extern std::string srs_get_local_ip(int fd);

--- a/trunk/src/kernel/srs_kernel_utility.hpp
+++ b/trunk/src/kernel/srs_kernel_utility.hpp
@@ -50,7 +50,7 @@ extern int64_t srs_get_system_startup_time_ms();
 extern int64_t srs_update_system_time_ms();
 
 // dns resolve utility, return the resolved ip address.
-extern std::string srs_dns_resolve(std::string host);
+extern std::string srs_dns_resolve(std::string host, int& family);
 
 // whether system is little endian
 extern bool srs_is_little_endian();

--- a/trunk/src/libs/srs_librtmp.cpp
+++ b/trunk/src/libs/srs_librtmp.cpp
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <srs_librtmp.hpp>
 
 #include <stdlib.h>
+#include <sys/socket.h>
 
 // for srs-librtmp, @see https://github.com/ossrs/srs/issues/213
 #ifndef _WIN32
@@ -331,15 +332,11 @@ struct Context
     {
         switch (af) {
         case AF_INET:
-            return (inet_ntop4( (unsigned char*)src, (char*)dst, size)); // ****
-    #ifdef AF_INET6
-        #error "IPv6 not supported"
-        //case AF_INET6:
-        //    return (char*)(inet_ntop6( (unsigned char*)src, (char*)dst, size)); // ****
-    #endif
+            return (inet_ntop4( (unsigned char*)src, (char*)dst, size));
+        case AF_INET6:
+           return (char*)(inet_ntop6( (unsigned char*)src, (char*)dst, size));
         default:
-            // return (NULL); // ****
-            return 0 ; // ****
+            return (NULL);
         }
         /* NOTREACHED */
     }
@@ -493,7 +490,8 @@ int srs_librtmp_context_resolve_host(Context* context)
     int ret = ERROR_SUCCESS;
     
     // connect to server:port
-    context->ip = srs_dns_resolve(context->host);
+    int family = AF_UNSPEC;
+    context->ip = srs_dns_resolve(context->host, family);
     if (context->ip.empty()) {
         return ERROR_SYSTEM_DNS_RESOLVE;
     }


### PR DESCRIPTION
This pull request adds IPv6 support to SRS.

Test with:

1. Start SRS:
./objs/srs -c conf/rtmp.conf
2. Start ffmpeg:
for((;;)); do
   ffmpeg -re -i ./doc/source.200kbps.768x320.flv \
      -vcodec copy -acodec copy \
      -f flv -y rtmp://[::1]/live/livestream;
   sleep 1
done
3. Start ffplay:
ffplay rtmp://[::1]:1935/live/livestream
