### PR TITLE
GB28181：支持作为GB/T 28181上级平台; 各种异常和问题修复

### DIFF
--- a/trunk/research/players/srs_gb28181.html
+++ b/trunk/research/players/srs_gb28181.html
@@ -465,7 +465,12 @@
     var url = null;
 
     var query = parse_query_string();
-    $("#txt_api_url").val("http://" + query.host + ":1985")
+    var query_host = query.host.split(':');
+    if (query_host && query_host.length == 2) {
+        $("#txt_api_url").val("http://" + query_host[0] + ":1985");
+    } else {
+        $("#txt_api_url").val("http://" + query.host + ":1985");
+    }
 
     var __active_dar = null;
     function select_dar(dar_id, num, den) {
@@ -588,7 +593,7 @@
             for (idx2 in devices)
             {
                 //href="javascript:void(0)" onclick="fn(this)">
-                var id = "-->" + devices[idx2].device_id + ":" + devices[idx2].device_status + ":" + devices[idx2].invite_status;
+                var id = "-->" + devices[idx2].device_name + ":" + devices[idx2].device_id + ":" + devices[idx2].device_status + ":" + devices[idx2].invite_status;
                 var li = "<li><a id='linkChannelId1' href='javascript:void(0)' onclick='sipSessionOnClick(this)' rel='"+ session.id + "'>" +id + "</a></li>";
                 $("#sipSessionList").append(li); 
             }
@@ -1007,7 +1012,7 @@
                     var str = text.split("-->");
                     id = str[0];
                     var str2 = str[1].split(":")
-                    chid = str2[0];
+                    chid = str2[1];
 
                     url = $("#txt_api_url").val();
                     var apiurl = url + "/api/v1/gb28181?action=sip_invite&id=" + id + "&chid="+chid;
@@ -1026,7 +1031,7 @@
                     var str = text.split("-->");
                     id = str[0];
                     var str2 = str[1].split(":")
-                    chid = str2[0];
+                    chid = str2[1];
 
                     url = $("#txt_api_url").val();
                     var apiurl = url + "/api/v1/gb28181?action=sip_bye&id=" + id + "&chid="+chid;
@@ -1048,7 +1053,7 @@
                     chid = str2[0];
 
                     url = $("#txt_api_url").val();
-                    var apiurl = url + "/api/v1/gb28181?action=sip_query_catalog&id=" + id + "&chid="+chid;
+                    var apiurl = url + "/api/v1/gb28181?action=sip_query_catalog&id=" + id;
                     var ret = http_get(apiurl);
                     $('#sipSessionMessage').html(syntaxHighlight(ret)); 
                     if (ret != undefined && ret.code == 0){
@@ -1069,9 +1074,17 @@
             });
 
             $("#btn_delete_channel").click(function(){
-                var id = $("#gb28181ChannelId").text();
+                var str = $("#gb28181ChannelId").text();
+                var str_array = str.split("@")
+                var chid = "";
+                var id = "";
+                if (str_array.length != 2){
+                    return;
+                }
+                id = str_array[0];
+                chid = str_array[1];
                 url = $("#txt_api_url").val();
-                var apiurl = url + "/api/v1/gb28181?action=delete_channel&id=" + id;
+                var apiurl = url + "/api/v1/gb28181?action=delete_channel&id=" + id + "&chid="+chid;
                 var ret = http_get(apiurl);
                 $('#gb28181ChannelMessage').html(syntaxHighlight(ret)); 
                 if (ret != undefined && ret.code == 0){
@@ -1190,7 +1203,8 @@
                         return pc.setLocalDescription(offer).then(function(){ return offer; });
                     }).then(function(offer) {
                         return new Promise(function(resolve, reject) {
-                            var port = urlObject.port || 1985;
+                            // var port = urlObject.port || 1985;
+                            var port = 1985;
 
                             // @see https://github.com/rtcdn/rtcdn-draft
                             var api = urlObject.user_query.play || '/rtc/v1/play/';

--- a/trunk/src/app/srs_app_gb28181.cpp
+++ b/trunk/src/app/srs_app_gb28181.cpp
@@ -215,7 +215,9 @@ srs_error_t SrsGb28181PsRtpProcessor::on_rtp_packet(const sockaddr* from, const 
                 (char*)&address_string, sizeof(address_string),
                 (char*)&port_string, sizeof(port_string),
                 NI_NUMERICHOST|NI_NUMERICSERV)){
-        return srs_error_new(ERROR_SYSTEM_IP_INVALID, "bad address");
+        // return srs_error_new(ERROR_SYSTEM_IP_INVALID, "bad address");
+        srs_warn("gb28181 ps rtp: bad address");
+        return srs_success;
     }
     
     int peer_port = atoi(port_string);
@@ -225,7 +227,10 @@ srs_error_t SrsGb28181PsRtpProcessor::on_rtp_packet(const sockaddr* from, const 
         SrsPsRtpPacket pkt;
         
         if ((err = pkt.decode(&stream)) != srs_success) {
-            return srs_error_wrap(err, "ps rtp decode error");
+            // return srs_error_wrap(err, "ps rtp decode error");
+            srs_warn("gb28181 ps rtp: decode error");
+            srs_freep(err);
+            return srs_success;
         }
 
         //TODO: fixme: the same device uses the same SSRC to send with different local ports
@@ -432,7 +437,9 @@ srs_error_t SrsGb28181PsRtpProcessor::on_rtp_packet_jitter(const sockaddr* from,
                 (char*)&address_string, sizeof(address_string),
                 (char*)&port_string, sizeof(port_string),
                 NI_NUMERICHOST|NI_NUMERICSERV)){
-        return srs_error_new(ERROR_SYSTEM_IP_INVALID, "bad address");
+        // return srs_error_new(ERROR_SYSTEM_IP_INVALID, "bad address");
+        srs_warn("gb28181 ps rtp: bad address");
+        return srs_success;
     }
     
     int peer_port = atoi(port_string);
@@ -443,7 +450,10 @@ srs_error_t SrsGb28181PsRtpProcessor::on_rtp_packet_jitter(const sockaddr* from,
         
         if ((err = pkt->decode(&stream)) != srs_success) {
             srs_freep(pkt);
-            return srs_error_wrap(err, "ps rtp decode error");
+            // return srs_error_wrap(err, "ps rtp decode error");
+            srs_warn("gb28181 ps rtp: decode error");
+            srs_freep(err);
+            return srs_success;
         }
         
         std::stringstream ss3;
@@ -1255,6 +1265,9 @@ void SrsGb28181RtmpMuxer::insert_jitterbuffer(SrsPsRtpPacket *pkt)
     recv_rtp_stream_time = srs_get_system_time();
 
     char *payload = pkt->payload->bytes();
+    if (!payload) {
+        return;
+    }
 
     uint8_t p1 = (uint8_t)(payload[0]);
     uint8_t p2 = (uint8_t)(payload[1]);
@@ -1432,13 +1445,12 @@ srs_error_t SrsGb28181RtmpMuxer::write_h264_ipb_frame2(char *frame, int frame_si
     std::list<int> list_index;
 
     for(; index < size; index++){
+        if (index > (size-4))
+            break;
         if (video_data[index] == 0x00 && video_data[index+1] == 0x00 &&
              video_data[index+2] == 0x00 && video_data[index+3] == 0x01){
                  list_index.push_back(index);
              }
-
-        if (index > (size-4))
-            break;
     }
 
     if (list_index.size() == 1){
@@ -1820,6 +1832,8 @@ void SrsGb28181RtmpMuxer::close()
     h264_pps = "";
     aac_specific_config = "";
 
+    // BUGFIX: if don't unpublish, it will always be in the /api/v1/streams list
+    //if (source_publish && !source){
     if (source_publish && source){
         source->on_unpublish();
     }
@@ -2012,6 +2026,28 @@ SrsGb28181RtmpMuxer* SrsGb28181Manger::fetch_rtmpmuxer(std::string id)
     
     muxer = rtmpmuxers[id];
     return muxer;
+}
+
+void SrsGb28181Manger::update_rtmpmuxer_to_newssrc_by_id(std::string id, uint32_t ssrc)
+{
+    SrsGb28181RtmpMuxer* muxer = NULL;
+
+    if (rtmpmuxers.find(id) == rtmpmuxers.end()) {
+        return;
+    }
+
+    muxer = rtmpmuxers[id];
+    SrsGb28181StreamChannel mc = muxer->get_channel();
+    uint32_t old_ssrc = mc.get_ssrc();
+    if (old_ssrc == ssrc) {
+        return;
+    } else {
+        srs_trace("gb28181: update ssrc of muxer %s from %x to %x", id.c_str(), old_ssrc, ssrc);
+    }
+    rtmpmuxer_unmap_by_ssrc(old_ssrc);
+    mc.set_ssrc(ssrc);
+    muxer->copy_channel(&mc);
+    rtmpmuxer_map_by_ssrc(muxer, ssrc);
 }
 
 SrsGb28181RtmpMuxer* SrsGb28181Manger::fetch_rtmpmuxer_by_ssrc(uint32_t ssrc)
@@ -2264,17 +2300,19 @@ srs_error_t SrsGb28181Manger::create_stream_channel(SrsGb28181StreamChannel *cha
     return err;
 }
 
-srs_error_t SrsGb28181Manger::delete_stream_channel(std::string id)
+srs_error_t SrsGb28181Manger::delete_stream_channel(std::string id, std::string chid)
 {
     srs_error_t err = srs_success;
 
     //notify the device to stop streaming 
     //if an internal sip service controlled channel
-    notify_sip_bye(id, id);
+    notify_sip_bye(id, chid);
 
-    SrsGb28181RtmpMuxer *muxer = fetch_rtmpmuxer(id);
+    string channel_id = id + "@" + chid;
+
+    SrsGb28181RtmpMuxer *muxer = fetch_rtmpmuxer(channel_id);
     if (muxer){
-        stop_rtp_listen(id);
+        stop_rtp_listen(channel_id);
         muxer->stop();
        return err;
     }else {
@@ -2389,7 +2427,11 @@ srs_error_t SrsGb28181Manger::notify_sip_unregister(std::string id)
         return srs_error_new(ERROR_GB28181_SIP_NOT_RUN, "sip not run");
     }
     sip_service->remove_session(id);
-    return delete_stream_channel(id);
+    return srs_success;
+    // useless, because
+    //   sip session has been removed
+    //   id is not channel id like id@chid
+    //return delete_stream_channel(id);
 }
 
 srs_error_t SrsGb28181Manger::notify_sip_query_catalog(std::string id)
@@ -2400,6 +2442,12 @@ srs_error_t SrsGb28181Manger::notify_sip_query_catalog(std::string id)
 
     SrsSipRequest req;
     req.sip_auth_id = id;
+    SrsGb28181SipSession *sip_session = sip_service->fetch(req.sip_auth_id);
+    if (sip_session) {
+        sip_session->item_list.clear();
+        sip_session->clear_device_list();
+        srs_trace("notify_sip_query_catalog, clear sip session item and device list");
+    }
     return sip_service->send_query_catalog(&req);
 }
 
@@ -2410,4 +2458,13 @@ srs_error_t SrsGb28181Manger::query_sip_session(std::string id, SrsJsonArray* ar
     }
     
     return sip_service->query_sip_session(id, arr);
+}
+
+srs_error_t SrsGb28181Manger::query_device_list(std::string id, SrsJsonArray* arr)
+{
+    if (!sip_service){
+        return srs_error_new(ERROR_GB28181_SIP_NOT_RUN, "sip not run");
+    }
+
+    return sip_service->query_device_list(id, arr);
 }

--- a/trunk/src/app/srs_app_gb28181.hpp
+++ b/trunk/src/app/srs_app_gb28181.hpp
@@ -487,6 +487,7 @@ public:
     srs_error_t fetch_or_create_rtmpmuxer(std::string id, SrsRequest *req, SrsGb28181RtmpMuxer** gb28181);
     SrsGb28181RtmpMuxer* fetch_rtmpmuxer(std::string id);
     SrsGb28181RtmpMuxer* fetch_rtmpmuxer_by_ssrc(uint32_t ssrc);
+    void update_rtmpmuxer_to_newssrc_by_id(std::string id, uint32_t ssrc);
     void rtmpmuxer_map_by_ssrc(SrsGb28181RtmpMuxer*muxer, uint32_t ssrc);
     void rtmpmuxer_unmap_by_ssrc(uint32_t ssrc);
     uint32_t generate_ssrc(std::string id);
@@ -494,11 +495,12 @@ public:
 
     void set_sip_service(SrsGb28181SipService *s) { sip_service = s; }
     SrsGb28181SipService* get_sip_service() { return sip_service; }
+    SrsGb28181Config* get_gb28181_config_ptr() { return config;}
 
 public:
     //stream channel api
     srs_error_t create_stream_channel(SrsGb28181StreamChannel *channel);
-    srs_error_t delete_stream_channel(std::string id);
+    srs_error_t delete_stream_channel(std::string id, std::string chid);
     srs_error_t query_stream_channel(std::string id, SrsJsonArray* arr);
     //sip api
     srs_error_t notify_sip_invite(std::string id, std::string ip, int port, uint32_t ssrc, std::string chid);
@@ -508,6 +510,7 @@ public:
     srs_error_t notify_sip_query_catalog(std::string id);
     srs_error_t notify_sip_ptz(std::string id, std::string chid, std::string cmd, uint8_t speed, int priority);
     srs_error_t query_sip_session(std::string id, SrsJsonArray* arr);
+    srs_error_t query_device_list(std::string id, SrsJsonArray* arr);
 
 private:
     void destroy();

--- a/trunk/src/app/srs_app_gb28181_sip.hpp
+++ b/trunk/src/app/srs_app_gb28181_sip.hpp
@@ -59,6 +59,7 @@ public:
     virtual ~SrsGb28181Device();
 public:
     std::string device_id;
+    std::string device_name;
     std::string device_status;
     SrsGb28181SipSessionStatusType  invite_status; 
     srs_utime_t  invite_time;
@@ -132,10 +133,14 @@ public:
     int sip_cseq(){ return _sip_cseq++;}
 
     std::string session_id() { return _session_id;}
+    std::map<std::string, std::map<std::string, std::string> > item_list;
+    int item_list_sumnum;
 public:
     void update_device_list(std::map<std::string, std::string> devlist);
+    void clear_device_list();
     SrsGb28181Device *get_device_info(std::string chid);
     void dumps(SrsJsonObject* obj);
+    void dumpItemList(SrsJsonObject* obj);
 
 public:
     virtual srs_error_t serve();
@@ -201,6 +206,7 @@ public:
     //
     srs_error_t send_sip_raw_data(SrsSipRequest *req, std::string data);
     srs_error_t query_sip_session(std::string sid,  SrsJsonArray* arr);
+    srs_error_t query_device_list(std::string sid,  SrsJsonArray* arr);
 
 public:
     srs_error_t fetch_or_create_sip_session(SrsSipRequest *req,  SrsGb28181SipSession** sess);

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1476,11 +1476,12 @@ srs_error_t SrsGoApiGb28181::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
         return srs_api_response(w, r, obj->dumps());
 
     } else if(action == "delete_channel"){
-       if (id.empty()){
-            return srs_error_new(ERROR_GB28181_VALUE_EMPTY, "no id");
+        string chid = r->query_get("chid");
+        if (id.empty() || chid.empty()){
+            return srs_error_new(ERROR_GB28181_VALUE_EMPTY, "no id or chid");
         }
 
-        if ((err = _srs_gb28181->delete_stream_channel(id)) != srs_success) {
+        if ((err = _srs_gb28181->delete_stream_channel(id, chid)) != srs_success) {
             return srs_error_wrap(err, "delete stream channel");
         }
 
@@ -1573,6 +1574,16 @@ srs_error_t SrsGoApiGb28181::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
         }
 
         return srs_api_response_code(w, r, 0);
+    } else if(action == "sip_query_devicelist"){
+        SrsJsonArray* arr = SrsJsonAny::array();
+        data->set("PlatformID", SrsJsonAny::str(_srs_gb28181->get_gb28181_config_ptr()->sip_serial.c_str()));
+        data->set("DeviceList", arr);
+
+        if ((err = _srs_gb28181->query_device_list("", arr)) != srs_success) {
+            return srs_error_wrap(err, "query device list");
+        }
+
+        return srs_api_response(w, r, obj->dumps());
     } else if(action == "sip_query_session"){
         SrsJsonArray* arr = SrsJsonAny::array();
         data->set("sessions", arr);

--- a/trunk/src/protocol/srs_sip_stack.hpp
+++ b/trunk/src/protocol/srs_sip_stack.hpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <sstream>
+#include <vector>
 #include <map>
 
 #include <srs_kernel_consts.hpp>
@@ -105,6 +106,9 @@ public:
 
     std::map<std::string, std::string> xml_body_map;
     std::map<std::string, std::string> device_list_map;
+    // add an item_list, you can do a lot of other things
+    // used by DeviceList, Alarmstatus, RecordList in "GB/T 28181—2016"
+    std::vector<std::map<std::string, std::string> > item_list;
 
 public:
     std::string serial;
@@ -120,6 +124,7 @@ public:
 
     std::string from_realm;
     std::string to_realm;
+    uint32_t y_ssrc;
 
 public:
     SrsRtspSdp* sdp;
@@ -152,7 +157,7 @@ public:
     virtual srs_error_t parse_request(SrsSipRequest** preq, const char *recv_msg, int nb_buf);
 protected:
     virtual srs_error_t do_parse_request(SrsSipRequest* req, const char *recv_msg);
-    virtual srs_error_t parse_xml(std::string xml_msg, std::map<std::string, std::string> &json_map);
+    virtual srs_error_t parse_xml(std::string xml_msg, std::map<std::string, std::string> &json_map, std::vector<std::map<std::string, std::string> > &item_list);
 
 private:
     //response from


### PR DESCRIPTION
gb28181模块可用性增强

主要改动，
1. 支持作为GB/T 28181上级平台
2. 新的目录接口sip_query_devicelist (/api/v1/gb28181?action=sip_query_devicelist)
3. 各种异常和问题修复
4. 其他一些小改动

以上改动基于feature/rtc分支（现为4.0release分支），因为需要网页用WebRTC来拉GB28181的监控流，而feature/gb28181分支代码有点老了。

更详细的改动说明，请见提交日志。
