### PR TITLE
fix: support transfer flv query params by callback

### DIFF
--- a/trunk/src/app/srs_app_http_conn.cpp
+++ b/trunk/src/app/srs_app_http_conn.cpp
@@ -861,6 +861,10 @@ SrsRequest* SrsHttpMessage::to_request(string vhost)
     }
     
     req->tcUrl = "rtmp://" + vhost + req->app;
+    std::string query = _uri->get_query();
+    if (!query.empty()) {
+        req->tcUrl = req->tcUrl + "?" + query;
+    }
     req->pageUrl = get_request_header("Referer");
     req->objectEncoding = 0;
     


### PR DESCRIPTION
eg: 
when request is "http://localhost/app/stream.flv?token=xxx&salt=yyy", the http callback from srs will take the param("?token=xxx&salt=yyy") in param field