### PR TITLE
H265: Fix some bugs.

### DIFF
--- a/trunk/auto/auto_headers.sh
+++ b/trunk/auto/auto_headers.sh
@@ -93,6 +93,12 @@ else
     srs_undefine_macro "SRS_FFMPEG_FIT" $SRS_AUTO_HEADERS_H
 fi
 
+if [ $SRS_H265 = YES ]; then
+    srs_define_macro "SRS_H265" $SRS_AUTO_HEADERS_H
+else
+    srs_undefine_macro "SRS_H265" $SRS_AUTO_HEADERS_H
+fi
+
 if [ $SRS_SIMULATOR = YES ]; then
     srs_define_macro "SRS_SIMULATOR" $SRS_AUTO_HEADERS_H
 else

--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -18,6 +18,7 @@ help=no
 SRS_HDS=NO
 SRS_SRT=NO
 SRS_RTC=YES
+SRS_H265=YES
 SRS_GB28181=NO
 SRS_CXX11=NO
 SRS_CXX14=NO
@@ -157,6 +158,7 @@ Features:
   --cxx11=on|off            Whether enable the C++11 support for SRS.
   --cxx14=on|off            Whether enable the C++14 support for SRS.
   --ffmpeg-fit=on|off       Whether enable the FFmpeg fit(source code) for SRS.
+  --h265=on|off             Whether build the H.265 support for SRS.
 
   --prefix=<path>           The absolute installation path for srs. Default: $SRS_PREFIX
   --gcov=on|off             Whether enable the GCOV compiler options.
@@ -321,6 +323,8 @@ function parse_user_option() {
         --without-rtc)                  SRS_RTC=NO                  ;;
         --rtc)                          if [[ $value == off ]]; then SRS_RTC=NO; else SRS_RTC=YES; fi    ;;
         --simulator)                    if [[ $value == off ]]; then SRS_SIMULATOR=NO; else SRS_SIMULATOR=YES; fi    ;;
+
+        --h265)                         if [[ $value == off ]]; then SRS_H265=NO; else SRS_H265=YES; fi    ;;
 
         --with-gb28181)                 SRS_GB28181=YES             ;;
         --without-gb28181)              SRS_GB28181=NO              ;;
@@ -537,6 +541,7 @@ function regenerate_options() {
     if [ $SRS_UTEST = YES ]; then           SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --utest=on"; else           SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --utest=off"; fi
     if [ $SRS_SRT = YES ]; then             SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --srt=on"; else             SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --srt=off"; fi
     if [ $SRS_RTC = YES ]; then             SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --rtc=on"; else             SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --rtc=off"; fi
+    if [ $SRS_H265 = YES ]; then            SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --h265=on"; else            SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --h265=off"; fi
     if [ $SRS_SIMULATOR = YES ]; then       SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --simulator=on"; else       SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --simulator=off"; fi
     if [ $SRS_GB28181 = YES ]; then         SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --gb28181=on"; else         SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --gb28181=off"; fi
     if [ $SRS_CXX11 = YES ]; then           SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --cxx11=on"; else           SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --cxx11=off"; fi

--- a/trunk/configure
+++ b/trunk/configure
@@ -238,6 +238,9 @@ fi
 if [[ $SRS_FFMPEG_FIT == YES ]]; then
     ModuleLibIncs+=("${LibFfmpegRoot[*]}")
 fi
+if [[ $SRS_H265 == YES ]]; then
+    MODULE_FILES+=("srs_raw_hevc")
+fi
 PROTOCOL_INCS="src/protocol"; MODULE_DIR=${PROTOCOL_INCS} . auto/modules.sh
 PROTOCOL_OBJS="${MODULE_OBJS[@]}"
 #

--- a/trunk/src/app/srs_app_hls.cpp
+++ b/trunk/src/app/srs_app_hls.cpp
@@ -384,6 +384,8 @@ srs_error_t SrsHlsMuxer::segment_open()
         std::string default_vcodec_str = _srs_config->get_hls_vcodec(req->vhost);
         if (default_vcodec_str == "h264") {
             default_vcodec = SrsVideoCodecIdAVC;
+        } else if (default_vcodec_str == "h265") {
+            default_vcodec = SrsVideoCodecIdHEVC;
         } else if (default_vcodec_str == "vn") {
             default_vcodec = SrsVideoCodecIdDisabled;
         } else {
@@ -1325,7 +1327,11 @@ srs_error_t SrsHls::on_video(SrsSharedPtrMessage* shared_video, SrsFormat* forma
     }
     
     srs_assert(format->vcodec);
-    if (format->vcodec->id != SrsVideoCodecIdAVC) {
+    bool ignore_frame = (format->vcodec->id != SrsVideoCodecIdAVC);
+#ifdef SRS_H265
+    ignore_frame = ignore_frame && (format->vcodec->id != SrsVideoCodecIdHEVC);
+#endif
+    if (ignore_frame) {
         return err;
     }
     

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1691,10 +1691,11 @@ SrsHttpApi::~SrsHttpApi()
     _srs_config->unsubscribe(this);
 }
 
-void SrsHttpApi::remark(int64_t* in, int64_t* out)
-{
-    // TODO: FIXME: implements it
-}
+// 2020.9.14 为解决播放flv，带宽数据异常，注释起来该函数，使其调用父类该函数
+// void SrsHttpApi::remark(int64_t* in, int64_t* out)
+// {
+//     // TODO: FIXME: implements it
+// }
 
 srs_error_t SrsHttpApi::do_cycle()
 {

--- a/trunk/src/app/srs_app_http_api.hpp
+++ b/trunk/src/app/srs_app_http_api.hpp
@@ -264,8 +264,9 @@ public:
     SrsHttpApi(IConnectionManager* cm, srs_netfd_t fd, SrsHttpServeMux* m, std::string cip, int port);
     virtual ~SrsHttpApi();
 // Interface ISrsKbpsDelta
-public:
-    virtual void remark(int64_t* in, int64_t* out);
+// 2020.9.14 为解决播放flv，带宽数据异常，注释起来该函数，使其调用父类该函数
+//public:
+//    virtual void remark(int64_t* in, int64_t* out);
 protected:
     virtual srs_error_t do_cycle();
 private:

--- a/trunk/src/app/srs_app_http_conn.cpp
+++ b/trunk/src/app/srs_app_http_conn.cpp
@@ -63,6 +63,7 @@ SrsHttpConn::SrsHttpConn(IConnectionManager* cm, srs_netfd_t fd, ISrsHttpServeMu
 {
     parser = new SrsHttpParser();
     cors = new SrsHttpCorsMux();
+
     http_mux = m;
 }
 
@@ -72,10 +73,11 @@ SrsHttpConn::~SrsHttpConn()
     srs_freep(cors);
 }
 
-void SrsHttpConn::remark(int64_t* in, int64_t* out)
-{
-    // TODO: FIXME: implements it
-}
+// 2020.9.14 为解决播放flv，带宽数据异常，注释起来该函数，使其调用父类该函数
+//void SrsHttpConn::remark(int64_t* in, int64_t* out)
+//{
+//    // TODO: FIXME: implements it
+//}
 
 srs_error_t SrsHttpConn::do_cycle()
 {

--- a/trunk/src/app/srs_app_http_conn.hpp
+++ b/trunk/src/app/srs_app_http_conn.hpp
@@ -66,8 +66,9 @@ public:
     SrsHttpConn(IConnectionManager* cm, srs_netfd_t fd, ISrsHttpServeMux* m, std::string cip, int port);
     virtual ~SrsHttpConn();
 // Interface ISrsKbpsDelta
-public:
-    virtual void remark(int64_t* in, int64_t* out);
+// 2020.9.14 为解决播放flv，带宽数据异常，注释起来该函数，使其调用父类该函数
+//public:
+//    virtual void remark(int64_t* in, int64_t* out);
 protected:
     virtual srs_error_t do_cycle();
 protected:

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -629,8 +629,11 @@ srs_error_t SrsGopCache::cache(SrsSharedPtrMessage* shared_msg)
     
     // got video, update the video count if acceptable
     if (msg->is_video()) {
-        // drop video when not h.264
-        if (!SrsFlvVideo::h264(msg->payload, msg->size)) {
+        bool ignore_frame = !SrsFlvVideo::h264(msg->payload, msg->size);
+#ifdef SRS_H265
+        ignore_frame = ignore_frame && !SrsFlvVideo::hevc(msg->payload, msg->size);
+#endif
+        if (ignore_frame) {
             return err;
         }
         

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -1052,7 +1052,9 @@ srs_error_t SrsOriginHub::on_video(SrsSharedPtrMessage* shared_video, bool is_se
         
         // when got video stream info.
         SrsStatistic* stat = SrsStatistic::instance();
-        if ((err = stat->on_video_info(req, SrsVideoCodecIdAVC, c->avc_profile, c->avc_level, c->width, c->height)) != srs_success) {
+        // if ((err = stat->on_video_info(req, SrsVideoCodecIdAVC, c->avc_profile, c->avc_level, c->width, c->height)) != srs_success) {
+        // fix 显示H265问题
+        if ((err = stat->on_video_info(req, c->id, c->avc_profile, c->avc_level, c->width, c->height)) != srs_success) {
             return srs_error_wrap(err, "stat video");
         }
         

--- a/trunk/src/app/srs_app_statistic.cpp
+++ b/trunk/src/app/srs_app_statistic.cpp
@@ -422,6 +422,27 @@ void SrsStatistic::on_stream_close(SrsRequest* req)
     }
 }
 
+void SrsStatistic::stream_close(SrsStatisticStream* stream)
+{
+    //close()本质上是将有流状态，转为无流状态，且将流数量减1，而无流状态时，流数量并未加上，在此无需要调用。
+    //stream->close();
+    // TODO: FIXME: Should fix https://github.com/ossrs/srs/issues/803
+    if (true) {
+        std::map<string, SrsStatisticStream*>::iterator it;
+        if ((it=streams.find(stream->id)) != streams.end()) {
+            streams.erase(it);
+        }
+    }
+
+    // TODO: FIXME: Should fix https://github.com/ossrs/srs/issues/803
+    if (true) {
+        std::map<std::string, SrsStatisticStream*>::iterator it;
+        if ((it=rstreams.find(stream->url)) != rstreams.end()) {
+            rstreams.erase(it);
+        }
+    }
+}
+
 srs_error_t SrsStatistic::on_client(SrsContextId cid, SrsRequest* req, SrsConnection* conn, SrsRtmpConnType type)
 {
     srs_error_t err = srs_success;
@@ -472,6 +493,9 @@ void SrsStatistic::on_disconnect(SrsContextId cid)
     
     stream->nb_clients--;
     vhost->nb_clients--;
+
+    //解决无流不删除的问题
+    if (!stream->active) stream_close(stream);
 }
 
 void SrsStatistic::kbps_add_delta(SrsConnection* conn)

--- a/trunk/src/app/srs_app_statistic.hpp
+++ b/trunk/src/app/srs_app_statistic.hpp
@@ -198,6 +198,7 @@ public:
     virtual void on_stream_publish(SrsRequest* req, SrsContextId cid);
     // When close stream.
     virtual void on_stream_close(SrsRequest* req);
+    virtual void stream_close(SrsStatisticStream* stream);
 public:
     // When got a client to publish/play stream,
     // @param id, the client srs id.

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -582,7 +582,8 @@ srs_error_t SrsVideoFrame::add_sample(char* bytes, int size)
     }
 
 #ifdef SRS_H265
-    if (vcodec()->id == SrsVideoCodecIdAVC) {
+    // 应该是SrsVideoCodecIdHEVC
+    if (vcodec()->id == SrsVideoCodecIdHEVC) {
         // for video, parse the nalu type, set the IDR flag.
         SrsAvcNaluType nal_unit_type = (SrsAvcNaluType)(bytes[0] & 0x1f);
         
@@ -1451,10 +1452,12 @@ srs_error_t SrsFormat::hevc_demux_ibmf_format(SrsBuffer* stream) {
             return srs_error_wrap(err, "avc add video frame");
         }
         stream->skip(NALUnitLength);
-        
-        i += vcodec->NAL_unit_length + 1 + NALUnitLength;
+
+        //fix 0916 0:53修改 h265 播放问题
+        //i += vcodec->NAL_unit_length + 1 + NALUnitLength;
+        i += nal_len_size + 1 + NALUnitLength;
     }
-    
+
     return err;
 }
 #endif

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -42,6 +42,7 @@ class SrsBuffer;
  *      5 = On2 VP6 with alpha channel
  *      6 = Screen video version 2
  *      7 = AVC
+ *     12 = HEVC
  */
 enum SrsVideoCodecId
 {
@@ -262,6 +263,12 @@ public:
      * check codec h264.
      */
     static bool h264(char* data, int size);
+#ifdef SRS_H265
+    /**
+     * check codec hevc.
+     */
+    static bool hevc(char* data, int size);
+#endif
     /**
      * check the video RTMP/flv header info,
      * @return true if video RTMP/flv header is ok.
@@ -397,6 +404,80 @@ enum SrsAvcNaluType
     SrsAvcNaluTypeCodedSliceExt = 20,
 };
 std::string srs_avc_nalu2str(SrsAvcNaluType nalu_type);
+
+#ifdef SRS_H265
+enum SrsHevcNaluType
+{
+	NAL_UNIT_CODED_SLICE_TRAIL_N = 0,
+	NAL_UNIT_CODED_SLICE_TRAIL_R, //1
+	NAL_UNIT_CODED_SLICE_TSA_N,   //2
+	NAL_UNIT_CODED_SLICE_TLA,     //3
+	NAL_UNIT_CODED_SLICE_STSA_N,  //4
+	NAL_UNIT_CODED_SLICE_STSA_R,  //5
+	NAL_UNIT_CODED_SLICE_RADL_N,  //6
+	NAL_UNIT_CODED_SLICE_DLP,     //7
+	NAL_UNIT_CODED_SLICE_RASL_N,  //8
+	NAL_UNIT_CODED_SLICE_TFD,     //9
+	NAL_UNIT_RESERVED_10,
+	NAL_UNIT_RESERVED_11,
+	NAL_UNIT_RESERVED_12,
+	NAL_UNIT_RESERVED_13,
+	NAL_UNIT_RESERVED_14,
+	NAL_UNIT_RESERVED_15,
+	NAL_UNIT_CODED_SLICE_BLA,      //16
+	NAL_UNIT_CODED_SLICE_BLANT,    //17
+	NAL_UNIT_CODED_SLICE_BLA_N_LP, //18
+	NAL_UNIT_CODED_SLICE_IDR,      //19
+	NAL_UNIT_CODED_SLICE_IDR_N_LP, //20
+	NAL_UNIT_CODED_SLICE_CRA,      //21
+	NAL_UNIT_RESERVED_22,
+	NAL_UNIT_RESERVED_23,
+	NAL_UNIT_RESERVED_24,
+	NAL_UNIT_RESERVED_25,
+	NAL_UNIT_RESERVED_26,
+	NAL_UNIT_RESERVED_27,
+	NAL_UNIT_RESERVED_28,
+	NAL_UNIT_RESERVED_29,
+	NAL_UNIT_RESERVED_30,
+	NAL_UNIT_RESERVED_31,
+	NAL_UNIT_VPS,                   // 32
+	NAL_UNIT_SPS,                   // 33
+	NAL_UNIT_PPS,                   // 34
+	NAL_UNIT_ACCESS_UNIT_DELIMITER, // 35
+	NAL_UNIT_EOS,                   // 36
+	NAL_UNIT_EOB,                   // 37
+	NAL_UNIT_FILLER_DATA,           // 38
+	NAL_UNIT_SEI ,                  // 39 Prefix SEI
+	NAL_UNIT_SEI_SUFFIX,            // 40 Suffix SEI
+	NAL_UNIT_RESERVED_41,
+	NAL_UNIT_RESERVED_42,
+	NAL_UNIT_RESERVED_43,
+	NAL_UNIT_RESERVED_44,
+	NAL_UNIT_RESERVED_45,
+	NAL_UNIT_RESERVED_46,
+	NAL_UNIT_RESERVED_47,
+	NAL_UNIT_UNSPECIFIED_48,
+	NAL_UNIT_UNSPECIFIED_49,
+	NAL_UNIT_UNSPECIFIED_50,
+	NAL_UNIT_UNSPECIFIED_51,
+	NAL_UNIT_UNSPECIFIED_52,
+	NAL_UNIT_UNSPECIFIED_53,
+	NAL_UNIT_UNSPECIFIED_54,
+	NAL_UNIT_UNSPECIFIED_55,
+	NAL_UNIT_UNSPECIFIED_56,
+	NAL_UNIT_UNSPECIFIED_57,
+	NAL_UNIT_UNSPECIFIED_58,
+	NAL_UNIT_UNSPECIFIED_59,
+	NAL_UNIT_UNSPECIFIED_60,
+	NAL_UNIT_UNSPECIFIED_61,
+	NAL_UNIT_UNSPECIFIED_62,
+	NAL_UNIT_UNSPECIFIED_63,
+	NAL_UNIT_INVALID,
+};
+
+//for nalu data first byte
+#define HEVC_NALU_TYPE(code) (SrsHevcNaluType)((code & 0x7E)>>1)
+#endif
 
 /**
  * Table 7-6 – Name association to slice_type
@@ -608,6 +689,41 @@ public:
     virtual bool is_aac_codec_ok();
 };
 
+#ifdef SRS_H265
+struct HEVCNalData {
+    uint16_t nalUnitLength;
+    std::vector<uint8_t>  nalUnitData;
+};
+
+struct HVCCNALUnit {
+    uint8_t  array_completeness;
+    uint8_t  NAL_unit_type;
+    uint16_t numNalus;
+    std::vector<HEVCNalData> nalData_vec;
+};
+
+struct HEVCDecoderConfigurationRecord {
+    uint8_t  configurationVersion;
+    uint8_t  general_profile_space;
+    uint8_t  general_tier_flag;
+    uint8_t  general_profile_idc;
+    uint32_t general_profile_compatibility_flags;
+    uint64_t general_constraint_indicator_flags;
+    uint8_t  general_level_idc;
+    uint16_t min_spatial_segmentation_idc;
+    uint8_t  parallelismType;
+    uint8_t  chromaFormat;
+    uint8_t  bitDepthLumaMinus8;
+    uint8_t  bitDepthChromaMinus8;
+    uint16_t avgFrameRate;
+    uint8_t  constantFrameRate;
+    uint8_t  numTemporalLayers;
+    uint8_t  temporalIdNested;
+    uint8_t  lengthSizeMinusOne;
+    std::vector<HVCCNALUnit> nalu_vec;
+};
+#endif
+
 /**
  * The video codec info.
  */
@@ -627,7 +743,7 @@ public:
      * @see: ffmpeg, AVCodecContext::extradata
      */
     std::vector<char> avc_extra_data;
-public:
+public://H264
     /**
      * video specified
      */
@@ -643,6 +759,10 @@ public:
 public:
     // the avc payload format.
     SrsAvcPayloadFormat payload_format;
+#ifdef SRS_H265
+public:
+    HEVCDecoderConfigurationRecord _hevcDecConfRecord;
+#endif
 public:
     SrsVideoCodecConfig();
     virtual ~SrsVideoCodecConfig();
@@ -767,10 +887,24 @@ private:
     virtual srs_error_t avc_demux_sps_pps(SrsBuffer* stream);
     virtual srs_error_t avc_demux_sps();
     virtual srs_error_t avc_demux_sps_rbsp(char* rbsp, int nb_rbsp);
+
 private:
-    // Parse the H.264 NALUs.
+    srs_error_t  (SrsFormat::*demux_ibmf_format_func)(SrsBuffer* stream);
+
+#ifdef SRS_H265
+private:
+    // Parse the hevc vps/sps/pps
+    virtual srs_error_t hevc_demux_hvcc(SrsBuffer* stream);
+    virtual srs_error_t hevc_demux_ibmf_format(SrsBuffer* stream);
+    virtual srs_error_t hevc_vps_data(char*& data_p, int& len);
+    virtual srs_error_t hevc_pps_data(char*& data_p, int& len);
+    virtual srs_error_t hevc_sps_data(char*& data_p, int& len);
+#endif
+
+private:
+    // Parse the H.264/hevc NALUs.
     virtual srs_error_t video_nalu_demux(SrsBuffer* stream);
-    // Demux the avc NALU in "AnnexB" from ISO_IEC_14496-10-AVC-2003.pdf, page 211.
+    // Demux the avc/hevc NALU in "AnnexB" from ISO_IEC_14496-10-AVC-2003.pdf, page 211.
     virtual srs_error_t avc_demux_annexb_format(SrsBuffer* stream);
     // Demux the avc NALU in "ISO Base Media File Format" from ISO_IEC_14496-15-AVC-format-2012.pdf, page 20
     virtual srs_error_t avc_demux_ibmf_format(SrsBuffer* stream);

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -287,6 +287,8 @@
 #define ERROR_INOTIFY_CREATE                3092
 #define ERROR_INOTIFY_OPENFD                3093
 #define ERROR_INOTIFY_WATCH                 3094
+#define ERROR_HEVC_API_NO_PREFIXED          3095
+#define ERROR_HEVC_DROP_BEFORE_SPS_PPS      3096
 
 ///////////////////////////////////////////////////////
 // HTTP/StreamCaster protocol error.
@@ -324,6 +326,9 @@
 #define ERROR_HTTP_302_INVALID              4038
 #define ERROR_BASE64_DECODE                 4039
 #define ERROR_HTTP_STREAM_EOF               4040
+#define ERROR_STREAM_CASTER_HEVC_PPS        4041
+#define ERROR_STREAM_CASTER_HEVC_VPS        4042
+#define ERROR_STREAM_CASTER_HEVC_SPS        4043
 
 ///////////////////////////////////////////////////////
 // RTC protocol error.

--- a/trunk/src/kernel/srs_kernel_ts.cpp
+++ b/trunk/src/kernel/srs_kernel_ts.cpp
@@ -463,7 +463,7 @@ srs_error_t SrsTsContext::encode_pes(ISrsStreamWriter* writer, SrsTsMessage* msg
         return err;
     }
 
-    bool invalid_codec = (sid != SrsTsStreamVideoH264 && && sid != SrsTsStreamAudioMp3 && sid != SrsTsStreamAudioAAC);
+    bool invalid_codec = (sid != SrsTsStreamVideoH264 && sid != SrsTsStreamAudioMp3 && sid != SrsTsStreamAudioAAC);
 #ifdef SRS_H265
     invalid_codec = invalid_codec && (sid != SrsTsStreamVideoHEVC);
 #endif
@@ -808,7 +808,7 @@ SrsTsPacket* SrsTsPacket::create_pmt(SrsTsContext* context,
     }
     
     // if h.264 specified, use video to carry pcr.
-    bool is_valid_codec = (vs == SrsTsStreamVideoH264);
+    /*bool*/ is_valid_codec = (vs == SrsTsStreamVideoH264);
 #ifdef SRS_H265
     is_valid_codec = is_valid_codec || (vs == SrsTsStreamVideoHEVC);
 #endif

--- a/trunk/src/kernel/srs_kernel_ts.hpp
+++ b/trunk/src/kernel/srs_kernel_ts.hpp
@@ -149,6 +149,10 @@ enum SrsTsStream
     // ITU-T Rec. H.222.0 | ISO/IEC 13818-1 Reserved
     // 0x15-0x7F
     SrsTsStreamVideoH264 = 0x1b,
+#ifdef SRS_H265
+    SrsTsStreamVideoHEVC = 0x24,
+#endif
+
     // User Private
     // 0x80-0xFF
     SrsTsStreamAudioAC3 = 0x81,
@@ -261,6 +265,9 @@ public:
     uint8_t continuity_counter;
     // The payload bytes.
     SrsSimpleStream* payload;
+public:
+    SrsVideoCodecId _id;
+
 public:
     SrsTsMessage(SrsTsChannel* c = NULL, SrsTsPacket* p = NULL);
     virtual ~SrsTsMessage();
@@ -1278,6 +1285,7 @@ public:
 public:
     // get the video codec of ts muxer.
     virtual SrsVideoCodecId video_codec();
+    virtual void update_vcodec(SrsVideoCodecId id);
 };
 
 // Used for HLS Encryption

--- a/trunk/src/protocol/srs_raw_hevc.cpp
+++ b/trunk/src/protocol/srs_raw_hevc.cpp
@@ -1,0 +1,645 @@
+#include "srs_raw_hevc.hpp"
+#include <srs_kernel_error.hpp>
+#include <srs_kernel_log.hpp>
+#include <srs_kernel_buffer.hpp>
+#include <srs_kernel_utility.hpp>
+#include <srs_core_autofree.hpp>
+#include <srs_kernel_codec.hpp>
+#include <string.h>
+using namespace std;
+
+#define MAX(x, y) ((x) > (y) ? (x) : (y))
+
+#define BIT(ptr, off) (((ptr)[(off) / 8] >> (7 - ((off) % 8))) & 0x01)
+
+struct mpeg4_hevc_t
+{
+	uint8_t  configurationVersion;	// 1-only
+	uint8_t  general_profile_space;	// 2bit,[0,3]
+	uint8_t  general_tier_flag;		// 1bit,[0,1]
+	uint8_t  general_profile_idc;	// 5bit,[0,31]
+	uint32_t general_profile_compatibility_flags;
+	uint64_t general_constraint_indicator_flags;
+	uint8_t  general_level_idc;
+	uint16_t min_spatial_segmentation_idc;
+	uint8_t  parallelismType;		// 2bit,[0,3]
+	uint8_t  chromaFormat;			// 2bit,[0,3]
+	uint8_t  bitDepthLumaMinus8;	// 3bit,[0,7]
+	uint8_t  bitDepthChromaMinus8;	// 3bit,[0,7]
+	uint16_t avgFrameRate;
+	uint8_t  constantFrameRate;		// 2bit,[0,3]
+	uint8_t  numTemporalLayers;		// 3bit,[0,7]
+	uint8_t  temporalIdNested;		// 1bit,[0,1]
+	uint8_t  lengthSizeMinusOne;	// 2bit,[0,3]
+
+	uint8_t  numOfArrays;
+	struct
+	{
+		uint8_t array_completeness;
+		uint8_t type; // nalu type
+		uint16_t bytes;
+		uint8_t* data;
+	} nalu[64];
+
+	uint8_t array_completeness;
+	uint8_t data[4 * 1024];
+	int off;
+};
+
+static uint8_t mpeg4_h264_read_ue(const uint8_t* data, int bytes, int* offset)
+{
+	int bit, i;
+	int leadingZeroBits = -1;
+
+	for (bit = 0; !bit && *offset / 8 < bytes; ++leadingZeroBits)
+	{
+		bit = (data[*offset / 8] >> (7 - (*offset % 8))) & 0x01;
+		++*offset;
+	}
+
+	bit = 0;
+	assert(leadingZeroBits < 32);
+	for (i = 0; i < leadingZeroBits && *offset / 8 < bytes; i++)
+	{
+		bit = (bit << 1) | ((data[*offset / 8] >> (7 - (*offset % 8))) & 0x01);
+		++*offset;
+	}
+
+	return (uint8_t)((1 << leadingZeroBits) - 1 + bit);
+}
+
+static int hevc_rbsp_decode(const uint8_t* nalu, int bytes, uint8_t* sodb)
+{
+	int i, j;
+	for (j = i = 0; i < bytes; i++)
+	{
+		if (i + 2 < bytes && 0 == nalu[i] && 0 == nalu[i + 1] && 0x03 == nalu[i + 2])
+		{
+			sodb[j++] = nalu[i];
+			sodb[j++] = nalu[i + 1];
+			i += 2;
+		}
+		else
+		{
+			sodb[j++] = nalu[i];
+		}
+	}
+	return j;
+}
+
+static int hevc_profile_tier_level(const uint8_t* nalu, int bytes, uint8_t maxNumSubLayersMinus1, struct mpeg4_hevc_t* hevc)
+{
+	int n;
+	uint8_t i;
+	uint8_t sub_layer_profile_present_flag[8];
+	uint8_t sub_layer_level_present_flag[8];
+
+	if (bytes < 12)
+		return -1;
+
+	hevc->general_profile_space = (nalu[0] >> 6) & 0x03;
+	hevc->general_tier_flag = (nalu[0] >> 5) & 0x01;
+	hevc->general_profile_idc = nalu[0] & 0x1f;
+
+	hevc->general_profile_compatibility_flags = 0;
+	hevc->general_profile_compatibility_flags |= nalu[1] << 24;
+	hevc->general_profile_compatibility_flags |= nalu[2] << 16;
+	hevc->general_profile_compatibility_flags |= nalu[3] << 8;
+	hevc->general_profile_compatibility_flags |= nalu[4];
+
+	hevc->general_constraint_indicator_flags = 0;
+	hevc->general_constraint_indicator_flags |= ((uint64_t)nalu[5]) << 40;
+	hevc->general_constraint_indicator_flags |= ((uint64_t)nalu[6]) << 32;
+	hevc->general_constraint_indicator_flags |= ((uint64_t)nalu[7]) << 24;
+	hevc->general_constraint_indicator_flags |= ((uint64_t)nalu[8]) << 16;
+	hevc->general_constraint_indicator_flags |= ((uint64_t)nalu[9]) << 8;
+	hevc->general_constraint_indicator_flags |= nalu[10];
+
+	hevc->general_level_idc = nalu[11];
+	if (maxNumSubLayersMinus1 < 1)
+		return 12;
+
+	if (bytes < 14)
+		return -1; // error
+
+	for (i = 0; i < maxNumSubLayersMinus1; i++)
+	{
+		sub_layer_profile_present_flag[i] = BIT(nalu, 12 * 8 + i * 2);
+		sub_layer_level_present_flag[i] = BIT(nalu, 12 * 8 + i * 2 + 1);
+	}
+
+	n = 12 + 2;
+	for (i = 0; i < maxNumSubLayersMinus1; i++)
+	{
+		if(sub_layer_profile_present_flag[i])
+			n += 11;
+		if (sub_layer_level_present_flag[i])
+			n += 1;
+	}
+
+	return bytes < n ? n : -1;
+}
+
+static uint8_t hevc_vps_id(const uint8_t* rbsp, int bytes, struct mpeg4_hevc_t* hevc, uint8_t* ptr)
+{
+	int sodb;
+	uint8_t vps;
+	uint8_t vps_max_sub_layers_minus1;
+	uint8_t vps_temporal_id_nesting_flag;
+
+	sodb = hevc_rbsp_decode(rbsp, bytes, ptr);
+	if (sodb < 16 + 2)
+		return 0xFF;
+
+	vps = ptr[2] >> 4;  // 2-nalu type
+	vps_max_sub_layers_minus1 = (ptr[3] >> 1) & 0x07;
+	vps_temporal_id_nesting_flag = ptr[3] & 0x01;
+	hevc->numTemporalLayers = MAX(hevc->numTemporalLayers, vps_max_sub_layers_minus1 + 1);
+	hevc->temporalIdNested = (hevc->temporalIdNested || vps_temporal_id_nesting_flag) ? 1 : 0;
+	hevc_profile_tier_level(ptr + 6, sodb - 6, vps_max_sub_layers_minus1, hevc);
+
+	return vps;
+}
+
+static uint8_t hevc_sps_id(const uint8_t* rbsp, int bytes, struct mpeg4_hevc_t* hevc, uint8_t* ptr, uint8_t* vps)
+{
+	int n;
+	int sodb;
+	uint8_t sps;
+	uint8_t sps_max_sub_layers_minus1;
+	uint8_t sps_temporal_id_nesting_flag;
+	uint8_t conformance_window_flag;
+
+	sodb = hevc_rbsp_decode(rbsp, bytes, ptr);
+	if (sodb < 12+3)
+		return 0xFF;
+
+	*vps = ptr[2] >> 4;  // 2-nalu type
+	sps_max_sub_layers_minus1 = (ptr[2] >> 1) & 0x07;
+	sps_temporal_id_nesting_flag = ptr[2] & 0x01;
+    (void)sps_temporal_id_nesting_flag;
+	n = hevc_profile_tier_level(ptr + 3, sodb - 3, sps_max_sub_layers_minus1, hevc);
+	if (n <= 0)
+		return 0xFF;
+
+	n = (n + 3) * 8;
+	sps = mpeg4_h264_read_ue(ptr, sodb, &n);
+	hevc->chromaFormat = mpeg4_h264_read_ue(ptr, sodb, &n);
+	if (3 == hevc->chromaFormat)
+		n++;
+	mpeg4_h264_read_ue(ptr, sodb, &n); // pic_width_in_luma_samples
+	mpeg4_h264_read_ue(ptr, sodb, &n); // pic_height_in_luma_samples
+	conformance_window_flag = BIT(ptr, n); n++; // conformance_window_flag
+	if (conformance_window_flag)
+	{
+		mpeg4_h264_read_ue(ptr, sodb, &n); // conf_win_left_offset
+		mpeg4_h264_read_ue(ptr, sodb, &n); // conf_win_right_offset
+		mpeg4_h264_read_ue(ptr, sodb, &n); // conf_win_top_offset
+		mpeg4_h264_read_ue(ptr, sodb, &n); // conf_win_bottom_offset
+	}
+	hevc->bitDepthLumaMinus8 = mpeg4_h264_read_ue(ptr, sodb, &n);
+	hevc->bitDepthChromaMinus8 = mpeg4_h264_read_ue(ptr, sodb, &n);
+
+	// TODO: vui_parameters
+	//mp4->hevc->min_spatial_segmentation_idc; // min_spatial_segmentation_idc
+	return sps;
+}
+
+static uint8_t hevc_pps_id(const uint8_t* rbsp, int bytes, struct mpeg4_hevc_t* hevc, uint8_t* ptr, uint8_t* sps)
+{
+	// TODO:
+	//hevc->parallelismType; // entropy_coding_sync_enabled_flag
+	(void)hevc;
+
+	int sodb;
+	int offset = 2 * 8;  // 2-nalu type
+	sodb = hevc_rbsp_decode(rbsp, bytes, ptr);
+	if (sodb < 3)
+		return 0xFF;
+	*sps = mpeg4_h264_read_ue(ptr, sodb, &offset);
+	return mpeg4_h264_read_ue(ptr, sodb, &offset);
+}
+
+static void mpeg4_hevc_remove(struct mpeg4_hevc_t* hevc, uint8_t* ptr, int bytes, const uint8_t* end)
+{
+	uint8_t i;
+	assert(ptr >= hevc->data && ptr + bytes <= end && end <= hevc->data + sizeof(hevc->data));
+	memmove(ptr, ptr + bytes, end - ptr - bytes);
+
+	for (i = 0; i < hevc->numOfArrays; i++)
+	{
+		if (hevc->nalu[i].data > ptr)
+			hevc->nalu[i].data -= bytes;
+	}
+}
+
+static int mpeg4_hevc_update2(struct mpeg4_hevc_t* hevc, int i, const uint8_t* nalu, int bytes)
+{
+	if (bytes == hevc->nalu[i].bytes && 0 == memcmp(nalu, hevc->nalu[i].data, bytes))
+		return 0; // do nothing
+
+	if (bytes > hevc->nalu[i].bytes && hevc->off + (bytes - hevc->nalu[i].bytes) > (int)sizeof(hevc->data))
+	{
+		assert(0);
+		return -1; // too big
+	}
+
+	mpeg4_hevc_remove(hevc, hevc->nalu[i].data, hevc->nalu[i].bytes, hevc->data + hevc->off);
+	hevc->off -= hevc->nalu[i].bytes;
+
+	hevc->nalu[i].data = hevc->data + hevc->off;
+	hevc->nalu[i].bytes = (uint16_t)bytes;
+	memcpy(hevc->nalu[i].data, nalu, bytes);
+	hevc->off += bytes;
+	return 1;
+}
+
+static int mpeg4_hevc_add(struct mpeg4_hevc_t* hevc, uint8_t type, const uint8_t* nalu, int bytes)
+{
+	// copy new
+	assert(hevc->numOfArrays < (int)sizeof(hevc->nalu) / (int)sizeof(hevc->nalu[0]));
+	if (hevc->numOfArrays >= (int)sizeof(hevc->nalu) / (int)sizeof(hevc->nalu[0])
+		|| hevc->off + bytes > (int)sizeof(hevc->data))
+	{
+		assert(0);
+		return -1;
+	}
+
+	hevc->nalu[hevc->numOfArrays].type = type;
+	hevc->nalu[hevc->numOfArrays].bytes = (uint16_t)bytes;
+	hevc->nalu[hevc->numOfArrays].array_completeness = 1;
+	hevc->nalu[hevc->numOfArrays].data = hevc->data + hevc->off;
+	memcpy(hevc->nalu[hevc->numOfArrays].data, nalu, bytes);
+	hevc->off += bytes;
+	++hevc->numOfArrays;
+	return 1;
+}
+
+static int h265_vps_copy(struct mpeg4_hevc_t* hevc, const uint8_t* nalu, int bytes)
+{
+	int i;
+	uint8_t vpsid;
+
+	if (bytes < 3)
+	{
+		assert(0);
+		return -1; // invalid length
+	}
+
+	vpsid = hevc_vps_id(nalu, bytes, hevc, hevc->data + hevc->off);
+	for (i = 0; i < hevc->numOfArrays; i++)
+	{
+		if (NAL_UNIT_VPS == hevc->nalu[i].type && vpsid == hevc_vps_id(hevc->nalu[i].data, hevc->nalu[i].bytes, hevc, hevc->data + hevc->off))
+			return mpeg4_hevc_update2(hevc, i, nalu, bytes);
+	}
+
+	return mpeg4_hevc_add(hevc, NAL_UNIT_VPS, nalu, bytes);
+}
+
+static int h265_sps_copy(struct mpeg4_hevc_t* hevc, const uint8_t* nalu, int bytes)
+{
+	int i;
+	uint8_t spsid;
+	uint8_t vpsid, vpsid2;
+
+	if (bytes < 13 + 2)
+	{
+		assert(0);
+		return -1; // invalid length
+	}
+
+	spsid = hevc_sps_id(nalu, bytes, hevc, hevc->data + hevc->off, &vpsid);
+	for (i = 0; i < hevc->numOfArrays; i++)
+	{
+		if (NAL_UNIT_SPS == hevc->nalu[i].type && spsid == hevc_sps_id(hevc->nalu[i].data, hevc->nalu[i].bytes, hevc, hevc->data + hevc->off, &vpsid2) && vpsid == vpsid2)
+			return mpeg4_hevc_update2(hevc, i, nalu, bytes);
+	}
+
+	return mpeg4_hevc_add(hevc, NAL_UNIT_SPS, nalu, bytes);
+}
+
+static int h265_pps_copy(struct mpeg4_hevc_t* hevc, const uint8_t* nalu, int bytes)
+{
+	int i;
+	uint8_t ppsid;
+	uint8_t spsid, spsid2;
+
+	if (bytes < 1 + 2)
+	{
+		assert(0);
+		return -1; // invalid length
+	}
+
+	ppsid = hevc_pps_id(nalu, bytes, hevc, hevc->data + hevc->off, &spsid);
+	for (i = 0; i < hevc->numOfArrays; i++)
+	{
+		if (NAL_UNIT_PPS == hevc->nalu[i].type && ppsid == hevc_pps_id(hevc->nalu[i].data, hevc->nalu[i].bytes, hevc, hevc->data + hevc->off, &spsid2) && spsid == spsid2)
+			return mpeg4_hevc_update2(hevc, i, nalu, bytes);
+	}
+
+	return mpeg4_hevc_add(hevc, NAL_UNIT_PPS, nalu, bytes);
+}
+
+SrsRawHEVCStream::SrsRawHEVCStream() {
+
+}
+
+SrsRawHEVCStream::~SrsRawHEVCStream() {
+
+}
+
+srs_error_t SrsRawHEVCStream::annexb_demux(SrsBuffer* stream, char** pframe, int* pnb_frame)
+{
+    srs_error_t err = srs_success;
+    
+    *pframe = NULL;
+    *pnb_frame = 0;
+    
+    while (!stream->empty()) {
+        // each frame must prefixed by annexb format.
+        // about annexb, @see ISO_IEC_14496-10-AVC-2003.pdf, page 211.
+        int pnb_start_code = 0;
+        if (!srs_avc_startswith_annexb(stream, &pnb_start_code)) {
+            return srs_error_new(ERROR_HEVC_API_NO_PREFIXED, "hevc annexb start code");
+        }
+        int start = stream->pos() + pnb_start_code;
+        
+        // find the last frame prefixed by annexb format.
+        stream->skip(pnb_start_code);
+        while (!stream->empty()) {
+            if (srs_avc_startswith_annexb(stream, NULL)) {
+                break;
+            }
+            stream->skip(1);
+        }
+        
+        // demux the frame.
+        *pnb_frame = stream->pos() - start;
+        *pframe = stream->data() + start;
+        break;
+    }
+    
+    return err;
+}
+
+// whether the frame is sps or pps or vps.
+bool SrsRawHEVCStream::is_sps(char* frame, int nb_frame)
+{
+    srs_assert(nb_frame > 0);
+    uint8_t nal_unit_type = HEVC_NALU_TYPE(frame[0]);
+    
+    return nal_unit_type == NAL_UNIT_SPS;
+}
+
+bool SrsRawHEVCStream::is_pps(char* frame, int nb_frame) {
+    srs_assert(nb_frame > 0);
+    uint8_t nal_unit_type = HEVC_NALU_TYPE(frame[0]);
+    
+    return nal_unit_type == NAL_UNIT_PPS;
+}
+
+bool SrsRawHEVCStream::is_vps(char* frame, int nb_frame) {
+    srs_assert(nb_frame > 0);
+    uint8_t nal_unit_type = HEVC_NALU_TYPE(frame[0]);
+    
+    return nal_unit_type == NAL_UNIT_VPS;
+}
+
+srs_error_t SrsRawHEVCStream::sps_demux(char* frame, int nb_frame, std::string& sps)
+{
+    srs_error_t err = srs_success;
+    
+    // atleast 1bytes for SPS to decode the type, profile, constrain and level.
+    if (nb_frame < 4) {
+        return err;
+    }
+
+    sps = string(frame, nb_frame);
+
+    return err;
+}
+
+srs_error_t SrsRawHEVCStream::pps_demux(char* frame, int nb_frame, std::string& pps)
+{
+    srs_error_t err = srs_success;
+
+    if (nb_frame <= 0) {
+        return srs_error_new(ERROR_STREAM_CASTER_HEVC_PPS, "no pps");
+    }
+
+    pps = string(frame, nb_frame);
+
+    return err;
+}
+
+srs_error_t SrsRawHEVCStream::vps_demux(char* frame, int nb_frame, std::string& vps)
+{
+    srs_error_t err = srs_success;
+
+    if (nb_frame <= 0) {
+        return srs_error_new(ERROR_STREAM_CASTER_HEVC_VPS, "no vps");
+    }
+
+    vps = string(frame, nb_frame);
+
+    return err;
+}
+
+srs_error_t SrsRawHEVCStream::mux_sequence_header(std::string sps, std::string pps, std::string vps,
+                                        uint32_t dts, uint32_t pts, std::string& hvcC)
+{
+    srs_error_t err = srs_success;
+    uint8_t temp8bits = 0;
+    struct mpeg4_hevc_t hevc_info;
+
+    memset(&hevc_info, 0, sizeof(hevc_info));
+
+    if (h265_vps_copy(&hevc_info, (uint8_t*)vps.data(), (int)vps.length()) < 0) {
+        return srs_error_new(ERROR_STREAM_CASTER_HEVC_VPS, "decode vps error");
+    }
+
+    if (h265_sps_copy(&hevc_info, (uint8_t*)sps.data(), (int)sps.length()) < 0) {
+        return srs_error_new(ERROR_STREAM_CASTER_HEVC_SPS, "decode sps error");
+    }
+
+    if (h265_pps_copy(&hevc_info, (uint8_t*)pps.data(), (int)pps.length()) < 0) {
+        return srs_error_new(ERROR_STREAM_CASTER_HEVC_PPS, "decode pps error");
+    }
+
+    // hevc header information:
+    // 23bytes header:
+    //      configurationVersion, general_profile_space, general_tier_flag, general_profile_idc
+    //      general_profile_compatibility_flags, general_constraint_indicator_flags,
+    //      general_level_idc, min_spatial_segmentation_idc, parallelismType,
+    //      chromaFormat, bitDepthLumaMinus8, bitDepthChromaMinus8,
+    //      avgFrameRate, constantFrameRate, numTemporalLayers, temporalIdNested,
+    //      lengthSizeMinusOne, numOfArrays
+    // 5bytes size of vps/sps/pps:
+    //      array_completeness, nal_unit_type, numNalus, nalUnitLength,
+    // Nbytes of vps/sps/pps.
+    //      sequenceParameterSetNALUnit
+
+
+    //use simple mode: nalu size + nalu data
+    int nb_packet = 23 + 5 + (int)sps.length() + 5 + (int)pps.length() + 5 + (int)vps.length();
+    char* packet = new char[nb_packet];
+    SrsAutoFreeA(char, packet);
+
+    // use stream to generate the hevc packet.
+    SrsBuffer stream(packet, nb_packet);
+
+    hevc_info.configurationVersion = 1;
+    stream.write_1bytes(hevc_info.configurationVersion);
+    
+    temp8bits = 0;
+    temp8bits |= ((hevc_info.general_profile_space << 6) & 0xc0);
+    temp8bits |= ((hevc_info.general_tier_flag << 5) & 0x20);
+    temp8bits |= hevc_info.general_profile_idc & 0x1f;
+    stream.write_1bytes(temp8bits);
+
+    stream.write_4bytes(hevc_info.general_profile_compatibility_flags);
+
+    stream.write_2bytes((hevc_info.general_constraint_indicator_flags >> 32) & 0xffff);
+    stream.write_4bytes(hevc_info.general_constraint_indicator_flags & 0xffffffff);
+
+    stream.write_1bytes(hevc_info.general_level_idc);
+
+    stream.write_2bytes(0xf000 | (hevc_info.min_spatial_segmentation_idc & 0x0fff));
+
+    stream.write_1bytes(0xfc|(hevc_info.parallelismType & 0x03));
+    stream.write_1bytes(0xfc|(hevc_info.chromaFormat & 0x03));
+
+    stream.write_1bytes(0xf8|(hevc_info.bitDepthLumaMinus8 & 0x07));
+
+    stream.write_1bytes(0xf8|(hevc_info.bitDepthChromaMinus8 & 0x07));
+
+    stream.write_2bytes(hevc_info.avgFrameRate);
+
+    hevc_info.lengthSizeMinusOne = 3;
+    temp8bits = 0;
+    temp8bits |= (hevc_info.constantFrameRate << 6) | 0xc0;
+    temp8bits |= (hevc_info.numTemporalLayers << 3) | 0x38;
+    temp8bits |= (hevc_info.temporalIdNested << 2) | 0x04;
+    temp8bits |= hevc_info.lengthSizeMinusOne & 0x03;
+
+    stream.write_1bytes(temp8bits);
+    
+    uint8_t numOfArrays = 3;//vps,sps,pps
+    stream.write_1bytes(numOfArrays);
+
+    uint8_t array_completeness = 0;//1bit
+    //uint8_t reserved = 0;//1bit
+    uint8_t nal_unit_type = 0;//6bits;
+
+    //vps
+    nal_unit_type = ((array_completeness << 7) & 0x80) | (NAL_UNIT_VPS & 0x3f);
+    stream.write_1bytes(nal_unit_type);
+
+    uint16_t namNalus = 1;
+    stream.write_2bytes(namNalus);
+
+    uint16_t nalUnitLength = vps.length();
+    stream.write_2bytes(nalUnitLength);
+
+    stream.write_string(vps);
+
+    //sps
+    nal_unit_type = ((array_completeness << 7) & 0x80) | (NAL_UNIT_SPS & 0x3f);
+    stream.write_1bytes(nal_unit_type);
+
+    namNalus = 1;
+    stream.write_2bytes(namNalus);
+
+    
+    nalUnitLength = sps.length();
+    stream.write_2bytes(nalUnitLength);
+
+    stream.write_string(sps);
+
+    //pps
+    nal_unit_type = ((array_completeness << 7) & 0x80) | (NAL_UNIT_PPS & 0x3f);
+    stream.write_1bytes(nal_unit_type);
+
+    namNalus = 1;
+    stream.write_2bytes(namNalus);
+
+    nalUnitLength = pps.length();
+    stream.write_2bytes(nalUnitLength);
+    stream.write_string(pps);
+
+    hvcC = string(packet, nb_packet);
+
+    return err;
+}
+
+srs_error_t SrsRawHEVCStream::mux_ipb_frame(char* frame, int nb_frame, std::string& ibp)
+{
+    srs_error_t err = srs_success;
+    
+    // 4bytes size of nalu:
+    //      NALUnitLength
+    // Nbytes of nalu.
+    //      NALUnit
+    int nb_packet = 4 + nb_frame;
+    char* packet = new char[nb_packet];
+    SrsAutoFreeA(char, packet);
+    
+    // use stream to generate the h264 packet.
+    SrsBuffer stream(packet, nb_packet);
+    
+    // 5.3.4.2.1 Syntax, ISO_IEC_14496-15-AVC-format-2012.pdf, page 16
+    // lengthSizeMinusOne, or NAL_unit_length, always use 4bytes size
+    uint32_t NAL_unit_length = nb_frame;
+    
+    // mux the avc NALU in "ISO Base Media File Format"
+    // from ISO_IEC_14496-15-AVC-format-2012.pdf, page 20
+    // NALUnitLength
+    stream.write_4bytes(NAL_unit_length);
+    // NALUnit
+    stream.write_bytes(frame, nb_frame);
+
+    ibp = string(packet, nb_packet);
+    
+    return err;
+}
+
+srs_error_t SrsRawHEVCStream::mux_avc2flv(std::string video, int8_t frame_type, int8_t avc_packet_type, uint32_t dts, uint32_t pts, char** flv, int* nb_flv)
+{
+    srs_error_t err = srs_success;
+    
+    // for h264 in RTMP video payload, there is 5bytes header:
+    //      1bytes, FrameType | CodecID
+    //      1bytes, AVCPacketType
+    //      3bytes, CompositionTime, the cts.
+    // @see: E.4.3 Video Tags, video_file_format_spec_v10_1.pdf, page 78
+    int size = (int)video.length() + 5;
+    char* data = new char[size];
+    char* p = data;
+    
+    // @see: E.4.3 Video Tags, video_file_format_spec_v10_1.pdf, page 78
+    // Frame Type, Type of video frame.
+    // CodecID, Codec Identifier.
+    // set the rtmp header
+    *p++ = (frame_type << 4) | SrsVideoCodecIdHEVC;
+    
+    // AVCPacketType
+    *p++ = avc_packet_type;
+    
+    // CompositionTime
+    // pts = dts + cts, or
+    // cts = pts - dts.
+    // where cts is the header in rtmp video packet payload header.
+    uint32_t cts = pts - dts;
+    char* pp = (char*)&cts;
+    *p++ = pp[2];
+    *p++ = pp[1];
+    *p++ = pp[0];
+    
+    // hevc raw data.
+    memcpy(p, video.data(), video.length());
+    
+    *flv = data;
+    *nb_flv = size;
+    
+    return err;
+}

--- a/trunk/src/protocol/srs_raw_hevc.hpp
+++ b/trunk/src/protocol/srs_raw_hevc.hpp
@@ -1,0 +1,75 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013-2020 Winlin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef SRS_PROTOCOL_RAW_HEVC_HPP
+#define SRS_PROTOCOL_RAW_HEVC_HPP
+
+#include <srs_core.hpp>
+#include <srs_kernel_codec.hpp>
+#include <string>
+
+class SrsBuffer;
+
+// The raw h.264 stream, in annexb.
+class SrsRawHEVCStream
+{
+public:
+    SrsRawHEVCStream();
+    virtual ~SrsRawHEVCStream();
+public:
+    // Demux the stream in annexb format.
+    // @param stream the input stream bytes.
+    // @param pframe the output hevc frame in stream. user should never free it.
+    // @param pnb_frame the output hevc frame size.
+    virtual srs_error_t annexb_demux(SrsBuffer* stream, char** pframe, int* pnb_frame);
+    // whether the frame is sps or pps or vps.
+    virtual bool is_sps(char* frame, int nb_frame);
+    virtual bool is_pps(char* frame, int nb_frame);
+    virtual bool is_vps(char* frame, int nb_frame);
+
+    // Demux the sps or pps or vps to string.
+    // @param sps/pps output the sps/pps/vps.
+    virtual srs_error_t sps_demux(char* frame, int nb_frame, std::string& sps);
+    virtual srs_error_t pps_demux(char* frame, int nb_frame, std::string& pps);
+    virtual srs_error_t vps_demux(char* frame, int nb_frame, std::string& vps);
+public:
+    // The hevc raw data to hevc packet, without flv payload header.
+    // Mux the sps/pps/vps to flv sequence header packet.
+    // @param sh output the sequence header.
+    virtual srs_error_t mux_sequence_header(std::string sps, std::string pps, std::string vps,
+                                            uint32_t dts, uint32_t pts, std::string& sh);
+    // The hevc raw data to hevc packet, without flv payload header.
+    // Mux the ibp to flv ibp packet.
+    // @param ibp output the packet.
+    // @param frame_type output the frame type.
+    virtual srs_error_t mux_ipb_frame(char* frame, int nb_frame, std::string& ibp);
+    // Mux the hevc video packet to flv video packet.
+    // @param frame_type, SrsVideoAvcFrameTypeKeyFrame or SrsVideoAvcFrameTypeInterFrame.
+    // @param avc_packet_type, SrsVideoAvcFrameTraitSequenceHeader or SrsVideoAvcFrameTraitNALU.
+    // @param video the hevc raw data.
+    // @param flv output the muxed flv packet.
+    // @param nb_flv output the muxed flv size.
+    virtual srs_error_t mux_avc2flv(std::string video, int8_t frame_type, int8_t avc_packet_type, uint32_t dts, uint32_t pts, char** flv, int* nb_flv);
+};
+
+#endif//end SRS_PROTOCOL_RAW_HEVC_HPP

--- a/trunk/src/srt/srt_to_rtmp.hpp
+++ b/trunk/src/srt/srt_to_rtmp.hpp
@@ -36,6 +36,8 @@
 #include <srs_kernel_ts.hpp>
 #include <srs_app_rtmp_conn.hpp>
 #include <srs_raw_avc.hpp>
+#include <srs_raw_hevc.hpp>
+
 #include <srs_protocol_utility.hpp>
 #include <unordered_map>
 
@@ -47,6 +49,7 @@
 
 typedef std::shared_ptr<SrsSimpleRtmpClient> RTMP_CONN_PTR;
 typedef std::shared_ptr<SrsRawH264Stream> AVC_PTR;
+typedef std::shared_ptr<SrsRawHEVCStream> HEVC_PTR;
 typedef std::shared_ptr<SrsRawAacStream> AAC_PTR;
 
 #define DEFAULT_VHOST "__default_host__"
@@ -98,10 +101,14 @@ private:
     virtual void on_data_callback(SRT_DATA_MSG_PTR data_ptr, unsigned int media_type, uint64_t dts, uint64_t pts);
 
 private:
-    srs_error_t on_ts_video(std::shared_ptr<SrsBuffer> avs_ptr, uint64_t dts, uint64_t pts);
-    srs_error_t on_ts_audio(std::shared_ptr<SrsBuffer> avs_ptr, uint64_t dts, uint64_t pts);
+    srs_error_t on_ts_h264(std::shared_ptr<SrsBuffer> avs_ptr, uint64_t dts, uint64_t pts);
+    srs_error_t on_ts_hevc(std::shared_ptr<SrsBuffer> avs_ptr, uint64_t dts, uint64_t pts);
+    srs_error_t on_ts_aac(std::shared_ptr<SrsBuffer> avs_ptr, uint64_t dts, uint64_t pts);
+
     virtual srs_error_t write_h264_sps_pps(uint32_t dts, uint32_t pts);
     virtual srs_error_t write_h264_ipb_frame(char* frame, int frame_size, uint32_t dts, uint32_t pts);
+    virtual srs_error_t write_hevc_sps_pps(uint32_t dts, uint32_t pts);
+    virtual srs_error_t write_hevc_ipb_frame(char* frame, int frame_size, uint32_t dts, uint32_t pts);
     virtual srs_error_t write_audio_raw_frame(char* frame, int frame_size, SrsRawAacStreamCodec* codec, uint32_t dts);
 
     int get_sample_rate(char sound_rate);
@@ -126,6 +133,17 @@ private:
     std::string _h264_pps;
     bool _h264_pps_changed;
     bool _h264_sps_pps_sent;
+
+private:
+    HEVC_PTR _hevc_ptr;
+    std::string _hevc_vps;
+    bool _hevc_vps_changed;
+    std::string _hevc_sps;
+    bool _hevc_sps_changed;
+    std::string _hevc_pps;
+    bool _hevc_pps_changed;
+    bool _hevc_sps_pps_sent;
+
 private:
     std::string _aac_specific_config;
     AAC_PTR _aac_ptr;

--- a/trunk/src/srt/ts_demux.cpp
+++ b/trunk/src/srt/ts_demux.cpp
@@ -412,7 +412,7 @@ int ts_demux::pes_parse(unsigned char* p, size_t npos,
         && stream_id != 248//ITU-T Rec. H.222.1 type E stream 1111 1000
         ) 
     {
-        assert(0x80 == p[pos]);
+        assert(0x80 == (p[pos] & 0xc0));
         //skip 2bits//'10' 2 bslbf
         int PES_scrambling_control = (p[pos]&30)>>4; //PES_scrambling_control 2 bslbf
         (void)PES_scrambling_control;


### PR DESCRIPTION
使用https://github.com/q191201771/lal推流工具，推h265.flv文件（https://ks3-cn-beijing.ksyun.com/ksplayer/h265/outside_demo/v1.1.3/720P2M30fpsh265-wasmtest.flv）会断开连接。解决了这个bug。

解决了视频信息不显示HEVC的问题。

解决了flv播放，带宽统计不对的问题