### PR TITLE
fix create dir success result check

### DIFF
--- a/trunk/src/kernel/srs_kernel_utility.cpp
+++ b/trunk/src/kernel/srs_kernel_utility.cpp
@@ -546,7 +546,7 @@ int srs_do_create_dir_recursively(string dir)
     {
         int ret = srs_do_create_dir_recursively(dir);
         
-        if (ret == ERROR_SYSTEM_DIR_EXISTS) {
+        if (ret == ERROR_SYSTEM_DIR_EXISTS || ret == ERROR_SUCCESS) {
             return srs_success;
         }
         


### PR DESCRIPTION
When creating TS slices, after the creation of the directory, the check state is not true, resulting in the failure of the publish stream.
