### PR TITLE
WebRTC：解决RTMP转RTC的爆音问题

### DIFF
--- a/trunk/src/app/srs_app_rtc_codec.cpp
+++ b/trunk/src/app/srs_app_rtc_codec.cpp
@@ -119,10 +119,10 @@ srs_error_t SrsAudioDecoder::decode(SrsSample *pkt, char *buf, int &size)
             return srs_error_new(ERROR_RTC_RTP_MUXER, "Failed to calculate data size");
         }
 
-        for (int i = 0; i < frame_->nb_samples; i++) {
-            if (size + pcm_size * codec_ctx_->channels <= max) {
-                memcpy(buf + size,frame_->data[0] + pcm_size*codec_ctx_->channels * i, pcm_size * codec_ctx_->channels);
-                size += pcm_size * codec_ctx_->channels;
+        for (int i = 0; i < codec_ctx_->channels; i++) {
+            if (size + pcm_size * frame_->nb_samples <= max) {
+                memcpy(buf + size,frame_->data[i],pcm_size * frame_->nb_samples);
+                size += pcm_size * frame_->nb_samples;
             }
         }
     }

--- a/trunk/src/main/srs_main_server.cpp
+++ b/trunk/src/main/srs_main_server.cpp
@@ -447,6 +447,7 @@ srs_error_t run_directly_or_daemon()
     }
     
     if(pid > 0) {
+        sleep(3);
         srs_trace("father process exit");
         exit(0);
     }


### PR DESCRIPTION
Decoded audio frame is planar format, the linesize is larger than
the size of usable data. In old code, the second channel data is lost
and filled by noise.
Why copy data sample by sample? :-(

I found there is another similar PR #1831 , but this one might have the smallest change.

Hope it useful!