### PR TITLE
IPv6 support (for 3.0 release)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -26,4 +26,4 @@ CONTRIBUTORS ordered by first contribution.
 * lovecat<littlefawn@163.com> "Bug fixed"
 * panda1986<542638787@qq.com> "Bug fixed"
 * YueHonghui<hongf.yue@hotmail.com> "Bug fixed"
-
+* Thomas Dreibholz<dreibh@simula.no> "IPv6 support"

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -26,4 +26,4 @@ CONTRIBUTORS ordered by first contribution.
 * lovecat<littlefawn@163.com> "Bug fixed"
 * panda1986<542638787@qq.com> "Bug fixed"
 * YueHonghui<hongf.yue@hotmail.com> "Bug fixed"
-* Thomas Dreibholz<dreibh@simula.no> "IPv6 support"
+* ThomasDreibholz<dreibh@simula.no> "IPv6 support"

--- a/trunk/configure
+++ b/trunk/configure
@@ -86,7 +86,7 @@ done
 #####################################################################################
 # build tools or compiler args.
 # enable gdb debug
-GDBDebug=" -g -O0"
+GDBDebug=" -g -O1"
 # the warning level.
 WarnLevel=" -Wall"
 # the compile standard.

--- a/trunk/src/app/srs_app_listener.hpp
+++ b/trunk/src/app/srs_app_listener.hpp
@@ -31,7 +31,7 @@
 #include <srs_app_st.hpp>
 #include <srs_app_thread.hpp>
 
-struct sockaddr_in;
+struct sockaddr;
 
 /**
  * the udp packet handler.
@@ -57,7 +57,7 @@ public:
      * @param nb_buf, the size of udp packet bytes.
      * @remark user should never use the buf, for it's a shared memory bytes.
      */
-    virtual srs_error_t on_udp_packet(sockaddr_in* from, char* buf, int nb_buf) = 0;
+    virtual srs_error_t on_udp_packet(const sockaddr* from, const int fromlen, char* buf, int nb_buf) = 0;
 };
 
 /**

--- a/trunk/src/app/srs_app_mpegts_udp.cpp
+++ b/trunk/src/app/srs_app_mpegts_udp.cpp
@@ -29,6 +29,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <netdb.h>
 using namespace std;
 
 #include <srs_app_config.hpp>
@@ -157,10 +158,18 @@ SrsMpegtsOverUdp::~SrsMpegtsOverUdp()
     srs_freep(pprint);
 }
 
-srs_error_t SrsMpegtsOverUdp::on_udp_packet(sockaddr_in* from, char* buf, int nb_buf)
+srs_error_t SrsMpegtsOverUdp::on_udp_packet(const sockaddr* from, const int fromlen, char* buf, int nb_buf)
 {
-    std::string peer_ip = inet_ntoa(from->sin_addr);
-    int peer_port = ntohs(from->sin_port);
+    char address_string[64];
+    char port_string[16];
+    if(getnameinfo(from, fromlen, 
+                   (char*)&address_string, sizeof(address_string),
+                   (char*)&port_string, sizeof(port_string),
+                   NI_NUMERICHOST|NI_NUMERICSERV) != 0) {
+        abort();
+    }
+    std::string peer_ip = std::string(address_string);
+    int peer_port = atoi(port_string);
     
     // append to buffer.
     buffer->append(buf, nb_buf);

--- a/trunk/src/app/srs_app_mpegts_udp.hpp
+++ b/trunk/src/app/srs_app_mpegts_udp.hpp
@@ -28,7 +28,7 @@
 
 #ifdef SRS_AUTO_STREAM_CASTER
 
-struct sockaddr_in;
+struct sockaddr;
 #include <string>
 #include <map>
 
@@ -101,7 +101,7 @@ public:
     virtual ~SrsMpegtsOverUdp();
 // interface ISrsUdpHandler
 public:
-    virtual srs_error_t on_udp_packet(sockaddr_in* from, char* buf, int nb_buf);
+    virtual srs_error_t on_udp_packet(const sockaddr* from, const int fromlen, char* buf, int nb_buf);
 private:
     virtual int on_udp_bytes(std::string host, int port, char* buf, int nb_buf);
 // interface ISrsTsHandler

--- a/trunk/src/app/srs_app_rtsp.cpp
+++ b/trunk/src/app/srs_app_rtsp.cpp
@@ -76,7 +76,7 @@ srs_error_t SrsRtpConn::listen()
     return listener->listen();
 }
 
-srs_error_t SrsRtpConn::on_udp_packet(sockaddr_in* from, char* buf, int nb_buf)
+srs_error_t SrsRtpConn::on_udp_packet(const sockaddr* from, const int fromlen, char* buf, int nb_buf)
 {
     int ret = ERROR_SUCCESS;
     srs_error_t err = srs_success;

--- a/trunk/src/app/srs_app_rtsp.cpp
+++ b/trunk/src/app/srs_app_rtsp.cpp
@@ -54,7 +54,7 @@ SrsRtpConn::SrsRtpConn(SrsRtspConn* r, int p, int sid)
     _port = p;
     stream_id = sid;
     // TODO: support listen at <[ip:]port>
-    listener = new SrsUdpListener(this, "0.0.0.0", p);
+    listener = new SrsUdpListener(this,  (srs_check_ipv6() ? "::" : "0.0.0.0"), p);
     cache = new SrsRtpPacket();
     pprint = SrsPithyPrint::create_caster();
 }

--- a/trunk/src/app/srs_app_rtsp.hpp
+++ b/trunk/src/app/srs_app_rtsp.hpp
@@ -74,7 +74,7 @@ public:
     virtual srs_error_t listen();
 // interface ISrsUdpHandler
 public:
-    virtual srs_error_t on_udp_packet(sockaddr_in* from, char* buf, int nb_buf);
+    virtual srs_error_t on_udp_packet(const sockaddr* from, const int fromlen, char* buf, int nb_buf);
 };
 
 /**

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -1137,7 +1137,7 @@ srs_error_t SrsServer::listen_stream_caster()
         }
         
         // TODO: support listen at <[ip:]port>
-        if ((err = listener->listen("0.0.0.0", port)) != srs_success) {
+        if ((err = listener->listen( (srs_check_ipv6() ? "::" : "0.0.0.0"), port)) != srs_success) {
             return srs_error_wrap(err, "listen at %d", port);
         }
     }

--- a/trunk/src/app/srs_app_utility.hpp
+++ b/trunk/src/app/srs_app_utility.hpp
@@ -643,6 +643,9 @@ extern SrsNetworkRtmpServer* srs_get_network_rtmp_server();
 // the deamon st-thread will update it.
 extern void srs_update_rtmp_server(int nb_conn, SrsKbps* kbps);
 
+// check for IPv6 support
+extern int srs_check_ipv6();
+
 // get local or peer ip.
 // where local ip is the server ip which client connected.
 extern std::string srs_get_local_ip(int fd);

--- a/trunk/src/kernel/srs_kernel_utility.cpp
+++ b/trunk/src/kernel/srs_kernel_utility.cpp
@@ -346,7 +346,7 @@ string srs_string_remove(string str, string remove_chars)
 
 bool srs_string_ends_with(string str, string flag)
 {
-    ssize_t pos = str.rfind(flag);
+    const size_t pos = str.rfind(flag);
     return (pos != string::npos) && (pos == str.length() - flag.length());
 }
 

--- a/trunk/src/kernel/srs_kernel_utility.hpp
+++ b/trunk/src/kernel/srs_kernel_utility.hpp
@@ -47,7 +47,7 @@ extern int64_t srs_get_system_startup_time_ms();
 extern int64_t srs_update_system_time_ms();
 
 // dns resolve utility, return the resolved ip address.
-extern std::string srs_dns_resolve(std::string host);
+extern std::string srs_dns_resolve(std::string host, int& family);
 
 // split the host:port to host and port.
 // @remark the hostport format in <host[:port]>, where port is optional.

--- a/trunk/src/libs/srs_lib_simple_socket.cpp
+++ b/trunk/src/libs/srs_lib_simple_socket.cpp
@@ -64,6 +64,8 @@
 
 #include <sys/types.h>
 #include <errno.h>
+#include <stdio.h>
+#include <netdb.h>
 
 #include <srs_kernel_utility.hpp>
 #include <srs_kernel_consts.hpp>
@@ -73,6 +75,7 @@
 struct SrsBlockSyncSocket
 {
     SOCKET fd;
+    int    family;
     int64_t rbytes;
     int64_t sbytes;
     // The send/recv timeout in ms.
@@ -105,27 +108,40 @@ void srs_hijack_io_destroy(srs_hijack_io_t ctx)
 int srs_hijack_io_create_socket(srs_hijack_io_t ctx, srs_rtmp_t owner)
 {
     SrsBlockSyncSocket* skt = (SrsBlockSyncSocket*)ctx;
-    
-    skt->fd = ::socket(AF_INET, SOCK_STREAM, 0);
+
+    skt->family = AF_INET6;
+    skt->fd = ::socket(skt->family, SOCK_STREAM, 0);   // Try IPv6 first.
+    if (!SOCKET_VALID(skt->fd)) {
+        skt->family = AF_INET;
+        skt->fd = ::socket(skt->family, SOCK_STREAM, 0);   // Try IPv4 instead, if IPv6 fails.
+    }
     if (!SOCKET_VALID(skt->fd)) {
         return ERROR_SOCKET_CREATE;
     }
-    
+
     return ERROR_SUCCESS;
 }
 int srs_hijack_io_connect(srs_hijack_io_t ctx, const char* server_ip, int port)
 {
     SrsBlockSyncSocket* skt = (SrsBlockSyncSocket*)ctx;
-    
-    sockaddr_in addr;
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
-    addr.sin_addr.s_addr = inet_addr(server_ip);
-    
-    if(::connect(skt->fd, (const struct sockaddr*)&addr, sizeof(sockaddr_in)) < 0){
-        return ERROR_SOCKET_CONNECT;
+
+    char port_string[8];
+    snprintf(port_string, sizeof(port_string), "%d", port);
+    addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family   = skt->family;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags    = AI_NUMERICHOST;
+    addrinfo* result  = NULL;
+
+    if(getaddrinfo(server_ip, port_string, (const addrinfo*)&hints, &result) == 0) {
+        if(::connect(skt->fd, result->ai_addr, result->ai_addrlen) < 0){
+            freeaddrinfo(result);
+            return ERROR_SOCKET_CONNECT;
+        }
     }
-    
+
+    freeaddrinfo(result);
     return ERROR_SUCCESS;
 }
 int srs_hijack_io_read(srs_hijack_io_t ctx, void* buf, size_t size, ssize_t* nread)

--- a/trunk/src/libs/srs_librtmp.cpp
+++ b/trunk/src/libs/srs_librtmp.cpp
@@ -24,6 +24,7 @@
 #include <srs_librtmp.hpp>
 
 #include <stdlib.h>
+#include <sys/socket.h>
 
 // for srs-librtmp, @see https://github.com/ossrs/srs/issues/213
 #ifndef _WIN32
@@ -346,16 +347,12 @@ static char *inet_ntop6(const u_char *src, char *dst, socklen_t size);
 const char* inet_ntop(int af, const void *src, char *dst, socklen_t size)
 {
     switch (af) {
-        case AF_INET:
-            return (inet_ntop4( (unsigned char*)src, (char*)dst, size)); // ****
-#ifdef AF_INET6
-#error "IPv6 not supported"
-            //case AF_INET6:
-            //    return (char*)(inet_ntop6( (unsigned char*)src, (char*)dst, size)); // ****
-#endif
-        default:
-            // return (NULL); // ****
-            return 0 ; // ****
+    case AF_INET:
+        return (inet_ntop4( (unsigned char*)src, (char*)dst, size));
+    case AF_INET6:
+       return (char*)(inet_ntop6( (unsigned char*)src, (char*)dst, size));
+    default:
+        return (NULL);
     }
     /* NOTREACHED */
 }
@@ -504,7 +501,8 @@ int srs_librtmp_context_resolve_host(Context* context)
     int ret = ERROR_SUCCESS;
     
     // connect to server:port
-    context->ip = srs_dns_resolve(context->host);
+    int family = AF_UNSPEC;
+    context->ip = srs_dns_resolve(context->host, family);
     if (context->ip.empty()) {
         return ERROR_SYSTEM_DNS_RESOLVE;
     }

--- a/trunk/src/service/srs_service_st.cpp
+++ b/trunk/src/service/srs_service_st.cpp
@@ -133,7 +133,8 @@ int srs_socket_connect(string server, int port, int64_t tm, srs_netfd_t* pstfd)
     }
     
     // connect to server.
-    std::string ip = srs_dns_resolve(server);
+    int family = AF_UNSPEC;
+    std::string ip = srs_dns_resolve(server, family);
     if (ip.empty()) {
         ret = ERROR_SYSTEM_IP_INVALID;
         srs_error("dns resolve server error, ip empty. ret=%d", ret);


### PR DESCRIPTION
This pull request adds IPv6 support to SRS.

Test with:

    Start SRS:
    ./objs/srs -c conf/rtmp.conf
    Start ffmpeg:
    for((;;)); do
    ffmpeg -re -i ./doc/source.200kbps.768x320.flv
    -vcodec copy -acodec copy
    -f flv -y rtmp://[::1]/live/livestream;
    sleep 1
    done
    Start ffplay:
    ffplay rtmp://[::1]:1935/live/livestream
