### PR TITLE
Don't override the default port if a value of 0 is sent explicitly

### DIFF
--- a/trunk/src/kernel/srs_kernel_utility.cpp
+++ b/trunk/src/kernel/srs_kernel_utility.cpp
@@ -209,7 +209,7 @@ void srs_parse_hostport(string hostport, string& host, int& port)
     if (hostport.find(":") == pos) {
         host = hostport.substr(0, pos);
         string p = hostport.substr(pos + 1);
-        if (!p.empty()) {
+        if (!p.empty() && p != "0") {
             port = ::atoi(p.c_str());
         }
         return;
@@ -224,7 +224,7 @@ void srs_parse_hostport(string hostport, string& host, int& port)
     // For ipv6, [host]:port.
     host = hostport.substr(1, pos - 1);
     string p = hostport.substr(pos + 2);
-    if (!p.empty()) {
+    if (!p.empty() && p != "0") {
         port = ::atoi(p.c_str());
     }
 }

--- a/trunk/src/utest/srs_utest_kernel.cpp
+++ b/trunk/src/utest/srs_utest_kernel.cpp
@@ -4386,6 +4386,14 @@ VOID TEST(KernelUtilityTest, CoverTimeUtilityAll)
         srs_parse_hostport("domain.com", host, port);
         EXPECT_STREQ("domain.com", host.c_str());
     }
+
+    if (true) {
+        string host;
+        int port = 1935;
+        srs_parse_hostport("domain.com:0", host, port);
+        EXPECT_EQ(1935, port);
+        EXPECT_STREQ("domain.com", host.c_str());
+    }
     
     if (true) {
         string ep = srs_any_address_for_listener();


### PR DESCRIPTION
Some encoders like the [Cerevo LiveShell 2](https://liveshell.cerevo.com/en/s2/) will send explicitly port `0` if you don't set any port. While it should default to not send any actual port or default the protocol's default (1935 for RTMP etc), it doesn't do that unfortunately.  

```
[2020-05-11 13:28:40.286][Error][1][5645][11] serve error code=2006 : service cycle : rtmp: stream service : discovery tcUrl failed, tcUrl=rtmp://localhost:0/live, schema=rtmp, vhost=__defaultVhost__, port=0, app=live
thread [1][5645]: do_cycle() [src/app/srs_app_rtmp_conn.cpp:210][errno=11]
thread [1][5645]: service_cycle() [src/app/srs_app_rtmp_conn.cpp:399][errno=11]
thread [1][5645]: stream_service_cycle() [src/app/srs_app_rtmp_conn.cpp:457][errno=11](Resource temporarily unavailable)
```

This small patch makes it so that if a port `0` is sent, the default value of `port` will not be overridden.  