### PR TITLE
修复rtmp不能监听ipv6的问题，增加了ipv6端口验证代码

### DIFF
--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -3557,8 +3557,23 @@ srs_error_t SrsConfig::check_normal_config()
         }
         for (int i = 0; i < (int)listens.size(); i++) {
             string port = listens[i];
-            if (port.empty() || ::atoi(port.c_str()) <= 0) {
-                return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "listen.port=%d is invalid", port.c_str());
+            bool err = false;
+            if (port.empty()) {
+                err = true;
+            } else if(port[0] == '['){
+                int pos = port.rfind("]");
+                pos += 1;
+                if( port[pos] != ':' || port.substr(0, pos) != "[::]" || ::atol(port.substr(pos + 1, port.length() - pos).c_str()) <= 0) {
+                    err = true;
+                }
+            } else {
+                if (::atol(port.c_str()) <= 0) {
+                    err = true;
+                }
+            }
+
+            if (err) {
+                return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "listen.port=%s is invalid", port.c_str());
             }
         }
     }

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -3561,9 +3561,11 @@ srs_error_t SrsConfig::check_normal_config()
             if (port.empty()) {
                 err = true;
             } else if(port[0] == '['){
-                int pos = port.rfind("]");
+                uint pos = port.rfind("]");
                 pos += 1;
-                if( port[pos] != ':' || port.substr(0, pos) != "[::]" || ::atol(port.substr(pos + 1, port.length() - pos).c_str()) <= 0) {
+                if( pos >= port.length() || port[pos] != ':' 
+                    || port.substr(0, pos) != "[::]" 
+                    || ::atol(port.substr(pos + 1, port.length() - pos).c_str()) <= 0) {
                     err = true;
                 }
             } else {


### PR DESCRIPTION
管理者你好，我最近修复了rtmp监听ipv6端口的一个小问题，请查阅
- 问题来源：[Issues 配置IPV6启动失败](https://github.com/ossrs/srs/issues/1920#issue-685392729)
- 问题：原来的问题主要是ipv4端口和ipv6端口的监听方式略微不同，ipv4只需要写入端口号就可以监听，而ipv6至少需要写`[::]:port`才能监听，因此验证的时候会产生错误
- 修改内容：增加了ipv6的验证代码，目前只能支持`[::]:port`这样的格式
- 使用及效果：修改设置，启动srs，经过测试可以正确监听ipv6的端口，且推流和拉流正常
    - ![image](https://user-images.githubusercontent.com/13149537/105136572-d67ae900-5b2c-11eb-85ad-ad9004d5100e.png)
    - ![image](https://user-images.githubusercontent.com/13149537/105136659-fad6c580-5b2c-11eb-8d12-33edc563c077.png)
    - ![image](https://user-images.githubusercontent.com/13149537/105137283-05458f00-5b2e-11eb-9096-50461e757e38.png)



