### PR TITLE
GB28181: G711 support and new RTC transcoder

### DIFF
--- a/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/codec_list.c
+++ b/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/codec_list.c
@@ -1,9 +1,13 @@
 static const AVCodec * const codec_list[] = {
     &ff_aac_encoder,
     &ff_opus_encoder,
+    &ff_pcm_alaw_encoder,
+    &ff_pcm_mulaw_encoder,
     &ff_libopus_encoder,
     &ff_aac_decoder,
     &ff_aac_fixed_decoder,
     &ff_aac_latm_decoder,
+    &ff_pcm_alaw_decoder,
+    &ff_pcm_mulaw_decoder,
     &ff_libopus_decoder,
     NULL };

--- a/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/pcm-bluray.c
+++ b/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/pcm-bluray.c
@@ -1,0 +1,314 @@
+/*
+ * LPCM codecs for PCM format found in Blu-ray PCM streams
+ * Copyright (c) 2009, 2013 Christian Schmidt
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * PCM codec for Blu-ray PCM audio tracks
+ */
+
+#include "libavutil/channel_layout.h"
+#include "avcodec.h"
+#include "bytestream.h"
+#include "internal.h"
+
+/*
+ * Channel Mapping according to
+ * Blu-ray Disc Read-Only Format Version 1
+ * Part 3: Audio Visual Basic Specifications
+ * mono     M1    X
+ * stereo   L     R
+ * 3/0      L     R    C    X
+ * 2/1      L     R    S    X
+ * 3/1      L     R    C    S
+ * 2/2      L     R    LS   RS
+ * 3/2      L     R    C    LS    RS    X
+ * 3/2+lfe  L     R    C    LS    RS    lfe
+ * 3/4      L     R    C    LS    Rls   Rrs  RS   X
+ * 3/4+lfe  L     R    C    LS    Rls   Rrs  RS   lfe
+ */
+
+/**
+ * Parse the header of a LPCM frame read from a Blu-ray MPEG-TS stream
+ * @param avctx the codec context
+ * @param header pointer to the first four bytes of the data packet
+ */
+static int pcm_bluray_parse_header(AVCodecContext *avctx,
+                                   const uint8_t *header)
+{
+    static const uint8_t bits_per_samples[4] = { 0, 16, 20, 24 };
+    static const uint32_t channel_layouts[16] = {
+        0, AV_CH_LAYOUT_MONO, 0, AV_CH_LAYOUT_STEREO, AV_CH_LAYOUT_SURROUND,
+        AV_CH_LAYOUT_2_1, AV_CH_LAYOUT_4POINT0, AV_CH_LAYOUT_2_2,
+        AV_CH_LAYOUT_5POINT0, AV_CH_LAYOUT_5POINT1, AV_CH_LAYOUT_7POINT0,
+        AV_CH_LAYOUT_7POINT1, 0, 0, 0, 0
+    };
+    static const uint8_t channels[16] = {
+        0, 1, 0, 2, 3, 3, 4, 4, 5, 6, 7, 8, 0, 0, 0, 0
+    };
+    uint8_t channel_layout = header[2] >> 4;
+
+    if (avctx->debug & FF_DEBUG_PICT_INFO)
+        ff_dlog(avctx, "pcm_bluray_parse_header: header = %02x%02x%02x%02x\n",
+                header[0], header[1], header[2], header[3]);
+
+    /* get the sample depth and derive the sample format from it */
+    avctx->bits_per_coded_sample = bits_per_samples[header[3] >> 6];
+    if (!(avctx->bits_per_coded_sample == 16 || avctx->bits_per_coded_sample == 24)) {
+        av_log(avctx, AV_LOG_ERROR, "unsupported sample depth (%d)\n", avctx->bits_per_coded_sample);
+        return AVERROR_INVALIDDATA;
+    }
+    avctx->sample_fmt = avctx->bits_per_coded_sample == 16 ? AV_SAMPLE_FMT_S16
+                                                           : AV_SAMPLE_FMT_S32;
+    if (avctx->sample_fmt == AV_SAMPLE_FMT_S32)
+        avctx->bits_per_raw_sample = avctx->bits_per_coded_sample;
+
+    /* get the sample rate. Not all values are used. */
+    switch (header[2] & 0x0f) {
+    case 1:
+        avctx->sample_rate = 48000;
+        break;
+    case 4:
+        avctx->sample_rate = 96000;
+        break;
+    case 5:
+        avctx->sample_rate = 192000;
+        break;
+    default:
+        avctx->sample_rate = 0;
+        av_log(avctx, AV_LOG_ERROR, "reserved sample rate (%d)\n",
+               header[2] & 0x0f);
+        return AVERROR_INVALIDDATA;
+    }
+
+    /*
+     * get the channel number (and mapping). Not all values are used.
+     * It must be noted that the number of channels in the MPEG stream can
+     * differ from the actual meaningful number, e.g. mono audio still has two
+     * channels, one being empty.
+     */
+    avctx->channel_layout  = channel_layouts[channel_layout];
+    avctx->channels        =        channels[channel_layout];
+    if (!avctx->channels) {
+        av_log(avctx, AV_LOG_ERROR, "reserved channel configuration (%d)\n",
+               channel_layout);
+        return AVERROR_INVALIDDATA;
+    }
+
+    avctx->bit_rate = FFALIGN(avctx->channels, 2) * avctx->sample_rate *
+                      avctx->bits_per_coded_sample;
+
+    if (avctx->debug & FF_DEBUG_PICT_INFO)
+        ff_dlog(avctx,
+                "pcm_bluray_parse_header: %d channels, %d bits per sample, %d Hz, %"PRId64" bit/s\n",
+                avctx->channels, avctx->bits_per_coded_sample,
+                avctx->sample_rate, avctx->bit_rate);
+    return 0;
+}
+
+static int pcm_bluray_decode_frame(AVCodecContext *avctx, void *data,
+                                   int *got_frame_ptr, AVPacket *avpkt)
+{
+    AVFrame *frame     = data;
+    const uint8_t *src = avpkt->data;
+    int buf_size = avpkt->size;
+    GetByteContext gb;
+    int num_source_channels, channel, retval;
+    int sample_size, samples;
+    int16_t *dst16;
+    int32_t *dst32;
+
+    if (buf_size < 4) {
+        av_log(avctx, AV_LOG_ERROR, "PCM packet too small\n");
+        return AVERROR_INVALIDDATA;
+    }
+
+    if ((retval = pcm_bluray_parse_header(avctx, src)))
+        return retval;
+    src += 4;
+    buf_size -= 4;
+
+    bytestream2_init(&gb, src, buf_size);
+
+    /* There's always an even number of channels in the source */
+    num_source_channels = FFALIGN(avctx->channels, 2);
+    sample_size = (num_source_channels *
+                   (avctx->sample_fmt == AV_SAMPLE_FMT_S16 ? 16 : 24)) >> 3;
+    samples = buf_size / sample_size;
+
+    /* get output buffer */
+    frame->nb_samples = samples;
+    if ((retval = ff_get_buffer(avctx, frame, 0)) < 0)
+        return retval;
+    dst16 = (int16_t *)frame->data[0];
+    dst32 = (int32_t *)frame->data[0];
+
+    if (samples) {
+        switch (avctx->channel_layout) {
+            /* cases with same number of source and coded channels */
+        case AV_CH_LAYOUT_STEREO:
+        case AV_CH_LAYOUT_4POINT0:
+        case AV_CH_LAYOUT_2_2:
+            samples *= num_source_channels;
+            if (AV_SAMPLE_FMT_S16 == avctx->sample_fmt) {
+#if HAVE_BIGENDIAN
+                bytestream2_get_buffer(&gb, dst16, buf_size);
+#else
+                do {
+                    *dst16++ = bytestream2_get_be16u(&gb);
+                } while (--samples);
+#endif
+            } else {
+                do {
+                    *dst32++ = bytestream2_get_be24u(&gb) << 8;
+                } while (--samples);
+            }
+            break;
+        /* cases where number of source channels = coded channels + 1 */
+        case AV_CH_LAYOUT_MONO:
+        case AV_CH_LAYOUT_SURROUND:
+        case AV_CH_LAYOUT_2_1:
+        case AV_CH_LAYOUT_5POINT0:
+            if (AV_SAMPLE_FMT_S16 == avctx->sample_fmt) {
+                do {
+#if HAVE_BIGENDIAN
+                    bytestream2_get_buffer(&gb, dst16, avctx->channels * 2);
+                    dst16 += avctx->channels;
+#else
+                    channel = avctx->channels;
+                    do {
+                        *dst16++ = bytestream2_get_be16u(&gb);
+                    } while (--channel);
+#endif
+                    bytestream2_skip(&gb, 2);
+                } while (--samples);
+            } else {
+                do {
+                    channel = avctx->channels;
+                    do {
+                        *dst32++ = bytestream2_get_be24u(&gb) << 8;
+                    } while (--channel);
+                    bytestream2_skip(&gb, 3);
+                } while (--samples);
+            }
+            break;
+            /* remapping: L, R, C, LBack, RBack, LF */
+        case AV_CH_LAYOUT_5POINT1:
+            if (AV_SAMPLE_FMT_S16 == avctx->sample_fmt) {
+                do {
+                    dst16[0] = bytestream2_get_be16u(&gb);
+                    dst16[1] = bytestream2_get_be16u(&gb);
+                    dst16[2] = bytestream2_get_be16u(&gb);
+                    dst16[4] = bytestream2_get_be16u(&gb);
+                    dst16[5] = bytestream2_get_be16u(&gb);
+                    dst16[3] = bytestream2_get_be16u(&gb);
+                    dst16 += 6;
+                } while (--samples);
+            } else {
+                do {
+                    dst32[0] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[1] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[2] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[4] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[5] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[3] = bytestream2_get_be24u(&gb) << 8;
+                    dst32 += 6;
+                } while (--samples);
+            }
+            break;
+            /* remapping: L, R, C, LSide, LBack, RBack, RSide, <unused> */
+        case AV_CH_LAYOUT_7POINT0:
+            if (AV_SAMPLE_FMT_S16 == avctx->sample_fmt) {
+                do {
+                    dst16[0] = bytestream2_get_be16u(&gb);
+                    dst16[1] = bytestream2_get_be16u(&gb);
+                    dst16[2] = bytestream2_get_be16u(&gb);
+                    dst16[5] = bytestream2_get_be16u(&gb);
+                    dst16[3] = bytestream2_get_be16u(&gb);
+                    dst16[4] = bytestream2_get_be16u(&gb);
+                    dst16[6] = bytestream2_get_be16u(&gb);
+                    dst16 += 7;
+                    bytestream2_skip(&gb, 2);
+                } while (--samples);
+            } else {
+                do {
+                    dst32[0] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[1] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[2] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[5] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[3] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[4] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[6] = bytestream2_get_be24u(&gb) << 8;
+                    dst32 += 7;
+                    bytestream2_skip(&gb, 3);
+                } while (--samples);
+            }
+            break;
+            /* remapping: L, R, C, LSide, LBack, RBack, RSide, LF */
+        case AV_CH_LAYOUT_7POINT1:
+            if (AV_SAMPLE_FMT_S16 == avctx->sample_fmt) {
+                do {
+                    dst16[0] = bytestream2_get_be16u(&gb);
+                    dst16[1] = bytestream2_get_be16u(&gb);
+                    dst16[2] = bytestream2_get_be16u(&gb);
+                    dst16[6] = bytestream2_get_be16u(&gb);
+                    dst16[4] = bytestream2_get_be16u(&gb);
+                    dst16[5] = bytestream2_get_be16u(&gb);
+                    dst16[7] = bytestream2_get_be16u(&gb);
+                    dst16[3] = bytestream2_get_be16u(&gb);
+                    dst16 += 8;
+                } while (--samples);
+            } else {
+                do {
+                    dst32[0] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[1] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[2] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[6] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[4] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[5] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[7] = bytestream2_get_be24u(&gb) << 8;
+                    dst32[3] = bytestream2_get_be24u(&gb) << 8;
+                    dst32 += 8;
+                } while (--samples);
+            }
+            break;
+        }
+    }
+
+    *got_frame_ptr = 1;
+
+    retval = bytestream2_tell(&gb);
+    if (avctx->debug & FF_DEBUG_BITSTREAM)
+        ff_dlog(avctx, "pcm_bluray_decode_frame: decoded %d -> %d bytes\n",
+                retval, buf_size);
+    return retval + 4;
+}
+
+AVCodec ff_pcm_bluray_decoder = {
+    .name           = "pcm_bluray",
+    .long_name      = NULL_IF_CONFIG_SMALL("PCM signed 16|20|24-bit big-endian for Blu-ray media"),
+    .type           = AVMEDIA_TYPE_AUDIO,
+    .id             = AV_CODEC_ID_PCM_BLURAY,
+    .decode         = pcm_bluray_decode_frame,
+    .capabilities   = AV_CODEC_CAP_DR1,
+    .sample_fmts    = (const enum AVSampleFormat[]){
+        AV_SAMPLE_FMT_S16, AV_SAMPLE_FMT_S32, AV_SAMPLE_FMT_NONE
+    },
+};

--- a/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/pcm-dvd.c
+++ b/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/pcm-dvd.c
@@ -1,0 +1,318 @@
+/*
+ * LPCM codecs for PCM formats found in Video DVD streams
+ * Copyright (c) 2013 Christian Schmidt
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * LPCM codecs for PCM formats found in Video DVD streams
+ */
+
+#include "avcodec.h"
+#include "bytestream.h"
+#include "internal.h"
+
+typedef struct PCMDVDContext {
+    uint32_t last_header;    // Cached header to see if parsing is needed
+    int block_size;          // Size of a block of samples in bytes
+    int last_block_size;     // Size of the last block of samples in bytes
+    int samples_per_block;   // Number of samples per channel per block
+    int groups_per_block;    // Number of 20/24-bit sample groups per block
+    uint8_t *extra_samples;  // Pointer to leftover samples from a frame
+    int extra_sample_count;  // Number of leftover samples in the buffer
+} PCMDVDContext;
+
+static av_cold int pcm_dvd_decode_init(AVCodecContext *avctx)
+{
+    PCMDVDContext *s = avctx->priv_data;
+
+    /* Invalid header to force parsing of the first header */
+    s->last_header = -1;
+    /* reserve space for 8 channels, 3 bytes/sample, 4 samples/block */
+    if (!(s->extra_samples = av_malloc(8 * 3 * 4)))
+        return AVERROR(ENOMEM);
+
+    return 0;
+}
+
+static av_cold int pcm_dvd_decode_uninit(AVCodecContext *avctx)
+{
+    PCMDVDContext *s = avctx->priv_data;
+
+    av_freep(&s->extra_samples);
+
+    return 0;
+}
+
+static int pcm_dvd_parse_header(AVCodecContext *avctx, const uint8_t *header)
+{
+    /* no traces of 44100 and 32000Hz in any commercial software or player */
+    static const uint32_t frequencies[4] = { 48000, 96000, 44100, 32000 };
+    PCMDVDContext *s = avctx->priv_data;
+    int header_int = (header[0] & 0xe0) | (header[1] << 8) | (header[2] << 16);
+
+    /* early exit if the header didn't change apart from the frame number */
+    if (s->last_header == header_int)
+        return 0;
+    s->last_header = -1;
+
+    if (avctx->debug & FF_DEBUG_PICT_INFO)
+        av_log(avctx, AV_LOG_DEBUG, "pcm_dvd_parse_header: header = %02x%02x%02x\n",
+                header[0], header[1], header[2]);
+    /*
+     * header[0] emphasis (1), muse(1), reserved(1), frame number(5)
+     * header[1] quant (2), freq(2), reserved(1), channels(3)
+     * header[2] dynamic range control (0x80 = off)
+     */
+
+    /* Discard potentially existing leftover samples from old channel layout */
+    s->extra_sample_count = 0;
+
+    /* get the sample depth and derive the sample format from it */
+    avctx->bits_per_coded_sample = 16 + (header[1] >> 6 & 3) * 4;
+    if (avctx->bits_per_coded_sample == 28) {
+        av_log(avctx, AV_LOG_ERROR,
+               "PCM DVD unsupported sample depth %i\n",
+               avctx->bits_per_coded_sample);
+        return AVERROR_INVALIDDATA;
+    }
+    avctx->sample_fmt = avctx->bits_per_coded_sample == 16 ? AV_SAMPLE_FMT_S16
+                                                           : AV_SAMPLE_FMT_S32;
+    avctx->bits_per_raw_sample = avctx->bits_per_coded_sample;
+
+    /* get the sample rate */
+    avctx->sample_rate = frequencies[header[1] >> 4 & 3];
+
+    /* get the number of channels */
+    avctx->channels = 1 + (header[1] & 7);
+    /* calculate the bitrate */
+    avctx->bit_rate = avctx->channels *
+                      avctx->sample_rate *
+                      avctx->bits_per_coded_sample;
+
+    /* 4 samples form a group in 20/24-bit PCM on DVD Video.
+     * A block is formed by the number of groups that are
+     * needed to complete a set of samples for each channel. */
+    if (avctx->bits_per_coded_sample == 16) {
+        s->samples_per_block = 1;
+        s->block_size        = avctx->channels * 2;
+    } else {
+        switch (avctx->channels) {
+        case 1:
+        case 2:
+        case 4:
+            /* one group has all the samples needed */
+            s->block_size        = 4 * avctx->bits_per_coded_sample / 8;
+            s->samples_per_block = 4 / avctx->channels;
+            s->groups_per_block  = 1;
+            break;
+        case 8:
+            /* two groups have all the samples needed */
+            s->block_size        = 8 * avctx->bits_per_coded_sample / 8;
+            s->samples_per_block = 1;
+            s->groups_per_block  = 2;
+            break;
+        default:
+            /* need avctx->channels groups */
+            s->block_size        = 4 * avctx->channels *
+                                   avctx->bits_per_coded_sample / 8;
+            s->samples_per_block = 4;
+            s->groups_per_block  = avctx->channels;
+            break;
+        }
+    }
+
+    if (avctx->debug & FF_DEBUG_PICT_INFO)
+        ff_dlog(avctx,
+                "pcm_dvd_parse_header: %d channels, %d bits per sample, %d Hz, %"PRId64" bit/s\n",
+                avctx->channels, avctx->bits_per_coded_sample,
+                avctx->sample_rate, avctx->bit_rate);
+
+    s->last_header = header_int;
+
+    return 0;
+}
+
+static void *pcm_dvd_decode_samples(AVCodecContext *avctx, const uint8_t *src,
+                                    void *dst, int blocks)
+{
+    PCMDVDContext *s = avctx->priv_data;
+    int16_t *dst16   = dst;
+    int32_t *dst32   = dst;
+    GetByteContext gb;
+    int i;
+    uint8_t t;
+
+    bytestream2_init(&gb, src, blocks * s->block_size);
+    switch (avctx->bits_per_coded_sample) {
+    case 16: {
+#if HAVE_BIGENDIAN
+        bytestream2_get_buffer(&gb, dst16, blocks * s->block_size);
+        dst16 += blocks * s->block_size / 2;
+#else
+        int samples = blocks * avctx->channels;
+        do {
+            *dst16++ = bytestream2_get_be16u(&gb);
+        } while (--samples);
+#endif
+        return dst16;
+    }
+    case 20:
+        if (avctx->channels == 1) {
+            do {
+                for (i = 2; i; i--) {
+                    dst32[0] = bytestream2_get_be16u(&gb) << 16;
+                    dst32[1] = bytestream2_get_be16u(&gb) << 16;
+                    t = bytestream2_get_byteu(&gb);
+                    *dst32++ += (t & 0xf0) << 8;
+                    *dst32++ += (t & 0x0f) << 12;
+                }
+            } while (--blocks);
+        } else {
+        do {
+            for (i = s->groups_per_block; i; i--) {
+                dst32[0] = bytestream2_get_be16u(&gb) << 16;
+                dst32[1] = bytestream2_get_be16u(&gb) << 16;
+                dst32[2] = bytestream2_get_be16u(&gb) << 16;
+                dst32[3] = bytestream2_get_be16u(&gb) << 16;
+                t = bytestream2_get_byteu(&gb);
+                *dst32++ += (t & 0xf0) << 8;
+                *dst32++ += (t & 0x0f) << 12;
+                t = bytestream2_get_byteu(&gb);
+                *dst32++ += (t & 0xf0) << 8;
+                *dst32++ += (t & 0x0f) << 12;
+            }
+        } while (--blocks);
+        }
+        return dst32;
+    case 24:
+        if (avctx->channels == 1) {
+            do {
+                for (i = 2; i; i--) {
+                    dst32[0] = bytestream2_get_be16u(&gb) << 16;
+                    dst32[1] = bytestream2_get_be16u(&gb) << 16;
+                    *dst32++ += bytestream2_get_byteu(&gb) << 8;
+                    *dst32++ += bytestream2_get_byteu(&gb) << 8;
+                }
+            } while (--blocks);
+        } else {
+        do {
+            for (i = s->groups_per_block; i; i--) {
+                dst32[0] = bytestream2_get_be16u(&gb) << 16;
+                dst32[1] = bytestream2_get_be16u(&gb) << 16;
+                dst32[2] = bytestream2_get_be16u(&gb) << 16;
+                dst32[3] = bytestream2_get_be16u(&gb) << 16;
+                *dst32++ += bytestream2_get_byteu(&gb) << 8;
+                *dst32++ += bytestream2_get_byteu(&gb) << 8;
+                *dst32++ += bytestream2_get_byteu(&gb) << 8;
+                *dst32++ += bytestream2_get_byteu(&gb) << 8;
+            }
+        } while (--blocks);
+        }
+        return dst32;
+    default:
+        return NULL;
+    }
+}
+
+static int pcm_dvd_decode_frame(AVCodecContext *avctx, void *data,
+                                int *got_frame_ptr, AVPacket *avpkt)
+{
+    AVFrame *frame     = data;
+    const uint8_t *src = avpkt->data;
+    int buf_size       = avpkt->size;
+    PCMDVDContext *s   = avctx->priv_data;
+    int retval;
+    int blocks;
+    void *dst;
+
+    if (buf_size < 3) {
+        av_log(avctx, AV_LOG_ERROR, "PCM packet too small\n");
+        return AVERROR_INVALIDDATA;
+    }
+
+    if ((retval = pcm_dvd_parse_header(avctx, src)))
+        return retval;
+    if (s->last_block_size && s->last_block_size != s->block_size) {
+        av_log(avctx, AV_LOG_WARNING, "block_size has changed %d != %d\n", s->last_block_size, s->block_size);
+        s->extra_sample_count = 0;
+    }
+    s->last_block_size = s->block_size;
+    src      += 3;
+    buf_size -= 3;
+
+    blocks = (buf_size + s->extra_sample_count) / s->block_size;
+
+    /* get output buffer */
+    frame->nb_samples = blocks * s->samples_per_block;
+    if ((retval = ff_get_buffer(avctx, frame, 0)) < 0)
+        return retval;
+    dst = frame->data[0];
+
+    /* consume leftover samples from last packet */
+    if (s->extra_sample_count) {
+        int missing_samples = s->block_size - s->extra_sample_count;
+        if (buf_size >= missing_samples) {
+            memcpy(s->extra_samples + s->extra_sample_count, src,
+                   missing_samples);
+            dst = pcm_dvd_decode_samples(avctx, s->extra_samples, dst, 1);
+            src += missing_samples;
+            buf_size -= missing_samples;
+            s->extra_sample_count = 0;
+            blocks--;
+        } else {
+            /* new packet still doesn't have enough samples */
+            memcpy(s->extra_samples + s->extra_sample_count, src, buf_size);
+            s->extra_sample_count += buf_size;
+            return avpkt->size;
+        }
+    }
+
+    /* decode remaining complete samples */
+    if (blocks) {
+        pcm_dvd_decode_samples(avctx, src, dst, blocks);
+        buf_size -= blocks * s->block_size;
+    }
+
+    /* store leftover samples */
+    if (buf_size) {
+        src += blocks * s->block_size;
+        memcpy(s->extra_samples, src, buf_size);
+        s->extra_sample_count = buf_size;
+    }
+
+    *got_frame_ptr = 1;
+
+    return avpkt->size;
+}
+
+AVCodec ff_pcm_dvd_decoder = {
+    .name           = "pcm_dvd",
+    .long_name      = NULL_IF_CONFIG_SMALL("PCM signed 16|20|24-bit big-endian for DVD media"),
+    .type           = AVMEDIA_TYPE_AUDIO,
+    .id             = AV_CODEC_ID_PCM_DVD,
+    .priv_data_size = sizeof(PCMDVDContext),
+    .init           = pcm_dvd_decode_init,
+    .decode         = pcm_dvd_decode_frame,
+    .close          = pcm_dvd_decode_uninit,
+    .capabilities   = AV_CODEC_CAP_DR1,
+    .sample_fmts    = (const enum AVSampleFormat[]) {
+        AV_SAMPLE_FMT_S16, AV_SAMPLE_FMT_S32, AV_SAMPLE_FMT_NONE
+    }
+};

--- a/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/pcm-dvdenc.c
+++ b/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/pcm-dvdenc.c
@@ -1,0 +1,197 @@
+/*
+ * LPCM codecs for PCM formats found in Video DVD streams
+ * Copyright (c) 2018 Paul B Mahol
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "avcodec.h"
+#include "bytestream.h"
+#include "internal.h"
+
+typedef struct PCMDVDContext {
+    uint8_t header[3];       // Header added to every frame
+    int block_size;          // Size of a block of samples in bytes
+    int samples_per_block;   // Number of samples per channel per block
+    int groups_per_block;    // Number of 20/24-bit sample groups per block
+    uint8_t *extra_samples;  // Pointer to leftover samples from a frame
+    int extra_sample_count;  // Number of leftover samples in the buffer
+} PCMDVDContext;
+
+static av_cold int pcm_dvd_encode_init(AVCodecContext *avctx)
+{
+    PCMDVDContext *s = avctx->priv_data;
+    int quant, freq, frame_size;
+
+    switch (avctx->sample_rate) {
+    case 48000:
+        freq = 0;
+        break;
+    case 96000:
+        freq = 1;
+        break;
+    }
+
+    switch (avctx->sample_fmt) {
+    case AV_SAMPLE_FMT_S16:
+        avctx->bits_per_coded_sample = 16;
+        quant = 0;
+        break;
+    case AV_SAMPLE_FMT_S32:
+        avctx->bits_per_coded_sample = 24;
+        quant = 2;
+        break;
+    }
+
+    avctx->bits_per_coded_sample = 16 + quant * 4;
+    avctx->block_align           = avctx->channels * avctx->bits_per_coded_sample / 8;
+    avctx->bit_rate              = avctx->block_align * 8LL * avctx->sample_rate;
+    if (avctx->bit_rate > 9800000) {
+        av_log(avctx, AV_LOG_ERROR, "Too big bitrate: reduce sample rate, bitdepth or channels.\n");
+        return AVERROR(EINVAL);
+    }
+
+    if (avctx->sample_fmt == AV_SAMPLE_FMT_S16) {
+        s->samples_per_block = 1;
+        s->block_size        = avctx->channels * 2;
+        frame_size           = 2008 / s->block_size;
+    } else {
+        switch (avctx->channels) {
+        case 1:
+        case 2:
+        case 4:
+            /* one group has all the samples needed */
+            s->block_size        = 4 * avctx->bits_per_coded_sample / 8;
+            s->samples_per_block = 4 / avctx->channels;
+            s->groups_per_block  = 1;
+            break;
+        case 8:
+            /* two groups have all the samples needed */
+            s->block_size        = 8 * avctx->bits_per_coded_sample / 8;
+            s->samples_per_block = 1;
+            s->groups_per_block  = 2;
+            break;
+        default:
+            /* need avctx->channels groups */
+            s->block_size        = 4 * avctx->channels *
+                                   avctx->bits_per_coded_sample / 8;
+            s->samples_per_block = 4;
+            s->groups_per_block  = avctx->channels;
+            break;
+        }
+
+        frame_size = FFALIGN(2008 / s->block_size, s->samples_per_block);
+    }
+
+    s->header[0] = 0x0c;
+    s->header[1] = (quant << 6) | (freq << 4) | (avctx->channels - 1);
+    s->header[2] = 0x80;
+
+    if (!avctx->frame_size)
+        avctx->frame_size = frame_size;
+
+    return 0;
+}
+
+static int pcm_dvd_encode_frame(AVCodecContext *avctx, AVPacket *avpkt,
+                                const AVFrame *frame, int *got_packet_ptr)
+{
+    PCMDVDContext *s = avctx->priv_data;
+    int samples = frame->nb_samples * avctx->channels;
+    int64_t pkt_size = (frame->nb_samples / s->samples_per_block) * s->block_size + 3;
+    int blocks = (pkt_size - 3) / s->block_size;
+    const int16_t *src16;
+    const int32_t *src32;
+    PutByteContext pb;
+    int ret;
+
+    if ((ret = ff_alloc_packet2(avctx, avpkt, pkt_size, 0)) < 0)
+        return ret;
+
+    memcpy(avpkt->data, s->header, 3);
+
+    src16 = (const int16_t *)frame->data[0];
+    src32 = (const int32_t *)frame->data[0];
+
+    bytestream2_init_writer(&pb, avpkt->data + 3, avpkt->size - 3);
+
+    switch (avctx->sample_fmt) {
+    case AV_SAMPLE_FMT_S16:
+        do {
+            bytestream2_put_be16(&pb, *src16++);
+        } while (--samples);
+        break;
+    case AV_SAMPLE_FMT_S32:
+        if (avctx->channels == 1) {
+            do {
+                for (int i = 2; i; i--) {
+                    bytestream2_put_be16(&pb, src32[0] >> 16);
+                    bytestream2_put_be16(&pb, src32[1] >> 16);
+                    bytestream2_put_byte(&pb, (*src32++) >> 24);
+                    bytestream2_put_byte(&pb, (*src32++) >> 24);
+                }
+            } while (--blocks);
+        } else {
+            do {
+                for (int i = s->groups_per_block; i; i--) {
+                    bytestream2_put_be16(&pb, src32[0] >> 16);
+                    bytestream2_put_be16(&pb, src32[1] >> 16);
+                    bytestream2_put_be16(&pb, src32[2] >> 16);
+                    bytestream2_put_be16(&pb, src32[3] >> 16);
+                    bytestream2_put_byte(&pb, (*src32++) >> 24);
+                    bytestream2_put_byte(&pb, (*src32++) >> 24);
+                    bytestream2_put_byte(&pb, (*src32++) >> 24);
+                    bytestream2_put_byte(&pb, (*src32++) >> 24);
+                }
+            } while (--blocks);
+        }
+        break;
+    }
+
+    avpkt->pts      = frame->pts;
+    avpkt->size     = pkt_size;
+    avpkt->duration = ff_samples_to_time_base(avctx, frame->nb_samples);
+    *got_packet_ptr = 1;
+
+    return 0;
+}
+
+static av_cold int pcm_dvd_encode_close(AVCodecContext *avctx)
+{
+    return 0;
+}
+
+AVCodec ff_pcm_dvd_encoder = {
+    .name           = "pcm_dvd",
+    .long_name      = NULL_IF_CONFIG_SMALL("PCM signed 16|20|24-bit big-endian for DVD media"),
+    .type           = AVMEDIA_TYPE_AUDIO,
+    .id             = AV_CODEC_ID_PCM_DVD,
+    .priv_data_size = sizeof(PCMDVDContext),
+    .init           = pcm_dvd_encode_init,
+    .close          = pcm_dvd_encode_close,
+    .encode2        = pcm_dvd_encode_frame,
+    .capabilities   = AV_CODEC_CAP_SMALL_LAST_FRAME,
+    .supported_samplerates = (const int[]) { 48000, 96000, 0},
+    .channel_layouts = (const uint64_t[]) { AV_CH_LAYOUT_MONO,
+                                            AV_CH_LAYOUT_STEREO,
+                                            AV_CH_LAYOUT_5POINT1,
+                                            AV_CH_LAYOUT_7POINT1,
+                                            0 },
+    .sample_fmts    = (const enum AVSampleFormat[]){ AV_SAMPLE_FMT_S16,
+                                                     AV_SAMPLE_FMT_S32,
+                                                     AV_SAMPLE_FMT_NONE },
+};

--- a/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/pcm.c
+++ b/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/pcm.c
@@ -1,0 +1,632 @@
+/*
+ * PCM codecs
+ * Copyright (c) 2001 Fabrice Bellard
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * PCM codecs
+ */
+
+#include "libavutil/attributes.h"
+#include "libavutil/float_dsp.h"
+#include "avcodec.h"
+#include "bytestream.h"
+#include "internal.h"
+#include "mathops.h"
+#include "pcm_tablegen.h"
+
+static av_cold int pcm_encode_init(AVCodecContext *avctx)
+{
+    avctx->frame_size = 0;
+    switch (avctx->codec->id) {
+    case AV_CODEC_ID_PCM_ALAW:
+        pcm_alaw_tableinit();
+        break;
+    case AV_CODEC_ID_PCM_MULAW:
+        pcm_ulaw_tableinit();
+        break;
+    case AV_CODEC_ID_PCM_VIDC:
+        pcm_vidc_tableinit();
+        break;
+    default:
+        break;
+    }
+
+    avctx->bits_per_coded_sample = av_get_bits_per_sample(avctx->codec->id);
+    avctx->block_align           = avctx->channels * avctx->bits_per_coded_sample / 8;
+    avctx->bit_rate              = avctx->block_align * 8LL * avctx->sample_rate;
+
+    return 0;
+}
+
+/**
+ * Write PCM samples macro
+ * @param type   Datatype of native machine format
+ * @param endian bytestream_put_xxx() suffix
+ * @param src    Source pointer (variable name)
+ * @param dst    Destination pointer (variable name)
+ * @param n      Total number of samples (variable name)
+ * @param shift  Bitshift (bits)
+ * @param offset Sample value offset
+ */
+#define ENCODE(type, endian, src, dst, n, shift, offset)                \
+    samples_ ## type = (const type *) src;                              \
+    for (; n > 0; n--) {                                                \
+        register type v = (*samples_ ## type++ >> shift) + offset;      \
+        bytestream_put_ ## endian(&dst, v);                             \
+    }
+
+#define ENCODE_PLANAR(type, endian, dst, n, shift, offset)              \
+    n /= avctx->channels;                                               \
+    for (c = 0; c < avctx->channels; c++) {                             \
+        int i;                                                          \
+        samples_ ## type = (const type *) frame->extended_data[c];      \
+        for (i = n; i > 0; i--) {                                       \
+            register type v = (*samples_ ## type++ >> shift) + offset;  \
+            bytestream_put_ ## endian(&dst, v);                         \
+        }                                                               \
+    }
+
+static int pcm_encode_frame(AVCodecContext *avctx, AVPacket *avpkt,
+                            const AVFrame *frame, int *got_packet_ptr)
+{
+    int n, c, sample_size, v, ret;
+    const short *samples;
+    unsigned char *dst;
+    const uint8_t *samples_uint8_t;
+    const int16_t *samples_int16_t;
+    const int32_t *samples_int32_t;
+    const int64_t *samples_int64_t;
+    const uint16_t *samples_uint16_t;
+    const uint32_t *samples_uint32_t;
+
+    sample_size = av_get_bits_per_sample(avctx->codec->id) / 8;
+    n           = frame->nb_samples * avctx->channels;
+    samples     = (const short *)frame->data[0];
+
+    if ((ret = ff_alloc_packet2(avctx, avpkt, n * sample_size, n * sample_size)) < 0)
+        return ret;
+    dst = avpkt->data;
+
+    switch (avctx->codec->id) {
+    case AV_CODEC_ID_PCM_U32LE:
+        ENCODE(uint32_t, le32, samples, dst, n, 0, 0x80000000)
+        break;
+    case AV_CODEC_ID_PCM_U32BE:
+        ENCODE(uint32_t, be32, samples, dst, n, 0, 0x80000000)
+        break;
+    case AV_CODEC_ID_PCM_S24LE:
+        ENCODE(int32_t, le24, samples, dst, n, 8, 0)
+        break;
+    case AV_CODEC_ID_PCM_S24LE_PLANAR:
+        ENCODE_PLANAR(int32_t, le24, dst, n, 8, 0)
+        break;
+    case AV_CODEC_ID_PCM_S24BE:
+        ENCODE(int32_t, be24, samples, dst, n, 8, 0)
+        break;
+    case AV_CODEC_ID_PCM_U24LE:
+        ENCODE(uint32_t, le24, samples, dst, n, 8, 0x800000)
+        break;
+    case AV_CODEC_ID_PCM_U24BE:
+        ENCODE(uint32_t, be24, samples, dst, n, 8, 0x800000)
+        break;
+    case AV_CODEC_ID_PCM_S24DAUD:
+        for (; n > 0; n--) {
+            uint32_t tmp = ff_reverse[(*samples >> 8) & 0xff] +
+                           (ff_reverse[*samples & 0xff] << 8);
+            tmp <<= 4; // sync flags would go here
+            bytestream_put_be24(&dst, tmp);
+            samples++;
+        }
+        break;
+    case AV_CODEC_ID_PCM_U16LE:
+        ENCODE(uint16_t, le16, samples, dst, n, 0, 0x8000)
+        break;
+    case AV_CODEC_ID_PCM_U16BE:
+        ENCODE(uint16_t, be16, samples, dst, n, 0, 0x8000)
+        break;
+    case AV_CODEC_ID_PCM_S8:
+        ENCODE(uint8_t, byte, samples, dst, n, 0, -128)
+        break;
+    case AV_CODEC_ID_PCM_S8_PLANAR:
+        ENCODE_PLANAR(uint8_t, byte, dst, n, 0, -128)
+        break;
+#if HAVE_BIGENDIAN
+    case AV_CODEC_ID_PCM_S64LE:
+    case AV_CODEC_ID_PCM_F64LE:
+        ENCODE(int64_t, le64, samples, dst, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S32LE:
+    case AV_CODEC_ID_PCM_F32LE:
+        ENCODE(int32_t, le32, samples, dst, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S32LE_PLANAR:
+        ENCODE_PLANAR(int32_t, le32, dst, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S16LE:
+        ENCODE(int16_t, le16, samples, dst, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S16LE_PLANAR:
+        ENCODE_PLANAR(int16_t, le16, dst, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_F64BE:
+    case AV_CODEC_ID_PCM_F32BE:
+    case AV_CODEC_ID_PCM_S64BE:
+    case AV_CODEC_ID_PCM_S32BE:
+    case AV_CODEC_ID_PCM_S16BE:
+#else
+    case AV_CODEC_ID_PCM_S64BE:
+    case AV_CODEC_ID_PCM_F64BE:
+        ENCODE(int64_t, be64, samples, dst, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_F32BE:
+    case AV_CODEC_ID_PCM_S32BE:
+        ENCODE(int32_t, be32, samples, dst, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S16BE:
+        ENCODE(int16_t, be16, samples, dst, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S16BE_PLANAR:
+        ENCODE_PLANAR(int16_t, be16, dst, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_F64LE:
+    case AV_CODEC_ID_PCM_F32LE:
+    case AV_CODEC_ID_PCM_S64LE:
+    case AV_CODEC_ID_PCM_S32LE:
+    case AV_CODEC_ID_PCM_S16LE:
+#endif /* HAVE_BIGENDIAN */
+    case AV_CODEC_ID_PCM_U8:
+        memcpy(dst, samples, n * sample_size);
+        break;
+#if HAVE_BIGENDIAN
+    case AV_CODEC_ID_PCM_S16BE_PLANAR:
+#else
+    case AV_CODEC_ID_PCM_S16LE_PLANAR:
+    case AV_CODEC_ID_PCM_S32LE_PLANAR:
+#endif /* HAVE_BIGENDIAN */
+        n /= avctx->channels;
+        for (c = 0; c < avctx->channels; c++) {
+            const uint8_t *src = frame->extended_data[c];
+            bytestream_put_buffer(&dst, src, n * sample_size);
+        }
+        break;
+    case AV_CODEC_ID_PCM_ALAW:
+        for (; n > 0; n--) {
+            v      = *samples++;
+            *dst++ = linear_to_alaw[(v + 32768) >> 2];
+        }
+        break;
+    case AV_CODEC_ID_PCM_MULAW:
+        for (; n > 0; n--) {
+            v      = *samples++;
+            *dst++ = linear_to_ulaw[(v + 32768) >> 2];
+        }
+        break;
+    case AV_CODEC_ID_PCM_VIDC:
+        for (; n > 0; n--) {
+            v      = *samples++;
+            *dst++ = linear_to_vidc[(v + 32768) >> 2];
+        }
+        break;
+    default:
+        return -1;
+    }
+
+    *got_packet_ptr = 1;
+    return 0;
+}
+
+typedef struct PCMDecode {
+    short   table[256];
+    AVFloatDSPContext *fdsp;
+    float   scale;
+} PCMDecode;
+
+static av_cold int pcm_decode_init(AVCodecContext *avctx)
+{
+    PCMDecode *s = avctx->priv_data;
+    int i;
+
+    if (avctx->channels <= 0) {
+        av_log(avctx, AV_LOG_ERROR, "PCM channels out of bounds\n");
+        return AVERROR(EINVAL);
+    }
+
+    switch (avctx->codec_id) {
+    case AV_CODEC_ID_PCM_ALAW:
+        for (i = 0; i < 256; i++)
+            s->table[i] = alaw2linear(i);
+        break;
+    case AV_CODEC_ID_PCM_MULAW:
+        for (i = 0; i < 256; i++)
+            s->table[i] = ulaw2linear(i);
+        break;
+    case AV_CODEC_ID_PCM_VIDC:
+        for (i = 0; i < 256; i++)
+            s->table[i] = vidc2linear(i);
+        break;
+    case AV_CODEC_ID_PCM_F16LE:
+    case AV_CODEC_ID_PCM_F24LE:
+        if (avctx->bits_per_coded_sample < 1 || avctx->bits_per_coded_sample > 24)
+            return AVERROR_INVALIDDATA;
+
+        s->scale = 1. / (1 << (avctx->bits_per_coded_sample - 1));
+        s->fdsp = avpriv_float_dsp_alloc(0);
+        if (!s->fdsp)
+            return AVERROR(ENOMEM);
+        break;
+    default:
+        break;
+    }
+
+    avctx->sample_fmt = avctx->codec->sample_fmts[0];
+
+    if (avctx->sample_fmt == AV_SAMPLE_FMT_S32)
+        avctx->bits_per_raw_sample = av_get_bits_per_sample(avctx->codec_id);
+
+    return 0;
+}
+
+static av_cold int pcm_decode_close(AVCodecContext *avctx)
+{
+    PCMDecode *s = avctx->priv_data;
+
+    av_freep(&s->fdsp);
+
+    return 0;
+}
+
+/**
+ * Read PCM samples macro
+ * @param size   Data size of native machine format
+ * @param endian bytestream_get_xxx() endian suffix
+ * @param src    Source pointer (variable name)
+ * @param dst    Destination pointer (variable name)
+ * @param n      Total number of samples (variable name)
+ * @param shift  Bitshift (bits)
+ * @param offset Sample value offset
+ */
+#define DECODE(size, endian, src, dst, n, shift, offset)                \
+    for (; n > 0; n--) {                                                \
+        uint ## size ## _t v = bytestream_get_ ## endian(&src);         \
+        AV_WN ## size ## A(dst, (v - offset) << shift);                 \
+        dst += size / 8;                                                \
+    }
+
+#define DECODE_PLANAR(size, endian, src, dst, n, shift, offset)         \
+    n /= avctx->channels;                                               \
+    for (c = 0; c < avctx->channels; c++) {                             \
+        int i;                                                          \
+        dst = frame->extended_data[c];                                \
+        for (i = n; i > 0; i--) {                                       \
+            uint ## size ## _t v = bytestream_get_ ## endian(&src);     \
+            AV_WN ## size ## A(dst, (v - offset) << shift);             \
+            dst += size / 8;                                            \
+        }                                                               \
+    }
+
+static int pcm_decode_frame(AVCodecContext *avctx, void *data,
+                            int *got_frame_ptr, AVPacket *avpkt)
+{
+    const uint8_t *src = avpkt->data;
+    int buf_size       = avpkt->size;
+    PCMDecode *s       = avctx->priv_data;
+    AVFrame *frame     = data;
+    int sample_size, c, n, ret, samples_per_block;
+    uint8_t *samples;
+    int32_t *dst_int32_t;
+
+    sample_size = av_get_bits_per_sample(avctx->codec_id) / 8;
+
+    /* av_get_bits_per_sample returns 0 for AV_CODEC_ID_PCM_DVD */
+    samples_per_block = 1;
+    if (avctx->codec_id == AV_CODEC_ID_PCM_LXF) {
+        /* we process 40-bit blocks per channel for LXF */
+        samples_per_block = 2;
+        sample_size       = 5;
+    }
+
+    if (sample_size == 0) {
+        av_log(avctx, AV_LOG_ERROR, "Invalid sample_size\n");
+        return AVERROR(EINVAL);
+    }
+
+    if (avctx->channels == 0) {
+        av_log(avctx, AV_LOG_ERROR, "Invalid number of channels\n");
+        return AVERROR(EINVAL);
+    }
+
+    if (avctx->codec_id != avctx->codec->id) {
+        av_log(avctx, AV_LOG_ERROR, "codec ids mismatch\n");
+        return AVERROR(EINVAL);
+    }
+
+    n = avctx->channels * sample_size;
+
+    if (n && buf_size % n) {
+        if (buf_size < n) {
+            av_log(avctx, AV_LOG_ERROR,
+                   "Invalid PCM packet, data has size %d but at least a size of %d was expected\n",
+                   buf_size, n);
+            return AVERROR_INVALIDDATA;
+        } else
+            buf_size -= buf_size % n;
+    }
+
+    n = buf_size / sample_size;
+
+    /* get output buffer */
+    frame->nb_samples = n * samples_per_block / avctx->channels;
+    if ((ret = ff_get_buffer(avctx, frame, 0)) < 0)
+        return ret;
+    samples = frame->data[0];
+
+    switch (avctx->codec_id) {
+    case AV_CODEC_ID_PCM_U32LE:
+        DECODE(32, le32, src, samples, n, 0, 0x80000000)
+        break;
+    case AV_CODEC_ID_PCM_U32BE:
+        DECODE(32, be32, src, samples, n, 0, 0x80000000)
+        break;
+    case AV_CODEC_ID_PCM_S24LE:
+        DECODE(32, le24, src, samples, n, 8, 0)
+        break;
+    case AV_CODEC_ID_PCM_S24LE_PLANAR:
+        DECODE_PLANAR(32, le24, src, samples, n, 8, 0);
+        break;
+    case AV_CODEC_ID_PCM_S24BE:
+        DECODE(32, be24, src, samples, n, 8, 0)
+        break;
+    case AV_CODEC_ID_PCM_U24LE:
+        DECODE(32, le24, src, samples, n, 8, 0x800000)
+        break;
+    case AV_CODEC_ID_PCM_U24BE:
+        DECODE(32, be24, src, samples, n, 8, 0x800000)
+        break;
+    case AV_CODEC_ID_PCM_S24DAUD:
+        for (; n > 0; n--) {
+            uint32_t v = bytestream_get_be24(&src);
+            v >>= 4; // sync flags are here
+            AV_WN16A(samples, ff_reverse[(v >> 8) & 0xff] +
+                             (ff_reverse[v        & 0xff] << 8));
+            samples += 2;
+        }
+        break;
+    case AV_CODEC_ID_PCM_U16LE:
+        DECODE(16, le16, src, samples, n, 0, 0x8000)
+        break;
+    case AV_CODEC_ID_PCM_U16BE:
+        DECODE(16, be16, src, samples, n, 0, 0x8000)
+        break;
+    case AV_CODEC_ID_PCM_S8:
+        for (; n > 0; n--)
+            *samples++ = *src++ + 128;
+        break;
+    case AV_CODEC_ID_PCM_S8_PLANAR:
+        n /= avctx->channels;
+        for (c = 0; c < avctx->channels; c++) {
+            int i;
+            samples = frame->extended_data[c];
+            for (i = n; i > 0; i--)
+                *samples++ = *src++ + 128;
+        }
+        break;
+#if HAVE_BIGENDIAN
+    case AV_CODEC_ID_PCM_S64LE:
+    case AV_CODEC_ID_PCM_F64LE:
+        DECODE(64, le64, src, samples, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S32LE:
+    case AV_CODEC_ID_PCM_F32LE:
+    case AV_CODEC_ID_PCM_F24LE:
+    case AV_CODEC_ID_PCM_F16LE:
+        DECODE(32, le32, src, samples, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S32LE_PLANAR:
+        DECODE_PLANAR(32, le32, src, samples, n, 0, 0);
+        break;
+    case AV_CODEC_ID_PCM_S16LE:
+        DECODE(16, le16, src, samples, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S16LE_PLANAR:
+        DECODE_PLANAR(16, le16, src, samples, n, 0, 0);
+        break;
+    case AV_CODEC_ID_PCM_F64BE:
+    case AV_CODEC_ID_PCM_F32BE:
+    case AV_CODEC_ID_PCM_S64BE:
+    case AV_CODEC_ID_PCM_S32BE:
+    case AV_CODEC_ID_PCM_S16BE:
+#else
+    case AV_CODEC_ID_PCM_S64BE:
+    case AV_CODEC_ID_PCM_F64BE:
+        DECODE(64, be64, src, samples, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_F32BE:
+    case AV_CODEC_ID_PCM_S32BE:
+        DECODE(32, be32, src, samples, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S16BE:
+        DECODE(16, be16, src, samples, n, 0, 0)
+        break;
+    case AV_CODEC_ID_PCM_S16BE_PLANAR:
+        DECODE_PLANAR(16, be16, src, samples, n, 0, 0);
+        break;
+    case AV_CODEC_ID_PCM_F64LE:
+    case AV_CODEC_ID_PCM_F32LE:
+    case AV_CODEC_ID_PCM_F24LE:
+    case AV_CODEC_ID_PCM_F16LE:
+    case AV_CODEC_ID_PCM_S64LE:
+    case AV_CODEC_ID_PCM_S32LE:
+    case AV_CODEC_ID_PCM_S16LE:
+#endif /* HAVE_BIGENDIAN */
+    case AV_CODEC_ID_PCM_U8:
+        memcpy(samples, src, n * sample_size);
+        break;
+#if HAVE_BIGENDIAN
+    case AV_CODEC_ID_PCM_S16BE_PLANAR:
+#else
+    case AV_CODEC_ID_PCM_S16LE_PLANAR:
+    case AV_CODEC_ID_PCM_S32LE_PLANAR:
+#endif /* HAVE_BIGENDIAN */
+        n /= avctx->channels;
+        for (c = 0; c < avctx->channels; c++) {
+            samples = frame->extended_data[c];
+            bytestream_get_buffer(&src, samples, n * sample_size);
+        }
+        break;
+    case AV_CODEC_ID_PCM_ZORK:
+        for (; n > 0; n--) {
+            int v = *src++;
+            if (v < 128)
+                v = 128 - v;
+            *samples++ = v;
+        }
+        break;
+    case AV_CODEC_ID_PCM_ALAW:
+    case AV_CODEC_ID_PCM_MULAW:
+    case AV_CODEC_ID_PCM_VIDC:
+        for (; n > 0; n--) {
+            AV_WN16A(samples, s->table[*src++]);
+            samples += 2;
+        }
+        break;
+    case AV_CODEC_ID_PCM_LXF:
+    {
+        int i;
+        n /= avctx->channels;
+        for (c = 0; c < avctx->channels; c++) {
+            dst_int32_t = (int32_t *)frame->extended_data[c];
+            for (i = 0; i < n; i++) {
+                // extract low 20 bits and expand to 32 bits
+                *dst_int32_t++ =  (src[2]         << 28) |
+                                  (src[1]         << 20) |
+                                  (src[0]         << 12) |
+                                 ((src[2] & 0x0F) <<  8) |
+                                   src[1];
+                // extract high 20 bits and expand to 32 bits
+                *dst_int32_t++ =  (src[4]         << 24) |
+                                  (src[3]         << 16) |
+                                 ((src[2] & 0xF0) <<  8) |
+                                  (src[4]         <<  4) |
+                                  (src[3]         >>  4);
+                src += 5;
+            }
+        }
+        break;
+    }
+    default:
+        return -1;
+    }
+
+    if (avctx->codec_id == AV_CODEC_ID_PCM_F16LE ||
+        avctx->codec_id == AV_CODEC_ID_PCM_F24LE) {
+        s->fdsp->vector_fmul_scalar((float *)frame->extended_data[0],
+                                    (const float *)frame->extended_data[0],
+                                    s->scale, FFALIGN(frame->nb_samples * avctx->channels, 4));
+        emms_c();
+    }
+
+    *got_frame_ptr = 1;
+
+    return buf_size;
+}
+
+#define PCM_ENCODER_0(id_, sample_fmt_, name_, long_name_)
+#define PCM_ENCODER_1(id_, sample_fmt_, name_, long_name_)                  \
+AVCodec ff_ ## name_ ## _encoder = {                                        \
+    .name         = #name_,                                                 \
+    .long_name    = NULL_IF_CONFIG_SMALL(long_name_),                       \
+    .type         = AVMEDIA_TYPE_AUDIO,                                     \
+    .id           = AV_CODEC_ID_ ## id_,                                    \
+    .init         = pcm_encode_init,                                        \
+    .encode2      = pcm_encode_frame,                                       \
+    .capabilities = AV_CODEC_CAP_VARIABLE_FRAME_SIZE,                       \
+    .sample_fmts  = (const enum AVSampleFormat[]){ sample_fmt_,             \
+                                                   AV_SAMPLE_FMT_NONE },    \
+}
+
+#define PCM_ENCODER_2(cf, id, sample_fmt, name, long_name)                  \
+    PCM_ENCODER_ ## cf(id, sample_fmt, name, long_name)
+#define PCM_ENCODER_3(cf, id, sample_fmt, name, long_name)                  \
+    PCM_ENCODER_2(cf, id, sample_fmt, name, long_name)
+#define PCM_ENCODER(id, sample_fmt, name, long_name)                        \
+    PCM_ENCODER_3(CONFIG_ ## id ## _ENCODER, id, sample_fmt, name, long_name)
+
+#define PCM_DECODER_0(id, sample_fmt, name, long_name)
+#define PCM_DECODER_1(id_, sample_fmt_, name_, long_name_)                  \
+AVCodec ff_ ## name_ ## _decoder = {                                        \
+    .name           = #name_,                                               \
+    .long_name      = NULL_IF_CONFIG_SMALL(long_name_),                     \
+    .type           = AVMEDIA_TYPE_AUDIO,                                   \
+    .id             = AV_CODEC_ID_ ## id_,                                  \
+    .priv_data_size = sizeof(PCMDecode),                                    \
+    .init           = pcm_decode_init,                                      \
+    .close          = pcm_decode_close,                                     \
+    .decode         = pcm_decode_frame,                                     \
+    .capabilities   = AV_CODEC_CAP_DR1,                                     \
+    .sample_fmts    = (const enum AVSampleFormat[]){ sample_fmt_,           \
+                                                     AV_SAMPLE_FMT_NONE },  \
+}
+
+#define PCM_DECODER_2(cf, id, sample_fmt, name, long_name)                  \
+    PCM_DECODER_ ## cf(id, sample_fmt, name, long_name)
+#define PCM_DECODER_3(cf, id, sample_fmt, name, long_name)                  \
+    PCM_DECODER_2(cf, id, sample_fmt, name, long_name)
+#define PCM_DECODER(id, sample_fmt, name, long_name)                        \
+    PCM_DECODER_3(CONFIG_ ## id ## _DECODER, id, sample_fmt, name, long_name)
+
+#define PCM_CODEC(id, sample_fmt_, name, long_name_)                    \
+    PCM_ENCODER(id, sample_fmt_, name, long_name_);                     \
+    PCM_DECODER(id, sample_fmt_, name, long_name_)
+
+/* Note: Do not forget to add new entries to the Makefile as well. */
+PCM_CODEC  (PCM_ALAW,         AV_SAMPLE_FMT_S16, pcm_alaw,         "PCM A-law / G.711 A-law");
+PCM_DECODER(PCM_F16LE,        AV_SAMPLE_FMT_FLT, pcm_f16le,        "PCM 16.8 floating point little-endian");
+PCM_DECODER(PCM_F24LE,        AV_SAMPLE_FMT_FLT, pcm_f24le,        "PCM 24.0 floating point little-endian");
+PCM_CODEC  (PCM_F32BE,        AV_SAMPLE_FMT_FLT, pcm_f32be,        "PCM 32-bit floating point big-endian");
+PCM_CODEC  (PCM_F32LE,        AV_SAMPLE_FMT_FLT, pcm_f32le,        "PCM 32-bit floating point little-endian");
+PCM_CODEC  (PCM_F64BE,        AV_SAMPLE_FMT_DBL, pcm_f64be,        "PCM 64-bit floating point big-endian");
+PCM_CODEC  (PCM_F64LE,        AV_SAMPLE_FMT_DBL, pcm_f64le,        "PCM 64-bit floating point little-endian");
+PCM_DECODER(PCM_LXF,          AV_SAMPLE_FMT_S32P,pcm_lxf,          "PCM signed 20-bit little-endian planar");
+PCM_CODEC  (PCM_MULAW,        AV_SAMPLE_FMT_S16, pcm_mulaw,        "PCM mu-law / G.711 mu-law");
+PCM_CODEC  (PCM_S8,           AV_SAMPLE_FMT_U8,  pcm_s8,           "PCM signed 8-bit");
+PCM_CODEC  (PCM_S8_PLANAR,    AV_SAMPLE_FMT_U8P, pcm_s8_planar,    "PCM signed 8-bit planar");
+PCM_CODEC  (PCM_S16BE,        AV_SAMPLE_FMT_S16, pcm_s16be,        "PCM signed 16-bit big-endian");
+PCM_CODEC  (PCM_S16BE_PLANAR, AV_SAMPLE_FMT_S16P,pcm_s16be_planar, "PCM signed 16-bit big-endian planar");
+PCM_CODEC  (PCM_S16LE,        AV_SAMPLE_FMT_S16, pcm_s16le,        "PCM signed 16-bit little-endian");
+PCM_CODEC  (PCM_S16LE_PLANAR, AV_SAMPLE_FMT_S16P,pcm_s16le_planar, "PCM signed 16-bit little-endian planar");
+PCM_CODEC  (PCM_S24BE,        AV_SAMPLE_FMT_S32, pcm_s24be,        "PCM signed 24-bit big-endian");
+PCM_CODEC  (PCM_S24DAUD,      AV_SAMPLE_FMT_S16, pcm_s24daud,      "PCM D-Cinema audio signed 24-bit");
+PCM_CODEC  (PCM_S24LE,        AV_SAMPLE_FMT_S32, pcm_s24le,        "PCM signed 24-bit little-endian");
+PCM_CODEC  (PCM_S24LE_PLANAR, AV_SAMPLE_FMT_S32P,pcm_s24le_planar, "PCM signed 24-bit little-endian planar");
+PCM_CODEC  (PCM_S32BE,        AV_SAMPLE_FMT_S32, pcm_s32be,        "PCM signed 32-bit big-endian");
+PCM_CODEC  (PCM_S32LE,        AV_SAMPLE_FMT_S32, pcm_s32le,        "PCM signed 32-bit little-endian");
+PCM_CODEC  (PCM_S32LE_PLANAR, AV_SAMPLE_FMT_S32P,pcm_s32le_planar, "PCM signed 32-bit little-endian planar");
+PCM_CODEC  (PCM_U8,           AV_SAMPLE_FMT_U8,  pcm_u8,           "PCM unsigned 8-bit");
+PCM_CODEC  (PCM_U16BE,        AV_SAMPLE_FMT_S16, pcm_u16be,        "PCM unsigned 16-bit big-endian");
+PCM_CODEC  (PCM_U16LE,        AV_SAMPLE_FMT_S16, pcm_u16le,        "PCM unsigned 16-bit little-endian");
+PCM_CODEC  (PCM_U24BE,        AV_SAMPLE_FMT_S32, pcm_u24be,        "PCM unsigned 24-bit big-endian");
+PCM_CODEC  (PCM_U24LE,        AV_SAMPLE_FMT_S32, pcm_u24le,        "PCM unsigned 24-bit little-endian");
+PCM_CODEC  (PCM_U32BE,        AV_SAMPLE_FMT_S32, pcm_u32be,        "PCM unsigned 32-bit big-endian");
+PCM_CODEC  (PCM_U32LE,        AV_SAMPLE_FMT_S32, pcm_u32le,        "PCM unsigned 32-bit little-endian");
+PCM_DECODER(PCM_ZORK,         AV_SAMPLE_FMT_U8,  pcm_zork,         "PCM Zork");
+PCM_CODEC  (PCM_S64BE,        AV_SAMPLE_FMT_S64, pcm_s64be,        "PCM signed 64-bit big-endian");
+PCM_CODEC  (PCM_S64LE,        AV_SAMPLE_FMT_S64, pcm_s64le,        "PCM signed 64-bit little-endian");
+PCM_CODEC  (PCM_VIDC,         AV_SAMPLE_FMT_S16, pcm_vidc,         "PCM Archimedes VIDC");

--- a/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/pcm_tablegen.h
+++ b/trunk/3rdparty/ffmpeg-4.2-fit/libavcodec/pcm_tablegen.h
@@ -1,0 +1,143 @@
+/*
+ * Header file for hardcoded PCM tables
+ *
+ * Copyright (c) 2010 Reimar Döffinger <Reimar.Doeffinger@gmx.de>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef AVCODEC_PCM_TABLEGEN_H
+#define AVCODEC_PCM_TABLEGEN_H
+
+#include <stdint.h>
+#include "libavutil/attributes.h"
+
+/* from g711.c by SUN microsystems (unrestricted use) */
+
+#define         SIGN_BIT        (0x80)      /* Sign bit for a A-law byte. */
+#define         QUANT_MASK      (0xf)       /* Quantization field mask. */
+#define         NSEGS           (8)         /* Number of A-law segments. */
+#define         SEG_SHIFT       (4)         /* Left shift for segment number. */
+#define         SEG_MASK        (0x70)      /* Segment field mask. */
+
+#define         BIAS            (0x84)      /* Bias for linear code. */
+
+#define         VIDC_SIGN_BIT    (1)
+#define         VIDC_QUANT_MASK  (0x1E)
+#define         VIDC_QUANT_SHIFT (1)
+#define         VIDC_SEG_SHIFT   (5)
+#define         VIDC_SEG_MASK    (0xE0)
+
+/* alaw2linear() - Convert an A-law value to 16-bit linear PCM */
+static av_cold int alaw2linear(unsigned char a_val)
+{
+        int t;
+        int seg;
+
+        a_val ^= 0x55;
+
+        t = a_val & QUANT_MASK;
+        seg = ((unsigned)a_val & SEG_MASK) >> SEG_SHIFT;
+        if(seg) t= (t + t + 1 + 32) << (seg + 2);
+        else    t= (t + t + 1     ) << 3;
+
+        return (a_val & SIGN_BIT) ? t : -t;
+}
+
+static av_cold int ulaw2linear(unsigned char u_val)
+{
+        int t;
+
+        /* Complement to obtain normal u-law value. */
+        u_val = ~u_val;
+
+        /*
+         * Extract and bias the quantization bits. Then
+         * shift up by the segment number and subtract out the bias.
+         */
+        t = ((u_val & QUANT_MASK) << 3) + BIAS;
+        t <<= ((unsigned)u_val & SEG_MASK) >> SEG_SHIFT;
+
+        return (u_val & SIGN_BIT) ? (BIAS - t) : (t - BIAS);
+}
+
+static av_cold int vidc2linear(unsigned char u_val)
+{
+        int t;
+
+        /*
+         * Extract and bias the quantization bits. Then
+         * shift up by the segment number and subtract out the bias.
+         */
+        t = (((u_val & VIDC_QUANT_MASK) >> VIDC_QUANT_SHIFT) << 3) + BIAS;
+        t <<= ((unsigned)u_val & VIDC_SEG_MASK) >> VIDC_SEG_SHIFT;
+
+        return (u_val & VIDC_SIGN_BIT) ? (BIAS - t) : (t - BIAS);
+}
+
+#if CONFIG_HARDCODED_TABLES
+#define pcm_alaw_tableinit()
+#define pcm_ulaw_tableinit()
+#define pcm_vidc_tableinit()
+#include "libavcodec/pcm_tables.h"
+#else
+/* 16384 entries per table */
+static uint8_t linear_to_alaw[16384];
+static uint8_t linear_to_ulaw[16384];
+static uint8_t linear_to_vidc[16384];
+
+static av_cold void build_xlaw_table(uint8_t *linear_to_xlaw,
+                             int (*xlaw2linear)(unsigned char),
+                             int mask)
+{
+    int i, j, v, v1, v2;
+
+    j = 1;
+    linear_to_xlaw[8192] = mask;
+    for(i=0;i<127;i++) {
+        v1 = xlaw2linear(i ^ mask);
+        v2 = xlaw2linear((i + 1) ^ mask);
+        v = (v1 + v2 + 4) >> 3;
+        for(;j<v;j+=1) {
+            linear_to_xlaw[8192 - j] = (i ^ (mask ^ 0x80));
+            linear_to_xlaw[8192 + j] = (i ^ mask);
+        }
+    }
+    for(;j<8192;j++) {
+        linear_to_xlaw[8192 - j] = (127 ^ (mask ^ 0x80));
+        linear_to_xlaw[8192 + j] = (127 ^ mask);
+    }
+    linear_to_xlaw[0] = linear_to_xlaw[1];
+}
+
+static void pcm_alaw_tableinit(void)
+{
+    build_xlaw_table(linear_to_alaw, alaw2linear, 0xd5);
+}
+
+static void pcm_ulaw_tableinit(void)
+{
+    build_xlaw_table(linear_to_ulaw, ulaw2linear, 0xff);
+}
+
+static void pcm_vidc_tableinit(void)
+{
+    build_xlaw_table(linear_to_vidc, vidc2linear, 0xff);
+}
+#endif /* CONFIG_HARDCODED_TABLES */
+
+#endif /* AVCODEC_PCM_TABLEGEN_H */

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -637,7 +637,8 @@ if [[ $SRS_FFMPEG_FIT == YES ]]; then
               --disable-d3d11va --disable-dxva2 --disable-ffnvcodec --disable-nvdec --disable-nvenc --disable-v4l2-m2m --disable-vaapi \
               --disable-vdpau --disable-appkit --disable-coreimage --disable-avfoundation --disable-securetransport --disable-iconv \
               --disable-lzma --disable-sdl2 --disable-everything --enable-decoder=aac --enable-decoder=aac_fixed --enable-decoder=aac_latm \
-              --enable-decoder=libopus --enable-encoder=aac --enable-encoder=opus --enable-encoder=libopus --enable-libopus &&
+              --enable-decoder=libopus --enable-encoder=aac --enable-encoder=opus --enable-encoder=libopus --enable-libopus \
+              --enable-decoder=pcm_alaw --enable-encoder=pcm_alaw --enable-decoder=pcm_mulaw --enable-encoder=pcm_mulaw &&
             make ${SRS_JOBS} && make install &&
             cd .. && rm -rf ffmpeg && ln -sf ffmpeg-4.2-fit/${SRS_PLATFORM}/_release ffmpeg
         )

--- a/trunk/src/app/srs_app_gb28181.cpp
+++ b/trunk/src/app/srs_app_gb28181.cpp
@@ -2023,7 +2023,7 @@ srs_error_t SrsGb28181RtmpMuxer::on_rtp_audio(SrsSimpleStream* stream, int64_t f
                 if (ptr_audio) {
                     memcpy(ptr_audio, stream->bytes(), stream->length());
                     err = transcode(ptr_audio, num_audio, dts);
-                    srs_freep(ptr_audio);
+                    srs_freepa(ptr_audio);
                 }
                 return err;
             }

--- a/trunk/src/app/srs_app_gb28181.hpp
+++ b/trunk/src/app/srs_app_gb28181.hpp
@@ -111,10 +111,10 @@ class SrsGb28181Caster;
 #define GB28181_TRANSCODE_G711_TO_AAC 1
 
 #if defined(SRS_FFMPEG_FIT) && defined(GB28181_TRANSCODE_G711_TO_AAC)
-// An G711 packet may be transcoded to many AAC packets.
-const int kMaxAacPackets = 8;
+// A G711 packet may be transcoded to many AAC packets.
+const int kMaxAacPackets = 4;
 // The max size for each AAC packet.
-const int kMaxAacPacketSize = 4096;
+const int kMaxAacPacketSize = 2048;
 class SrsAudioTranscoder;
 #endif
 
@@ -348,6 +348,8 @@ private:
     char *ps_buffer_audio;
 #if defined(SRS_FFMPEG_FIT) && defined(GB28181_TRANSCODE_G711_TO_AAC)
     SrsAudioTranscoder* transcoder;
+    // Here doesn't use static buffer like opus_payloads, because there is a very long process
+    // after write_audio_raw_frame and we can't ensure there is no state thread switch.
     char* aac_payloads[kMaxAacPackets];
 #endif
 

--- a/trunk/src/app/srs_app_gb28181.hpp
+++ b/trunk/src/app/srs_app_gb28181.hpp
@@ -107,6 +107,17 @@ class SrsResourceManager;
 class SrsGb28181Conn;
 class SrsGb28181Caster;
 
+// comment it (means undef) if you don't want to transcode G711 to AAC in GB28181
+#define GB28181_TRANSCODE_G711_TO_AAC 1
+
+#if defined(SRS_FFMPEG_FIT) && defined(GB28181_TRANSCODE_G711_TO_AAC)
+// An G711 packet may be transcoded to many AAC packets.
+const int kMaxAacPackets = 8;
+// The max size for each AAC packet.
+const int kMaxAacPacketSize = 4096;
+class SrsAudioTranscoder;
+#endif
+
 //ps rtp header packet parse
 
 class SrsPsRtpPacket: public SrsRtpPacket
@@ -335,6 +346,10 @@ private:
 
     char *ps_buffer;
     char *ps_buffer_audio;
+#if defined(SRS_FFMPEG_FIT) && defined(GB28181_TRANSCODE_G711_TO_AAC)
+    SrsAudioTranscoder* transcoder;
+    char* aac_payloads[kMaxAacPackets];
+#endif
 
     int ps_buflen;
     int ps_buflen_auido;
@@ -392,6 +407,9 @@ private:
     virtual srs_error_t write_h264_sps_pps(uint32_t dts, uint32_t pts);
     virtual srs_error_t write_h264_ipb_frame(char* frame, int frame_size, uint32_t dts, uint32_t pts, bool b = true);
     virtual srs_error_t write_audio_raw_frame(char* frame, int frame_size, SrsRawAacStreamCodec* codec, uint32_t dts);
+#if defined(SRS_FFMPEG_FIT) && defined(GB28181_TRANSCODE_G711_TO_AAC)
+    virtual srs_error_t transcode(char* ptr_audio, int num_audio, uint32_t dts);
+#endif
     virtual srs_error_t rtmp_write_packet(char type, uint32_t timestamp, char* data, int size);
     virtual srs_error_t rtmp_write_packet_by_source(char type, uint32_t timestamp, char* data, int size);
 private:

--- a/trunk/src/app/srs_app_rtc_codec.cpp
+++ b/trunk/src/app/srs_app_rtc_codec.cpp
@@ -291,7 +291,7 @@ srs_error_t SrsAudioEncoder::encode(AVFrame *resampled_frame, int &used_samples,
     } else if (ret < 0) {
         char error_buf[1024];
         av_strerror(ret, error_buf, sizeof(error_buf) - 1);
-        return srs_error_new(ERROR_RTC_RTP_MUXER, "Error during decoding: %s", error_buf);
+        return srs_error_new(ERROR_RTC_RTP_MUXER, "Error during encoding: %s", error_buf);
     }
 
     // av_packet_unref(*encoded_packet) outside

--- a/trunk/src/app/srs_app_rtc_codec.cpp
+++ b/trunk/src/app/srs_app_rtc_codec.cpp
@@ -268,9 +268,9 @@ srs_error_t SrsAudioEncoder::encode(AVFrame *resampled_frame, int &used_samples,
                                  codec_ctx_->frame_size - left_samples : resampled_frame->nb_samples - used_samples;
             int pcm_size = av_get_bytes_per_sample(codec_ctx_->sample_fmt);
             if (!av_sample_fmt_is_planar(codec_ctx_->sample_fmt)) {
-               memcpy(frame_->data[0] + left_samples * codec_ctx_->channels * pcm_size,
-                      resampled_frame->data[0] + used_samples * codec_ctx_->channels * pcm_size,
-                      filled_samples * codec_ctx_->channels * pcm_size);
+                memcpy(frame_->data[0] + left_samples * codec_ctx_->channels * pcm_size,
+                       resampled_frame->data[0] + used_samples * codec_ctx_->channels * pcm_size,
+                       filled_samples * codec_ctx_->channels * pcm_size);
             } else {
                 for (int i = 0; i < codec_ctx_->channels; i++) {
                     memcpy(frame_->data[i] + left_samples * pcm_size,

--- a/trunk/src/app/srs_app_rtc_codec.hpp
+++ b/trunk/src/app/srs_app_rtc_codec.hpp
@@ -122,7 +122,7 @@ public:
     SrsAudioTranscoder(SrsAudioCodecId src_codec, int src_channels, int src_samplerate, SrsAudioCodecId dst_codec, int dst_channels, int dst_samplerate);
     virtual ~SrsAudioTranscoder();
     srs_error_t initialize();
-    virtual srs_error_t transcode(SrsSample *pkt, char **buf_array, int *len_array, int buf_array_max, int buf_max_size, int &n);
+    virtual srs_error_t transcode(SrsSample *pkt, char **buf_array, int *len_array, int buf_array_size, int buf_max_size, int &n);
 };
 
 #endif /* SRS_APP_RTC_CODEC_HPP */

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -777,7 +777,7 @@ srs_error_t SrsRtcFromRtmpBridger::on_audio(SrsSharedPtrMessage* msg)
         g711_raw_data(msg, format, &adts_audio, &nn_adts_audio);
         if (adts_audio) {
             err = transcode(adts_audio, nn_adts_audio);
-            srs_freep(adts_audio);
+            srs_freepa(adts_audio);
         }
         return err;
     }
@@ -789,7 +789,7 @@ srs_error_t SrsRtcFromRtmpBridger::on_audio(SrsSharedPtrMessage* msg)
 
     if (adts_audio) {
         err = transcode(adts_audio, nn_adts_audio);
-        srs_freep(adts_audio);
+        srs_freepa(adts_audio);
     }
 
     return err;

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -37,6 +37,7 @@
 #include <srs_service_st.hpp>
 #include <srs_app_source.hpp>
 #include <srs_kernel_rtc_rtp.hpp>
+#include <srs_kernel_codec.hpp>
 
 class SrsRequest;
 class SrsMetaCache;
@@ -45,7 +46,7 @@ class SrsCommonMessage;
 class SrsMessageArray;
 class SrsRtcStream;
 class SrsRtcFromRtmpBridger;
-class SrsAudioRecode;
+class SrsAudioTranscoder;
 class SrsRtpPacket2;
 class SrsSample;
 class SrsRtcStreamDescription;
@@ -223,6 +224,11 @@ public:
 };
 
 #ifdef SRS_FFMPEG_FIT
+// An AAC packet may be transcoded to many OPUS packets.
+const int kMaxOpusPackets = 8;
+// The max size for each OPUS packet.
+const int kMaxOpusPacketSize = 4096;
+
 class SrsRtcFromRtmpBridger : public ISrsSourceBridger
 {
 private:
@@ -234,7 +240,9 @@ private:
     SrsMetaCache* meta;
 private:
     bool discard_aac;
-    SrsAudioRecode* codec;
+    SrsAudioTranscoder* codec;
+    char* opus_payloads[kMaxOpusPackets];
+    SrsAudioCodecConfig codec_info;
     bool discard_bframe;
     bool merge_nalus;
     uint32_t audio_timestamp;

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -224,11 +224,6 @@ public:
 };
 
 #ifdef SRS_FFMPEG_FIT
-// An AAC packet may be transcoded to many OPUS packets.
-const int kMaxOpusPackets = 8;
-// The max size for each OPUS packet.
-const int kMaxOpusPacketSize = 4096;
-
 class SrsRtcFromRtmpBridger : public ISrsSourceBridger
 {
 private:
@@ -241,7 +236,6 @@ private:
 private:
     bool discard_aac;
     SrsAudioTranscoder* codec;
-    char* opus_payloads[kMaxOpusPackets];
     SrsAudioCodecConfig codec_info;
     bool discard_bframe;
     bool merge_nalus;

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -779,7 +779,7 @@ private:
     //          Demux the asc from sequence header.
     //          Demux the sampels from RAW data.
     virtual srs_error_t audio_aac_demux(SrsBuffer* stream, int64_t timestamp);
-    virtual srs_error_t audio_mp3_demux(SrsBuffer* stream, int64_t timestamp);
+    virtual srs_error_t audio_other_demux(SrsBuffer* stream, int64_t timestamp);
 public:
     // Directly demux the sequence header, without RTMP packet header.
     virtual srs_error_t audio_aac_sequence_header_demux(char* data, int size);


### PR DESCRIPTION
G711 support and new RTC transcoder
1. GB28181: Transcode G711 to AAC before sending to SRS by RTMP. You can disable it by undefining GB28181_TRANSCODE_G711_TO_AAC in srs_app_gb28181.hpp.
2. WebRTC: Transcode G711 to OPUS.
ffmpeg -re -i test.flv -acodec pcm_mulaw -ac 1 -ar 8000 -vcodec copy -f flv -y rtmp://xx.xx.xx.xx/live/test_stream
3. WebRTC: New RTC transcoder; Support changing audio codec of the same URL.
4. New added PCM encoder and decoder files are from ffmpeg 4.2.2, because I don't know the exact version of ffmpeg-4.2-fit. Please delete objs/Platform-Linux-XXX directory and reconfigure your project to rebuild ffmpeg.