### PR TITLE
Security: Enable CIDR for allow/deny play/publish

### DIFF
--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -962,16 +962,20 @@ vhost security.srs.com {
         # default: off
         enabled         on;
         # the security list, each item format as:
-        #       allow|deny    publish|play    all|<ip>
+        #       allow|deny    publish|play    all|<ip or cidr>
         # for example:
         #       allow           publish     all;
         #       deny            publish     all;
         #       allow           publish     127.0.0.1;
         #       deny            publish     127.0.0.1;
+        #       allow           publish     10.0.0.0/8;
+        #       deny            publish     10.0.0.0/8;
         #       allow           play        all;
         #       deny            play        all;
         #       allow           play        127.0.0.1;
         #       deny            play        127.0.0.1;
+        #       allow           play        10.0.0.0/8;
+        #       deny            play        10.0.0.0/8;
         # SRS apply the following simple strategies one by one:
         #       1. allow all if security disabled.
         #       2. default to deny all when security enabled.

--- a/trunk/src/app/srs_app_security.cpp
+++ b/trunk/src/app/srs_app_security.cpp
@@ -87,12 +87,18 @@ srs_error_t SrsSecurity::allow_check(SrsConfDirective* rules, SrsRtmpConnType ty
         }
         allow_rules++;
 
+        string cidr_ipv4 = srs_get_cidr_ipv4(rule->arg1());
+        string cidr_mask = srs_get_cidr_mask(rule->arg1());
+
         switch (type) {
             case SrsRtmpConnPlay:
                 if (rule->arg0() != "play") {
                     break;
                 }
                 if (rule->arg1() == "all" || rule->arg1() == ip) {
+                    return srs_success; // OK
+                }
+                if (srs_is_ipv4(cidr_ipv4) && cidr_mask != "" && srs_ipv4_within_mask(ip, cidr_ipv4, cidr_mask)) {
                     return srs_success; // OK
                 }
                 break;
@@ -103,6 +109,9 @@ srs_error_t SrsSecurity::allow_check(SrsConfDirective* rules, SrsRtmpConnType ty
                     break;
                 }
                 if (rule->arg1() == "all" || rule->arg1() == ip) {
+                    return srs_success; // OK
+                }
+                if (srs_is_ipv4(cidr_ipv4) && cidr_mask != "" && srs_ipv4_within_mask(ip, cidr_ipv4, cidr_mask)) {
                     return srs_success; // OK
                 }
                 break;
@@ -126,6 +135,9 @@ srs_error_t SrsSecurity::deny_check(SrsConfDirective* rules, SrsRtmpConnType typ
         if (rule->name != "deny") {
             continue;
         }
+
+        string cidr_ipv4 = srs_get_cidr_ipv4(rule->arg1());
+        string cidr_mask = srs_get_cidr_mask(rule->arg1());
         
         switch (type) {
             case SrsRtmpConnPlay:
@@ -133,6 +145,9 @@ srs_error_t SrsSecurity::deny_check(SrsConfDirective* rules, SrsRtmpConnType typ
                     break;
                 }
                 if (rule->arg1() == "all" || rule->arg1() == ip) {
+                    return srs_error_new(ERROR_SYSTEM_SECURITY_DENY, "deny by rule<%s>", rule->arg1().c_str());
+                }
+                if (srs_is_ipv4(cidr_ipv4) && cidr_mask != "" && srs_ipv4_within_mask(ip, cidr_ipv4, cidr_mask)) {
                     return srs_error_new(ERROR_SYSTEM_SECURITY_DENY, "deny by rule<%s>", rule->arg1().c_str());
                 }
                 break;
@@ -143,6 +158,9 @@ srs_error_t SrsSecurity::deny_check(SrsConfDirective* rules, SrsRtmpConnType typ
                     break;
                 }
                 if (rule->arg1() == "all" || rule->arg1() == ip) {
+                    return srs_error_new(ERROR_SYSTEM_SECURITY_DENY, "deny by rule<%s>", rule->arg1().c_str());
+                }
+                if (srs_is_ipv4(cidr_ipv4) && cidr_mask != "" && srs_ipv4_within_mask(ip, cidr_ipv4, cidr_mask)) {
                     return srs_error_new(ERROR_SYSTEM_SECURITY_DENY, "deny by rule<%s>", rule->arg1().c_str());
                 }
                 break;

--- a/trunk/src/app/srs_app_security.hpp
+++ b/trunk/src/app/srs_app_security.hpp
@@ -29,6 +29,7 @@
 #include <string>
 
 #include <srs_rtmp_stack.hpp>
+#include <srs_protocol_utility.hpp>
 
 class SrsConfDirective;
 

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -391,3 +391,22 @@ bool srs_is_ipv4(string domain)
     return true;
 }
 
+uint32_t srs_ipv4_to_num(string ip) {
+    int a, b, c, d;
+    uint32_t addr = 0;
+
+    if (!srs_is_ipv4(ip)) {
+        return 0;
+    }
+
+    if (sscanf(ip.c_str(), "%d.%d.%d.%d", &a, &b, &c, &d) != 4) {
+        return 0;
+    }
+
+    addr = a << 24;
+    addr |= b << 16;
+    addr |= c << 8;
+    addr |= d;
+
+    return addr;
+}

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -503,3 +503,43 @@ string srs_get_cidr_mask(string network_address) {
 
     return CIDR_VALUES[cidr_length_num-1].mask;
 }
+
+string srs_get_cidr_ipv4(string network_address) {
+    string delimiter = "/";
+
+    size_t delimiter_position = network_address.find(delimiter);
+    if (delimiter_position == string::npos) {
+        // Even if it does not have "/N", it can be a valid IP, by default "/32".
+        if (srs_is_ipv4(network_address)) {
+            return network_address;
+        }
+        return "";
+    }
+
+    // Change here to include IPv6 support.
+    string ipv4_address = network_address.substr(0, delimiter_position);
+    if (!srs_is_ipv4(ipv4_address)) {
+        return "";
+    }
+
+    size_t cidr_length_position = delimiter_position + delimiter.length();
+    if (cidr_length_position >= network_address.length()) {
+        return "";
+    }
+
+    string cidr_length = network_address.substr(cidr_length_position, network_address.length());
+    if (cidr_length.length() <= 0) {
+        return "";
+    }
+
+    try {
+        size_t cidr_length_num = atoi(cidr_length.c_str());
+        if (cidr_length_num <= 0) {
+            return "";
+        }
+    } catch (...) {
+        return "";
+    }
+
+    return ipv4_address;
+}

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -424,3 +424,82 @@ bool srs_ipv4_within_mask(string ip, string network, string mask) {
     }
     return false;
 }
+
+static struct CIDR_VALUE {
+    size_t length;
+    std::string mask;
+} CIDR_VALUES[32] = {
+    { .length = 1,  .mask = "128.0.0.0" },
+    { .length = 2,  .mask = "192.0.0.0" },
+    { .length = 3,  .mask = "224.0.0.0" },
+    { .length = 4,  .mask = "240.0.0.0" },
+    { .length = 5,  .mask = "248.0.0.0" },
+    { .length = 6,  .mask = "252.0.0.0" },
+    { .length = 7,  .mask = "254.0.0.0" },
+    { .length = 8,  .mask = "255.0.0.0" },
+    { .length = 9,  .mask = "255.128.0.0" },
+    { .length = 10, .mask = "255.192.0.0" },
+    { .length = 11, .mask = "255.224.0.0" },
+    { .length = 12, .mask = "255.240.0.0" },
+    { .length = 13, .mask = "255.248.0.0" },
+    { .length = 14, .mask = "255.252.0.0" },
+    { .length = 15, .mask = "255.254.0.0" },
+    { .length = 16, .mask = "255.255.0.0" },
+    { .length = 17, .mask = "255.255.128.0" },
+    { .length = 18, .mask = "255.255.192.0" },
+    { .length = 19, .mask = "255.255.224.0" },
+    { .length = 20, .mask = "255.255.240.0" },
+    { .length = 21, .mask = "255.255.248.0" },
+    { .length = 22, .mask = "255.255.252.0" },
+    { .length = 23, .mask = "255.255.254.0" },
+    { .length = 24, .mask = "255.255.255.0" },
+    { .length = 25, .mask = "255.255.255.128" },
+    { .length = 26, .mask = "255.255.255.192" },
+    { .length = 27, .mask = "255.255.255.224" },
+    { .length = 28, .mask = "255.255.255.240" },
+    { .length = 29, .mask = "255.255.255.248" },
+    { .length = 30, .mask = "255.255.255.252" },
+    { .length = 31, .mask = "255.255.255.254" },
+    { .length = 32, .mask = "255.255.255.255" },
+};
+
+string srs_get_cidr_mask(string network_address) {
+    string delimiter = "/";
+
+    size_t delimiter_position = network_address.find(delimiter);
+    if (delimiter_position == string::npos) {
+        // Even if it does not have "/N", it can be a valid IP, by default "/32".
+        if (srs_is_ipv4(network_address)) {
+            return CIDR_VALUES[32-1].mask;
+        }
+        return "";
+    }
+
+    // Change here to include IPv6 support.
+    string is_ipv4_address = network_address.substr(0, delimiter_position);
+    if (!srs_is_ipv4(is_ipv4_address)) {
+        return "";
+    }
+
+    size_t cidr_length_position = delimiter_position + delimiter.length();
+    if (cidr_length_position >= network_address.length()) {
+        return "";
+    }
+
+    string cidr_length = network_address.substr(cidr_length_position, network_address.length());
+    if (cidr_length.length() <= 0) {
+        return "";
+    }
+
+    size_t cidr_length_num = 31;
+    try {
+        cidr_length_num = atoi(cidr_length.c_str());
+        if (cidr_length_num <= 0) {
+            return "";
+        }
+    } catch (...) {
+        return "";
+    }
+
+    return CIDR_VALUES[cidr_length_num-1].mask;
+}

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -410,3 +410,17 @@ uint32_t srs_ipv4_to_num(string ip) {
 
     return addr;
 }
+
+bool srs_ipv4_within_mask(string ip, string network, string mask) {
+    uint32_t ip_addr = srs_ipv4_to_num(ip);
+    uint32_t mask_addr = srs_ipv4_to_num(mask);
+    uint32_t network_addr = srs_ipv4_to_num(network);
+
+    uint32_t net_lower = (network_addr & mask_addr);
+    uint32_t net_upper = (net_lower | (~mask_addr));
+
+    if (ip_addr >= net_lower && ip_addr <= net_upper) {
+        return true;
+    }
+    return false;
+}

--- a/trunk/src/protocol/srs_protocol_utility.hpp
+++ b/trunk/src/protocol/srs_protocol_utility.hpp
@@ -112,5 +112,7 @@ extern std::string srs_join_vector_string(std::vector<std::string>& vs, std::str
 // Whether domain is an IPv4 address.
 extern bool srs_is_ipv4(std::string domain);
 
+// Convert an IPv4 from string to uint32_t. Extracted from https://www.stev.org/post/ccheckanipaddressisinaipmask
+extern uint32_t srs_ipv4_to_num(std::string ip);
 #endif
 

--- a/trunk/src/protocol/srs_protocol_utility.hpp
+++ b/trunk/src/protocol/srs_protocol_utility.hpp
@@ -114,5 +114,9 @@ extern bool srs_is_ipv4(std::string domain);
 
 // Convert an IPv4 from string to uint32_t. Extracted from https://www.stev.org/post/ccheckanipaddressisinaipmask
 extern uint32_t srs_ipv4_to_num(std::string ip);
+
+// Whether the IPv4 is in an IP mask. Extracted from https://www.stev.org/post/ccheckanipaddressisinaipmask
+extern bool srs_ipv4_within_mask(std::string ip, std::string network, std::string mask);
+
 #endif
 

--- a/trunk/src/protocol/srs_protocol_utility.hpp
+++ b/trunk/src/protocol/srs_protocol_utility.hpp
@@ -121,5 +121,8 @@ extern bool srs_ipv4_within_mask(std::string ip, std::string network, std::strin
 // Get the CIDR (Classless Inter-Domain Routing) mask for a network address.
 extern std::string srs_get_cidr_mask(std::string network_address);
 
+// Get the CIDR (Classless Inter-Domain Routing) IPv4 for a network address.
+extern std::string srs_get_cidr_ipv4(std::string network_address);
+
 #endif
 

--- a/trunk/src/protocol/srs_protocol_utility.hpp
+++ b/trunk/src/protocol/srs_protocol_utility.hpp
@@ -118,5 +118,8 @@ extern uint32_t srs_ipv4_to_num(std::string ip);
 // Whether the IPv4 is in an IP mask. Extracted from https://www.stev.org/post/ccheckanipaddressisinaipmask
 extern bool srs_ipv4_within_mask(std::string ip, std::string network, std::string mask);
 
+// Get the CIDR (Classless Inter-Domain Routing) mask for a network address.
+extern std::string srs_get_cidr_mask(std::string network_address);
+
 #endif
 

--- a/trunk/src/utest/srs_utest_rtmp.cpp
+++ b/trunk/src/utest/srs_utest_rtmp.cpp
@@ -3246,6 +3246,17 @@ VOID TEST(ProtocolRTMPTest, OthersAll)
     }
 
     if (true) {
+        EXPECT_STREQ("127.0.0.1", srs_get_cidr_ipv4("127.0.0.1").c_str());
+        EXPECT_STREQ("127.0.0.1", srs_get_cidr_ipv4("127.0.0.1/12").c_str());
+    }
+
+    if (true) {
+        EXPECT_STREQ("", srs_get_cidr_ipv4("my.custom.domain").c_str());
+        EXPECT_STREQ("", srs_get_cidr_ipv4("my.custom.domain/12").c_str());
+        EXPECT_STREQ("", srs_get_cidr_ipv4("127.0.0.1/invalid/netmask").c_str());
+    }
+
+    if (true) {
         SrsMessageArray h(10);
         h.msgs[0] = new SrsSharedPtrMessage();
         h.msgs[1] = new SrsSharedPtrMessage();

--- a/trunk/src/utest/srs_utest_rtmp.cpp
+++ b/trunk/src/utest/srs_utest_rtmp.cpp
@@ -3235,6 +3235,17 @@ VOID TEST(ProtocolRTMPTest, OthersAll)
     }
 
     if (true) {
+        EXPECT_STREQ("255.255.255.255", srs_get_cidr_mask("127.0.0.1").c_str());
+        EXPECT_STREQ("255.240.0.0", srs_get_cidr_mask("127.0.0.1/12").c_str());
+    }
+
+    if (true) {
+        EXPECT_STREQ("", srs_get_cidr_mask("my.custom.domain").c_str());
+        EXPECT_STREQ("", srs_get_cidr_mask("my.custom.domain/12").c_str());
+        EXPECT_STREQ("", srs_get_cidr_mask("127.0.0.1/invalid/netmask").c_str());
+    }
+
+    if (true) {
         SrsMessageArray h(10);
         h.msgs[0] = new SrsSharedPtrMessage();
         h.msgs[1] = new SrsSharedPtrMessage();

--- a/trunk/src/utest/srs_utest_rtmp.cpp
+++ b/trunk/src/utest/srs_utest_rtmp.cpp
@@ -3211,6 +3211,14 @@ VOID TEST(ProtocolRTMPTest, OthersAll)
     }
 
     if (true) {
+        EXPECT_EQ((uint32_t)0, srs_ipv4_to_num("not.a.valid.ip"));
+    }
+
+    if (true) {
+        EXPECT_EQ((uint32_t)2130706433, srs_ipv4_to_num("127.0.0.1"));
+    }
+
+    if (true) {
         SrsMessageArray h(10);
         h.msgs[0] = new SrsSharedPtrMessage();
         h.msgs[1] = new SrsSharedPtrMessage();

--- a/trunk/src/utest/srs_utest_rtmp.cpp
+++ b/trunk/src/utest/srs_utest_rtmp.cpp
@@ -3219,6 +3219,22 @@ VOID TEST(ProtocolRTMPTest, OthersAll)
     }
 
     if (true) {
+        EXPECT_TRUE(srs_ipv4_within_mask("192.168.1.1", "192.168.1.0", "255.255.255.0"));
+        EXPECT_TRUE(srs_ipv4_within_mask("220.1.1.22", "220.1.1.22", "255.255.255.255"));
+        EXPECT_TRUE(srs_ipv4_within_mask("0.0.0.1", "0.0.0.0", "0.0.0.0"));
+        EXPECT_TRUE(srs_ipv4_within_mask("10.2.13.243", "10.0.0.0", "255.0.0.0"));
+    }
+
+    if (true) {
+        EXPECT_FALSE(srs_ipv4_within_mask("192.168.1.1", "192.168.1.2", "255.255.255.255"));
+        EXPECT_FALSE(srs_ipv4_within_mask("192.168.1.3", "192.168.1.2", "255.255.255.255"));
+        EXPECT_FALSE(srs_ipv4_within_mask("220.1.1.22", "192.168.1.0", "255.255.255.0"));
+        EXPECT_FALSE(srs_ipv4_within_mask("220.1.1.22", "220.1.1.23", "255.255.255.255"));
+        EXPECT_FALSE(srs_ipv4_within_mask("220.1.1.22", "220.1.1.21", "255.255.255.255"));
+        EXPECT_FALSE(srs_ipv4_within_mask("192.168.1.2", "10.0.0.1", "255.255.255.255"));
+    }
+
+    if (true) {
         SrsMessageArray h(10);
         h.msgs[0] = new SrsSharedPtrMessage();
         h.msgs[1] = new SrsSharedPtrMessage();


### PR DESCRIPTION
Previously you could only specify static IPs to the security config, this PR enables specifying ranges of IPs in a network.  
Tests added and passing.  

Fixes #1190

Thanks