### PR TITLE
clear meta cache when unpublish

### DIFF
--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -2235,9 +2235,10 @@ void SrsSource::on_unpublish()
     hds->on_unpublish();
 #endif
 
-    // only clear the gop cache,
-    // donot clear the sequence header, for it maybe not changed,
-    // when drop dup sequence header, drop the metadata also.
+    srs_freep(cache_metadata);
+    srs_freep(cache_sh_video);
+    srs_freep(cache_sh_audio);
+    
     gop_cache->clear();
     
     srs_info("clear cache/metadata when unpublish.");


### PR DESCRIPTION
Hi, @winlinvip ,

虽然你在void SrsSource::on_unpublish()中有明确的注释表明在这个函数中不清理metadata,sequence header的缓存:
```
    // only clear the gop cache,
    // donot clear the sequence header, for it maybe not changed,
    // when drop dup sequence header, drop the metadata also.
```

但基于如下几个考虑,我觉得还是应该在这里清理掉这几个缓存:

1. 边缘拉流时某些客户端会崩掉

场景为,假设回源结构为srsA->srsB, 假设第一个播放器连接到srsA进而触发了edge ingester,边缘srsA上缓存了metadata,sequence header, 然后播放器断开连接, 这时由于没有播放器,所以edge ingester退出. 然后另一个播放器连接到边缘srsA, 再次触发edge ingester,这个时候播放器就会连续收到两个metadata,sequence header序列(一个是边缘自己缓存的,另一个是edge ingester publish过来的),如果回源层再多一些,比如srsA->srsB->srsC, 则会连续收到三个metadata,sequence header序列, 某些很二的客户端就会崩掉.

这个场景下, 在边缘配置reduce_sequence_header on,是可以解决这个问题.但是我觉得你设计reduce_sequence_header的初衷,是为了解决编码器主动重复推sequence header的问题,而我提到的这个场景是服务器内部的机制.  另外,现在2.0分支是由于没有source清理的机制,如果有的话,也是应该清掉这几个cache 内容的.

2. 也可以解决https://github.com/ossrs/srs/issues/1134
