### PR TITLE
relax the restriction of edge's origin config. make it not crash.

### DIFF
--- a/trunk/src/app/srs_app_edge.cpp
+++ b/trunk/src/app/srs_app_edge.cpp
@@ -600,7 +600,11 @@ int SrsEdgeForwarder::connect_server(string& ep_server, string& ep_port)
     close_underlayer_socket();
     
     SrsConfDirective* conf = _srs_config->get_vhost_edge_origin(_req->vhost);
-    srs_assert(conf);
+    if (!conf) {
+        ret = ERROR_RTMP_EDGE_ORIGIN_NOT_FOUND;
+        srs_warn("vhost %s origin not found. ret=%d", _req->vhost.c_str(), ret);
+        return ret;
+    }
     
     // select the origin.
     std::string server = conf->args.at(origin_index % conf->args.size());

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -154,6 +154,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define ERROR_RTMP_STREAM_NOT_FOUND         2048
 #define ERROR_RTMP_CLIENT_NOT_FOUND         2049
 #define ERROR_RTMP_STREAM_NAME_EMPTY        2050
+#define ERROR_RTMP_EDGE_ORIGIN_NOT_FOUND    2051
 //                                           
 // system control message, 
 // not an error, but special control logic.


### PR DESCRIPTION
@winlinvip  hi，
如果edge没有配置origin配置项的话，在推流时会crash掉。这个限制似乎有点太严厉了，在现实场景中，新增一个vhost时，存在由于疏忽忘记增加origin了的情况，本来通过推流失败以及错误日志是能发现问题并修改的。