### PR TITLE
Fix build failed in Raspberry Pi 4 64bit

### DIFF
--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -555,6 +555,8 @@ else
     (
         rm -rf ${SRS_OBJS}/srtp2 && cd ${SRS_OBJS}/${SRS_PLATFORM} &&
         rm -rf libsrtp-2.0.0 && unzip -q ../../3rdparty/libsrtp-2.0.0.zip && cd libsrtp-2.0.0 &&
+        wget -O config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' &&
+        wget -O config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' &&
         ${SRTP_CONFIG} && ./configure ${SRTP_OPTIONS} --prefix=`pwd`/_release &&
         make ${SRS_JOBS} && make install &&
         cd .. && rm -rf srtp2 && ln -sf libsrtp-2.0.0/_release srtp2

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -84,6 +84,13 @@ function Ubuntu_prepare()
         echo "The unzip is installed."
     fi
 
+    wget --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
+        echo "Installing wget."
+        require_sudoer "sudo apt-get install -y --force-yes wget"
+        sudo apt-get install -y --force-yes wget; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
+        echo "The wget is installed."
+    fi
+
     if [[ $SRS_VALGRIND == YES ]]; then
         valgrind --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
             echo "Installing valgrind."

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -84,13 +84,6 @@ function Ubuntu_prepare()
         echo "The unzip is installed."
     fi
 
-    wget --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
-        echo "Installing wget."
-        require_sudoer "sudo apt-get install -y --force-yes wget"
-        sudo apt-get install -y --force-yes wget; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
-        echo "The wget is installed."
-    fi
-
     if [[ $SRS_VALGRIND == YES ]]; then
         valgrind --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
             echo "Installing valgrind."
@@ -562,8 +555,8 @@ else
     (
         rm -rf ${SRS_OBJS}/srtp2 && cd ${SRS_OBJS}/${SRS_PLATFORM} &&
         rm -rf libsrtp-2.0.0 && unzip -q ../../3rdparty/libsrtp-2.0.0.zip && cd libsrtp-2.0.0 &&
-        wget -O config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' &&
-        wget -O config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' &&
+        $SYS_PYTHON -c "import urllib; urllib.urlretrieve('http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD','config.guess')" &&
+        $SYS_PYTHON -c "import urllib; urllib.urlretrieve('http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD','config.sub')" &&
         ${SRTP_CONFIG} && ./configure ${SRTP_OPTIONS} --prefix=`pwd`/_release &&
         make ${SRS_JOBS} && make install &&
         cd .. && rm -rf srtp2 && ln -sf libsrtp-2.0.0/_release srtp2

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -630,6 +630,7 @@ if [[ $SRS_FFMPEG_FIT == YES ]]; then
             PKG_CONFIG_PATH=$ABS_OBJS/opus/lib/pkgconfig ./configure \
               --prefix=`pwd`/${SRS_PLATFORM}/_release \
               --pkg-config-flags="--static" --extra-libs=-lpthread --extra-libs=-lm ${FFMPEG_OPTIONS} \
+              --disable-neon \
               --disable-programs --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages \
               --disable-avdevice --disable-avformat --disable-swscale --disable-postproc --disable-avfilter --disable-network \
               --disable-dct --disable-dwt --disable-error-resilience --disable-lsp --disable-lzo --disable-faan --disable-pixelutils \

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -473,7 +473,7 @@ fi
 # Affected users should upgrade to OpenSSL 1.1.0e. Users unable to immediately
 # upgrade can alternatively recompile OpenSSL with -DOPENSSL_NO_HEARTBEATS.
 if [[ $SRS_SSL == YES && $SRS_USE_SYS_SSL != YES ]]; then
-    OPENSSL_OPTIONS="-no-shared -no-threads -DOPENSSL_NO_HEARTBEATS"
+    OPENSSL_OPTIONS="-no-afalgeng -no-shared -no-threads -DOPENSSL_NO_HEARTBEATS"
     OPENSSL_CONFIG="./config"
     # https://stackoverflow.com/questions/15539062/cross-compiling-of-openssl-for-linux-arm-v5te-linux-gnueabi-toolchain
     if [[ $SRS_CROSS_BUILD == YES ]]; then


### PR DESCRIPTION
Fix build some libraries in Raspberry Pi 4 64bit.

srs don't support for ARMv7 now because ARMv7 modules is missing in FFmpeg.
So I changed my Raspberry Pi 4 to 64bit, and fix some compiling error.

OS: Debian buster with ds64-shell