### PR TITLE
Edge: 防止ingester多次调用stop导致崩溃

### DIFF
--- a/trunk/src/app/srs_app_edge.cpp
+++ b/trunk/src/app/srs_app_edge.cpp
@@ -690,6 +690,7 @@ void SrsPlayEdge::on_all_client_stop()
     // when all client disconnected,
     // and edge is ingesting origin stream, abort it.
     if (state == SrsEdgeStatePlay || state == SrsEdgeStateIngestConnected) {
+        state = SrsEdgeStateIngestStoping; // avoid multi call stop
         ingester->stop();
         
         SrsEdgeState pstate = state;

--- a/trunk/src/app/srs_app_edge.hpp
+++ b/trunk/src/app/srs_app_edge.hpp
@@ -57,6 +57,7 @@ enum SrsEdgeState
     // play stream from origin, ingest stream
     SrsEdgeStateIngestConnected = 101,
     
+    SrsEdgeStateIngestStoping = 1000,
     // For publish edge
     SrsEdgeStatePublish = 200,
 };


### PR DESCRIPTION
防止ingester多次调用stop导致崩溃