### PR TITLE
Fix compile error at GCC 7.4.0

### DIFF
--- a/trunk/auto/utest.sh
+++ b/trunk/auto/utest.sh
@@ -58,7 +58,7 @@ USER_DIR = .
 CPPFLAGS += -I\$(GTEST_DIR)/include
 
 # Flags passed to the C++ compiler.
-CXXFLAGS += -g -Wall -Wextra -O0 ${EXTRA_DEFINES}
+CXXFLAGS += -g -Wall -Wextra -O0 -DUTEST ${EXTRA_DEFINES}
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.

--- a/trunk/src/app/srs_app_fragment.hpp
+++ b/trunk/src/app/srs_app_fragment.hpp
@@ -33,6 +33,9 @@
 // It's a media file, for example FLV or MP4, with duration.
 class SrsFragment
 {
+#ifdef UTEST
+    FRIEND_TEST(AppFragmentTest, CheckDuration);
+#endif
 private:
     // The duration in srs_utime_t.
     srs_utime_t dur;

--- a/trunk/src/app/srs_app_log.hpp
+++ b/trunk/src/app/srs_app_log.hpp
@@ -37,7 +37,7 @@
 // when you want to use different level, override this classs, set the protected _level.
 class SrsFastLog : public ISrsLog, public ISrsReloadHandler
 {
-private:
+protected:
     // Defined in SrsLogLevel.
     SrsLogLevel level;
 private:

--- a/trunk/src/kernel/srs_kernel_aac.hpp
+++ b/trunk/src/kernel/srs_kernel_aac.hpp
@@ -38,6 +38,9 @@ class ISrsStreamWriter;
 // Transmux the RTMP packets to AAC stream.
 class SrsAacTransmuxer
 {
+#ifdef UTEST
+    FRIEND_TEST(KernelAACTest, TransmaxRTMP2AAC);
+#endif
 private:
     ISrsStreamWriter* writer;
 private:

--- a/trunk/src/kernel/srs_kernel_balance.hpp
+++ b/trunk/src/kernel/srs_kernel_balance.hpp
@@ -35,6 +35,9 @@
  */
 class SrsLbRoundRobin
 {
+#ifdef UTEST
+    FRIEND_TEST(KernelLBRRTest, CoverAll);
+#endif
 private:
     // current selected index.
     int index;

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -693,6 +693,10 @@ public:
  */
 class SrsFormat
 {
+#ifdef UTEST
+    FRIEND_TEST(KernelCodecTest, AudioFormat);
+    FRIEND_TEST(KernelCodecTest, VideoFormat);
+#endif
 public:
     SrsAudioFrame* audio;
     SrsAudioCodecConfig* acodec;

--- a/trunk/src/kernel/srs_kernel_ts.hpp
+++ b/trunk/src/kernel/srs_kernel_ts.hpp
@@ -308,6 +308,12 @@ public:
 // The context of ts, to decode the ts stream.
 class SrsTsContext
 {
+#ifdef UTEST
+    FRIEND_TEST(KernelUtilityTest, CoverTimeUtilityAll);
+    FRIEND_TEST(KernelAACTest, TransmaxRTMP2AAC);
+    FRIEND_TEST(KernelTSTest, CoverContextUtility);
+    FRIEND_TEST(KernelTSTest, CoverContextEncode);
+#endif
 private:
     // Whether context is ready, failed if try to write data when not ready.
     // When PAT and PMT writen, the context is ready.

--- a/trunk/src/utest/srs_utest.hpp
+++ b/trunk/src/utest/srs_utest.hpp
@@ -24,10 +24,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef SRS_UTEST_PUBLIC_SHARED_HPP
 #define SRS_UTEST_PUBLIC_SHARED_HPP
 
-// Public all private and protected members.
-#define private public
-#define protected public
-
 /*
 #include <srs_utest.hpp>
 */

--- a/trunk/src/utest/srs_utest_protocol.cpp
+++ b/trunk/src/utest/srs_utest_protocol.cpp
@@ -5605,6 +5605,7 @@ MockStage::MockStage(http_parser* from)
 
 class MockParser
 {
+	FRIEND_TEST(ProtocolHTTPTest, HTTPParser);
 private:
 	http_parser_settings settings;
 	http_parser* parser;

--- a/trunk/src/utest/srs_utest_service.cpp
+++ b/trunk/src/utest/srs_utest_service.cpp
@@ -46,6 +46,9 @@ VOID TEST(ServiceTimeTest, TimeUnit)
 
 class MockTcpHandler : public ISrsTcpHandler
 {
+    FRIEND_TEST(TCPServerTest, WritevIOVC);
+    FRIEND_TEST(TCPServerTest, PingPong);
+    FRIEND_TEST(TCPServerTest, PingPongWithTimeout);
 private:
 	srs_netfd_t fd;
 public:


### PR DESCRIPTION
[Root Cause]
GCC 7.4.0 cannot accept the following code
``` c++
#define private public
#define protected public
```
It would make compilation fail even force set standard to C++98.
But the same code would accepted by clang 6.0.0

Two workaround solutions
1. Use clang as the default compilier
2. configure without utest

I think these solutions are not suitable.
I refer [this link](https://stackoverflow.com/questions/47354280/what-is-the-best-way-of-testing-private-methods-with-googletest/47358700) to fix the issue.