### PR TITLE
incomplete_len 在大华摄像头下，可能为负值,增加兼容性判断

### DIFF
--- a/trunk/src/app/srs_app_gb28181.cpp
+++ b/trunk/src/app/srs_app_gb28181.cpp
@@ -614,7 +614,8 @@ srs_error_t SrsPsStreamDemixer::on_ps_stream(char* ps_data, int ps_size, uint32_
         ps_fw.write(ps_data, ps_size, NULL);          
 #endif
 
-	while(incomplete_len >= sizeof(SrsPsPacketStartCode))
+	while(incomplete_len > 0 
+        && incomplete_len >= sizeof(SrsPsPacketStartCode))
     {
     	if (next_ps_pack
 			&& next_ps_pack[0] == (char)0x00


### PR DESCRIPTION
incomplete_len 在大华摄像头下，大华可能会在包头填上音频的固定长度320， 而实际数据域却没有数据，导致incomplete_len被减为负值。
当incomplete_len 为负数情况下， 由于sizeof(SrsPsPacketStart）返回的是unsigned类型， 因此C++会将负数转为unsigned与sizeof(SrsPsPacketStart）做比较，导致代码进入异常分支。