### PR TITLE
fixed frame loss when time_jitter is off

### DIFF
--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -269,7 +269,9 @@ srs_error_t SrsMessageQueue::enqueue(SrsSharedPtrMessage* msg, bool* is_overflow
 {
     srs_error_t err = srs_success;
     
-    if (msg->is_av()) {
+    // maybe the SH timestamp much short than A/V packet,
+    // shrink does not contain SH
+    if ((msg->is_audio() && !SrsFlvAudio::sh(msg->payload, msg->size)) || (msg->is_video() && !SrsFlvVideo::sh(msg->payload, msg->size))) {
         if (av_start_time == -1) {
             av_start_time = srs_utime_t(msg->timestamp * SRS_UTIME_MILLISECONDS);
         }


### PR DESCRIPTION
**描述(Description)**

1. SRS版本(Version): `3.0release分支`
1. SRS的日志如下(Log):
```
shrinking, size=2, removed=2, max=30000ms
dispatch cached gop success. count=49, duration=-1
create consumer, active=1, queue_size=0.00, jitter=30000000
```
1. SRS的配置如下(Config):
```
vhost __defaultVhost__ {
    time_jitter     off;
}
```

**重现(Replay)**

> 重现Bug的步骤(How to replay bug?)

1. 配置time_jitter  off;
2. 推流
3. 30s后，使用ffplay播放，前2s有明显的音画不同步，画面播放慢的现象。

**问题**
1. 有消费者时，srs会发送：metadata->audio sequence header->video sequence header->gop cache->...
2. sequence header时间戳通常为0。在关闭时间校准后，在gop cache放入SrsMessageQueue时，判断队列中的duration已经超过30s了，就会丢弃第一个帧（通常为视频关键帧）。

**修复**
在SrsMessageQueue计算队列中数据累计时长时，排查sequence header