### PR TITLE
Update srs_app_statistic.cpp 

### DIFF
--- a/trunk/src/app/srs_app_statistic.cpp
+++ b/trunk/src/app/srs_app_statistic.cpp
@@ -45,9 +45,17 @@ int64_t srs_generate_id()
     return srs_gvid++;
 }
 
+template <typename T>
+std::string tostring(const T& t)
+{
+    std::ostringstream oss;
+    oss << t;
+    return oss.str();
+}
+
 SrsStatisticVhost::SrsStatisticVhost()
 {
-    id = srs_generate_id();
+    id = tostring(srs_generate_id());
     
     clk = new SrsWallClock();
     kbps = new SrsKbps(clk);
@@ -98,7 +106,7 @@ srs_error_t SrsStatisticVhost::dumps(SrsJsonObject* obj)
 
 SrsStatisticStream::SrsStatisticStream()
 {
-    id = srs_generate_id();
+    id = tostring(srs_generate_id());
     vhost = NULL;
     active = false;
 


### PR DESCRIPTION
int64_t 直接赋值给 std::string，造成http_api接口  
/api/v1/clients/ 返回json数据中元素vhost 、stream值不正确
![image](https://raw.githubusercontent.com/nowgoing/src_files/master/srs_ApiGoClients.jpg)
/api/v1/streams/ 返回json数据中元素id、vhost 值不正确
![image](https://raw.githubusercontent.com/nowgoing/src_files/master/srs_ApiGoStreams.jpg)

