### PR TITLE
fix srs_librtmp build error in windows.

### DIFF
--- a/trunk/auto/CMakeLists.txt
+++ b/trunk/auto/CMakeLists.txt
@@ -1,0 +1,108 @@
+cmake_minimum_required (VERSION 2.6)
+project(srs_librtmp)
+
+option(BUILD_WITH_TEST "build with demo " OFF)
+option(BUILD_WITH_STATIC "build with static" ON)
+option(BUILD_WITH_SHARD "build with shard" OFF)
+
+#configure_file(${CMAKE_CURRENT_LIST_DIR}srs_auto_headers.hpp.in )
+set(SRC_ROOT ${CMAKE_CURRENT_LIST_DIR}/src)
+include_directories(${CMAKE_CURRENT_LIST_DIR}/objs)
+
+include_directories(${SRC_ROOT}/core)
+include_directories(${SRC_ROOT}/kernel)
+include_directories(${SRC_ROOT}/libs)
+include_directories(${SRC_ROOT}/protocol)
+
+file(GLOB OBJS_HEADERS "${CMAKE_CURRENT_LIST_DIR}/objs/*.h*" )
+
+file(GLOB CORE_HEADERS "${SRC_ROOT}/core/*.h*" )
+file(GLOB CORE_SRCS "${SRC_ROOT}/core/*.c*")
+
+file(GLOB KERNEL_HEADERS "${SRC_ROOT}/kernel/*.h*" )
+file(GLOB KERNEL_SRCS "${SRC_ROOT}/kernel/*.c*")
+
+file(GLOB LIBS_HEADERS "${SRC_ROOT}/libs/*.h*" )
+file(GLOB LIBS_SRCS "${SRC_ROOT}/libs/*.c*")
+
+file(GLOB PROTOCOL_HEADERS "${SRC_ROOT}/protocol/*.h*" )
+file(GLOB PROTOCOL_SRCS "${SRC_ROOT}/protocol/*.c*")
+
+if(BUILD_WITH_STATIC)
+    add_library(srs_librtmp STATIC ${OBJS_HEADERS}
+    ${CORE_HEADERS} ${CORE_SRCS}
+    ${KERNEL_HEADERS} ${KERNEL_SRCS}
+    ${LIBS_HEADERS} ${LIBS_SRCS}
+    ${PROTOCOL_HEADERS} ${PROTOCOL_SRCS})
+    install(TARGETS srs_librtmp
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib )
+endif()
+
+if(BUILD_WITH_SHARD)
+    set(LIB_NAME srs_librtmp)
+    if(BUILD_WITH_STATIC)
+        set(LIB_NAME srs_librtmp_shared)
+    endif()
+
+    add_library(${LIB_NAME} SHARED ${ROOT_HEADERS} ${ROOT_SRCS}
+    ${CORE_HEADERS} ${CORE_SRCS}
+    ${KERNEL_HEADERS} ${KERNEL_SRCS}
+    ${LIBS_HEADERS} ${LIBS_SRCS}
+    ${PROTOCOL_HEADERS} ${PROTOCOL_SRCS})
+
+    install(TARGETS ${LIB_NAME}
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib )
+endif()
+
+if(BUILD_WITH_TEST)
+
+if(UNIX)
+	set(EXTRA_LIBS ${EXTRA_LIBS} stdc++ z pthread dl)
+elseif(MSVC)
+	 set(EXTRA_LIBS ${EXTRA_LIBS} ws2_32 winmm vfw32 wininet Userenv)
+endif()
+
+add_executable(srs_aac_raw_publish ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_aac_raw_publish.c)
+TARGET_LINK_LIBRARIES(srs_aac_raw_publish srs_librtmp ${EXTRA_LIBS})
+
+add_executable(srs_bandwidth_check ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_bandwidth_check.c)
+TARGET_LINK_LIBRARIES(srs_bandwidth_check srs_librtmp ${EXTRA_LIBS})
+
+add_executable(srs_detect_rtmp ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_detect_rtmp.c)
+TARGET_LINK_LIBRARIES(srs_detect_rtmp srs_librtmp ${EXTRA_LIBS})
+
+add_executable(srs_flv_injecter ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_flv_injecter.c)
+TARGET_LINK_LIBRARIES(srs_flv_injecter srs_librtmp ${EXTRA_LIBS})
+
+add_executable(srs_flv_parser ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_flv_parser.c)
+TARGET_LINK_LIBRARIES(srs_flv_parser srs_librtmp ${EXTRA_LIBS})
+
+add_executable(srs_h264_raw_publish ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_h264_raw_publish.c)
+TARGET_LINK_LIBRARIES(srs_h264_raw_publish srs_librtmp ${EXTRA_LIBS})
+
+add_executable(srs_ingest_flv ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_ingest_flv.c)
+TARGET_LINK_LIBRARIES(srs_ingest_flv srs_librtmp ${EXTRA_LIBS})
+
+add_executable(srs_ingest_rtmp ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_ingest_rtmp.c)
+TARGET_LINK_LIBRARIES(srs_ingest_rtmp srs_librtmp ${EXTRA_LIBS})
+
+add_executable(srs_play ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_play.c)
+TARGET_LINK_LIBRARIES(srs_play srs_librtmp ${EXTRA_LIBS})
+
+add_executable(srs_publish ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_publish.c)
+TARGET_LINK_LIBRARIES(srs_publish srs_librtmp ${EXTRA_LIBS})
+
+add_executable(srs_rtmp_dump ${CMAKE_CURRENT_LIST_DIR}/research/librtmp/srs_rtmp_dump.c)
+TARGET_LINK_LIBRARIES(srs_rtmp_dump srs_librtmp ${EXTRA_LIBS})
+endif()
+
+install(FILES ${ROOT_HEADERS}  ${CORE_HEADERS} ${KERNEL_HEADERS} ${LIBS_HEADERS}  ${PROTOCOL_HEADERS} DESTINATION include )
+
+install(TARGETS ${PG_LIB_NAME}
+	RUNTIME DESTINATION bin
+	LIBRARY DESTINATION lib
+	ARCHIVE DESTINATION lib )

--- a/trunk/auto/generate-srs-librtmp-project.sh
+++ b/trunk/auto/generate-srs-librtmp-project.sh
@@ -17,7 +17,7 @@ if [ $SRS_EXPORT_LIBRTMP_PROJECT != NO ]; then
         exit 1
     fi
     # create target
-    SRS_WORKDIR=${SRS_EXPORT_LIBRTMP_PROJECT} && SRS_OBJS=${SRS_WORKDIR}/${SRS_OBJS_DIR} && mkdir -p ${SRS_OBJS} &&
+    SRS_WORKDIR=${SRS_EXPORT_LIBRTMP_PROJECT} && SRS_OBJS=${SRS_WORKDIR}/${SRS_OBJS_DIR} && mkdir -p ${SRS_OBJS} && cp auto/CMakeLists.txt ${SRS_EXPORT_LIBRTMP_PROJECT}
     # copy src to target
     _CPT=${SRS_EXPORT_LIBRTMP_PROJECT}/research/librtmp && mkdir -p ${_CPT} && cp research/librtmp/*.c research/librtmp/Makefile ${_CPT} &&
     _CPT=${SRS_EXPORT_LIBRTMP_PROJECT}/auto && mkdir -p ${_CPT} && cp auto/generate_header.sh auto/generate-srs-librtmp-single.sh ${_CPT} &&

--- a/trunk/src/core/srs_core.hpp
+++ b/trunk/src/core/srs_core.hpp
@@ -87,6 +87,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // for srs-librtmp, @see https://github.com/ossrs/srs/issues/213
 #ifndef _WIN32
 #include <inttypes.h>
+#else
+#include "srs_librtmp.hpp"
 #endif
 
 #include <assert.h>
@@ -132,7 +134,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * only support the following cpus: i386/amd64/x86_64/arm
  * @reamrk to patch ST for arm, read https://github.com/ossrs/state-threads/issues/1
  */
-#if !defined(__amd64__) && !defined(__x86_64__) && !defined(__i386__) && !defined(__arm__)
+#if !defined(__amd64__) && !defined(__x86_64__) && !defined(__i386__) && !defined(__arm__) && !defined(WIN32) && !defined(WIN64)
     #error "only support i386/amd64/x86_64/arm cpu"
 #endif
 

--- a/trunk/src/libs/srs_lib_bandwidth.cpp
+++ b/trunk/src/libs/srs_lib_bandwidth.cpp
@@ -326,7 +326,12 @@ int SrsBandwidthClient::publish_checking(int duration_ms, int play_kbps)
                 srs_update_system_time_ms();
                 elaps = (int)(srs_get_system_time_ms() - starttime);
                 current_kbps = (int)(_rtmp->get_send_bytes() * 8 / elaps);
+#if defined(WIN32)
+				Sleep(100);
+#else
+
                 usleep(100 * 1000); // TODO: FIXME: magic number.
+#endif
             }
         }
     }

--- a/trunk/src/libs/srs_lib_simple_socket.cpp
+++ b/trunk/src/libs/srs_lib_simple_socket.cpp
@@ -171,9 +171,18 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         microsec = srs_max(0, microsec);
         
         struct timeval tv = { sec , microsec };
-        if (setsockopt(skt->fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) == -1) {
-            return SOCKET_ERRNO();
-        }
+
+#ifdef _WIN32
+		if (setsockopt(skt->fd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof(tv)) == -1) {
+			return SOCKET_ERRNO();
+		}
+#else
+		if (setsockopt(skt->fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) == -1) {
+			return SOCKET_ERRNO();
+		}
+#endif // _WIN32
+
+        
         skt->recv_timeout = timeout_us;
         
         return ERROR_SUCCESS;
@@ -199,9 +208,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         microsec = srs_max(0, microsec);
 
         struct timeval tv = { sec , microsec };
-        if (setsockopt(skt->fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) == -1) {
-            return SOCKET_ERRNO();
-        }
+#ifdef _WIN32
+		if (setsockopt(skt->fd, SOL_SOCKET, SO_SNDTIMEO, (const char*)&tv, sizeof(tv)) == -1) {
+			return SOCKET_ERRNO();
+		}
+#else
+		if (setsockopt(skt->fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) == -1) {
+			return SOCKET_ERRNO();
+		}
+#endif // _WIN32
 
         skt->send_timeout = timeout_us;
         

--- a/trunk/src/libs/srs_librtmp.cpp
+++ b/trunk/src/libs/srs_librtmp.cpp
@@ -332,11 +332,16 @@ struct Context
         switch (af) {
         case AF_INET:
             return (inet_ntop4( (unsigned char*)src, (char*)dst, size)); // ****
+#ifdef _WIN32
+		case AF_INET6:
+		    return (char*)(inet_ntop6( (unsigned char*)src, (char*)dst, size));
+#else
     #ifdef AF_INET6
         #error "IPv6 not supported"
         //case AF_INET6:
         //    return (char*)(inet_ntop6( (unsigned char*)src, (char*)dst, size)); // ****
     #endif
+#endif
         default:
             // return (NULL); // ****
             return 0 ; // ****

--- a/trunk/src/libs/srs_librtmp.hpp
+++ b/trunk/src/libs/srs_librtmp.hpp
@@ -44,6 +44,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // for srs-librtmp, @see https://github.com/ossrs/srs/issues/213
 #ifdef _WIN32
     // include windows first.
+#pragma   warning(disable:4996) 
+#pragma   warning(disable:4309) 
+#pragma   warning(disable:4244) 
+#pragma   warning(disable:4267) 
+	#include <stdint.h>
+	#include <stdio.h>
+	#include <winsock2.h>
     #include <windows.h>
     // the type used by this header for windows.
     typedef unsigned long long u_int64_t;
@@ -52,7 +59,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     typedef u_int32_t uint32_t;
     typedef int int32_t;
     typedef unsigned char u_int8_t;
-    typedef char int8_t;
+    //typedef char int8_t;
     typedef unsigned short u_int16_t;
     typedef short int16_t;
     typedef int64_t ssize_t;
@@ -1095,7 +1102,9 @@ typedef void* srs_hijack_io_t;
     int socket_cleanup();
     
     // others.
-    #define snprintf _snprintf
+#ifndef snprintf
+	#define snprintf _snprintf
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/trunk/src/protocol/srs_rtmp_stack.cpp
+++ b/trunk/src/protocol/srs_rtmp_stack.cpp
@@ -2567,7 +2567,11 @@ int SrsRtmpServer::response_connect_app(SrsRequest *req, const char* server_ip)
     
     SrsConnectAppResPacket* pkt = new SrsConnectAppResPacket();
     
-    pkt->props->set("fmsVer", SrsAmf0Any::str("FMS/"RTMP_SIG_FMS_VER));
+#ifdef _WIN32
+	pkt->props->set("fmsVer", SrsAmf0Any::str("FMS/" RTMP_SIG_FMS_VER));
+#else
+	pkt->props->set("fmsVer", SrsAmf0Any::str("FMS/"RTMP_SIG_FMS_VER));
+#endif // _WIN32
     pkt->props->set("capabilities", SrsAmf0Any::number(127));
     pkt->props->set("mode", SrsAmf0Any::number(1));
     

--- a/trunk/src/protocol/srs_rtmp_utility.cpp
+++ b/trunk/src/protocol/srs_rtmp_utility.cpp
@@ -71,10 +71,16 @@ void srs_discovery_tc_url(
     vhost = host;
     srs_vhost_resolve(vhost, app, param);
     srs_vhost_resolve(vhost, stream, param);
-    
+
+#ifdef _WIN32
+	if (param == "?vhost=" SRS_CONSTS_RTMP_DEFAULT_VHOST) {
+		param = "";
+	}
+#else
     if (param == "?vhost="SRS_CONSTS_RTMP_DEFAULT_VHOST) {
         param = "";
     }
+#endif
 }
 
 void srs_vhost_resolve(string& vhost, string& app, string& param)


### PR DESCRIPTION
add srs_librtmp CMakeLists.txt
主要是修复在Windows上编译 srs_librtmp 时遇到的错误，以及添加 cmake 脚本来构建srs_librtmp