### PR TITLE
Fix mp3 streaming blocked by RTC

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -690,7 +690,9 @@ srs_error_t SrsRtcFromRtmpBridger::on_audio(SrsSharedPtrMessage* msg)
 
     // ts support audio codec: aac/mp3
     SrsAudioCodecId acodec = format->acodec->id;
-    if (acodec != SrsAudioCodecIdAAC && acodec != SrsAudioCodecIdMP3) {
+    // rtc can't process mp3 proberly, so pass it
+    // mp3 streaming was blocked by rtc, even it would crash in it
+    if (acodec != SrsAudioCodecIdAAC/* && acodec != SrsAudioCodecIdMP3*/) {
         return err;
     }
 


### PR DESCRIPTION
RTC can't process mp3 proberly, so pass it.
Mp3 streaming was blocked by RTC, even it would crash in it.