### PR TITLE
RTC: Support planar audio like aac.

### DIFF
--- a/trunk/src/app/srs_app_rtc_codec.hpp
+++ b/trunk/src/app/srs_app_rtc_codec.hpp
@@ -55,11 +55,13 @@ private:
     AVPacket* packet_;
     AVCodecContext* codec_ctx_;
     std::string codec_name_;
+    uint8_t** decode_buf_;
+    int decode_linesize_;
 public:
     SrsAudioDecoder(std::string codec);
     virtual ~SrsAudioDecoder();
     srs_error_t initialize();
-    virtual srs_error_t decode(SrsSample *pkt, char *buf, int &size);
+    virtual srs_error_t decode(SrsSample *pkt, char ***buf, int &size);
     AVCodecContext* codec_ctx();
 };
 

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -365,6 +365,7 @@ SrsSample::SrsSample()
 {
     size = 0;
     bytes = NULL;
+    ppBytes = NULL;
     bframe = false;
 }
 

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -534,6 +534,8 @@ public:
     int size;
     // The ptr of unit, user must free it.
     char* bytes;
+    // The double ptr of unit, for planar audio like aac
+    char** ppBytes;
     // Whether is B frame.
     bool bframe;
 public:


### PR DESCRIPTION
The sample format of decoded AAC is planar(AV_SAMPLE_FMT_FLTP) not interlaced.