### PR TITLE
Properly initialize memory

### DIFF
--- a/trunk/src/app/srs_app_http_conn.cpp
+++ b/trunk/src/app/srs_app_http_conn.cpp
@@ -75,6 +75,7 @@ SrsHttpConn::~SrsHttpConn()
 void SrsHttpConn::remark(int64_t* in, int64_t* out)
 {
     // TODO: FIXME: implements it
+    *in = *out = 0;
 }
 
 srs_error_t SrsHttpConn::do_cycle()


### PR DESCRIPTION
Those two pointers were passed in without being initialized. If they don't get initialized here, uninitialized values will be used in caller function and will result in unusable statistics data in this case.