### PR TITLE
更新CMakeLists.txt文件，使项目能在clion编译通过

### DIFF
--- a/trunk/ide/srs_clion/CMakeLists.txt
+++ b/trunk/ide/srs_clion/CMakeLists.txt
@@ -1,15 +1,17 @@
 cmake_minimum_required(VERSION 2.6.4)
 project(srs CXX)
 
-INCLUDE_DIRECTORIES(../../objs 
-    ../../objs/st ../../objs/hp ../../objs/openssl/include 
-    ../../src/core ../../src/kernel ../../src/protocol ../../src/app)
+INCLUDE_DIRECTORIES(../../objs
+    ../../objs/st ../../objs/hp ../../objs/openssl/include
+    ../../src/core ../../src/kernel ../../src/protocol ../../src/app
+    ../../src/service)
 
 set(SOURCE_FILES ../../src/main/srs_main_server.cpp)
 AUX_SOURCE_DIRECTORY(../../src/core SOURCE_FILES)
 AUX_SOURCE_DIRECTORY(../../src/kernel SOURCE_FILES)
 AUX_SOURCE_DIRECTORY(../../src/protocol SOURCE_FILES)
 AUX_SOURCE_DIRECTORY(../../src/app SOURCE_FILES)
+AUX_SOURCE_DIRECTORY(../../src/service SOURCE_FILES)
 
 ADD_DEFINITIONS("-g -O0")
 
@@ -18,7 +20,6 @@ TARGET_LINK_LIBRARIES(srs dl)
 TARGET_LINK_LIBRARIES(srs ${PROJECT_SOURCE_DIR}/../../objs/st/libst.a)
 TARGET_LINK_LIBRARIES(srs ${PROJECT_SOURCE_DIR}/../../objs/openssl/lib/libssl.a)
 TARGET_LINK_LIBRARIES(srs ${PROJECT_SOURCE_DIR}/../../objs/openssl/lib/libcrypto.a)
-TARGET_LINK_LIBRARIES(srs ${PROJECT_SOURCE_DIR}/../../objs/hp/libhttp_parser.a)
 TARGET_LINK_LIBRARIES(srs -ldl)
 
 IF(NOT EXISTS ${PROJECT_SOURCE_DIR}/../../objs/st/libst.a)


### PR DESCRIPTION
原先的CMakeLists.txt 在clion无法编译通过。修改后测试推拉流正常。