### PR TITLE
fixbug  通过http api接口 获取 的 stream id是乱码

### DIFF
--- a/trunk/src/app/srs_app_statistic.cpp
+++ b/trunk/src/app/srs_app_statistic.cpp
@@ -47,7 +47,7 @@ int64_t srs_generate_id()
 
 SrsStatisticVhost::SrsStatisticVhost()
 {
-    id = srs_generate_id();
+    id = std::to_string(srs_generate_id());
     
     clk = new SrsWallClock();
     kbps = new SrsKbps(clk);
@@ -98,7 +98,7 @@ srs_error_t SrsStatisticVhost::dumps(SrsJsonObject* obj)
 
 SrsStatisticStream::SrsStatisticStream()
 {
-    id = srs_generate_id();
+    id = std::to_string(srs_generate_id());
     vhost = NULL;
     active = false;
 

--- a/trunk/src/app/srs_app_statistic.cpp
+++ b/trunk/src/app/srs_app_statistic.cpp
@@ -47,7 +47,7 @@ int64_t srs_generate_id()
 
 SrsStatisticVhost::SrsStatisticVhost()
 {
-    id = std::to_string(srs_generate_id());
+    id = srs_int2str(srs_generate_id());
     
     clk = new SrsWallClock();
     kbps = new SrsKbps(clk);
@@ -98,7 +98,7 @@ srs_error_t SrsStatisticVhost::dumps(SrsJsonObject* obj)
 
 SrsStatisticStream::SrsStatisticStream()
 {
-    id = std::to_string(srs_generate_id());
+    id = srs_int2str(srs_generate_id());
     vhost = NULL;
     active = false;
 


### PR DESCRIPTION
需要把 int64_t转化为字符串 再 赋值给 SrsStatisticStream类的成员变量id 