### PR TITLE
GB28181 API delete_channel 兼容性修改

### DIFF
--- a/trunk/research/players/srs_gb28181.html
+++ b/trunk/research/players/srs_gb28181.html
@@ -1074,17 +1074,9 @@
             });
 
             $("#btn_delete_channel").click(function(){
-                var str = $("#gb28181ChannelId").text();
-                var str_array = str.split("@")
-                var chid = "";
-                var id = "";
-                if (str_array.length != 2){
-                    return;
-                }
-                id = str_array[0];
-                chid = str_array[1];
+                var id = $("#gb28181ChannelId").text();
                 url = $("#txt_api_url").val();
-                var apiurl = url + "/api/v1/gb28181?action=delete_channel&id=" + id + "&chid="+chid;
+                var apiurl = url + "/api/v1/gb28181?action=delete_channel&id=" + id;
                 var ret = http_get(apiurl);
                 $('#gb28181ChannelMessage').html(syntaxHighlight(ret)); 
                 if (ret != undefined && ret.code == 0){

--- a/trunk/src/app/srs_app_gb28181.cpp
+++ b/trunk/src/app/srs_app_gb28181.cpp
@@ -2621,19 +2621,20 @@ srs_error_t SrsGb28181Manger::create_stream_channel(SrsGb28181StreamChannel *cha
     return err;
 }
 
-srs_error_t SrsGb28181Manger::delete_stream_channel(std::string id, std::string chid)
+srs_error_t SrsGb28181Manger::delete_stream_channel(std::string id)
 {
     srs_error_t err = srs_success;
 
     //notify the device to stop streaming 
     //if an internal sip service controlled channel
-    notify_sip_bye(id, chid);
+    if (id.find("@") != string::npos) {
+        vector<string> ids = srs_string_split(id, "@");
+        notify_sip_bye(ids[0], ids[1]);
+    }
 
-    string channel_id = id + "@" + chid;
-
-    SrsGb28181RtmpMuxer *muxer = fetch_rtmpmuxer(channel_id);
+    SrsGb28181RtmpMuxer *muxer = fetch_rtmpmuxer(id);
     if (muxer){
-        stop_rtp_listen(channel_id);
+        stop_rtp_listen(id);
         muxer->stop();
        return err;
     }else {

--- a/trunk/src/app/srs_app_gb28181.hpp
+++ b/trunk/src/app/srs_app_gb28181.hpp
@@ -532,7 +532,7 @@ public:
 public:
     //stream channel api
     srs_error_t create_stream_channel(SrsGb28181StreamChannel *channel);
-    srs_error_t delete_stream_channel(std::string id, std::string chid);
+    srs_error_t delete_stream_channel(std::string id);
     srs_error_t query_stream_channel(std::string id, SrsJsonArray* arr);
     //sip api
     srs_error_t notify_sip_invite(std::string id, std::string ip, int port, uint32_t ssrc, std::string chid);

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1476,12 +1476,11 @@ srs_error_t SrsGoApiGb28181::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
         return srs_api_response(w, r, obj->dumps());
 
     } else if(action == "delete_channel"){
-        string chid = r->query_get("chid");
-        if (id.empty() || chid.empty()){
-            return srs_error_new(ERROR_GB28181_VALUE_EMPTY, "no id or chid");
+        if (id.empty()){
+            return srs_error_new(ERROR_GB28181_VALUE_EMPTY, "no id");
         }
 
-        if ((err = _srs_gb28181->delete_stream_channel(id, chid)) != srs_success) {
+        if ((err = _srs_gb28181->delete_stream_channel(id)) != srs_success) {
             return srs_error_wrap(err, "delete stream channel");
         }
 


### PR DESCRIPTION
1. PR 2014打破了API delete_channel的兼容性，现回退delete_channel这个API到原版本。
2. delete_stream_channel函数，在处理bye摄像头的时候，无效，此处保留PR 2014中的修改。