### PR TITLE
Rtc rtmp

### DIFF
--- a/trunk/conf/push.gb28181.conf
+++ b/trunk/conf/push.gb28181.conf
@@ -2,11 +2,19 @@
 
 listen                  1935;
 max_connections         1000;
+srs_log_file            ./objs/srs_gb28181.log;
+srs_log_tank            console;
+daemon                  off;
 
 http_api {
     enabled         on;
     listen          1985;
 }   
+
+http_server {
+    enabled         on;
+    listen          8080;
+}
 
 stats {
     network         0;
@@ -27,7 +35,7 @@ stream_caster {
     listen              9000;
     # 多路复用端口类型，on为tcp，off为udp
     # 默认：off
-    tcp_enable            on;
+    tcp_enable            off;
 
     # rtp接收监听端口范围，最小值
     rtp_port_min        58200;
@@ -109,5 +117,26 @@ stream_caster {
         query_catalog_interval  60;
     }
 }
+rtc_server {
+    enabled         on;
+    # Listen at udp://8000
+    listen          8000;
+    #
+    # The $CANDIDATE means fetch from env, if not configed, use * as default.
+    #
+    # The * means retrieving server IP automatically, from all network interfaces,
+    # @see https://github.com/ossrs/srs/issues/307#issuecomment-599028124
+    candidate       $CANDIDATE;
+}
+
 vhost __defaultVhost__ {
+    rtc {
+        enabled     on;
+        bframe      discard;
+    }
+
+    http_remux {
+        enabled     on;
+        mount       [vhost]/[app]/[stream].flv;
+    }
 }

--- a/trunk/conf/rtc_rtmp.conf
+++ b/trunk/conf/rtc_rtmp.conf
@@ -11,7 +11,7 @@ http_server {
     dir             ./research/players;
 
     https {
-        enabled on;
+        enabled off;
         listen 443;
         key ./conf/server.key;
         cert ./conf/server.crt;
@@ -23,7 +23,7 @@ http_api {
     enabled         on;
     listen          1985;
     https {
-        enabled on;
+        enabled off;
         listen 443;
         key ./conf/server.key;
         cert ./conf/server.crt;
@@ -47,7 +47,7 @@ rtc_server {
         enabled on;
         output  rtmp://127.0.0.1:1935/[app]/[stream];
         audio_enable off;
-        audio_foramt opus;
+        audio_foramt rtp;
         req_keyframe   0; 
         keyframe_interval_print 10;
     }
@@ -57,6 +57,20 @@ vhost __defaultVhost__ {
     rtc {
         enabled     on;
         bframe      discard;
+    }
+
+    http_remux {
+        enabled     on;
+        mount       [vhost]/[app]/[stream].flv;
+    }
+
+    tcp_nodelay     on
+    min_latency     on;
+
+    play {
+        gop_cache       off;
+        queue_length    10;
+        mw_latency      100;
     }
 }
 

--- a/trunk/conf/rtc_rtmp.conf
+++ b/trunk/conf/rtc_rtmp.conf
@@ -1,0 +1,62 @@
+
+listen              1935;
+max_connections     1000;
+srs_log_file        ./objs/srs.log;
+srs_log_tank        console;
+daemon              off;
+
+http_server {
+    enabled         on;
+    listen          8080;
+    dir             ./research/players;
+
+    https {
+        enabled on;
+        listen 443;
+        key ./conf/server.key;
+        cert ./conf/server.crt;
+    }
+    
+}
+
+http_api {
+    enabled         on;
+    listen          1985;
+    https {
+        enabled on;
+        listen 443;
+        key ./conf/server.key;
+        cert ./conf/server.crt;
+    }
+}
+stats {
+    network         0;
+}
+rtc_server {
+    enabled         on;
+    # Listen at udp://8000
+    listen          8000;
+    #
+    # The $CANDIDATE means fetch from env, if not configed, use * as default.
+    #
+    # The * means retrieving server IP automatically, from all network interfaces,
+    # @see https://github.com/ossrs/srs/issues/307#issuecomment-599028124
+    candidate       $CANDIDATE;
+
+    rtmp {
+        enabled on;
+        output  rtmp://127.0.0.1:1935/[app]/[stream];
+        audio_enable off;
+        audio_foramt opus;
+        req_keyframe   0; 
+        keyframe_interval_print 10;
+    }
+}
+
+vhost __defaultVhost__ {
+    rtc {
+        enabled     on;
+        bframe      discard;
+    }
+}
+

--- a/trunk/conf/rtc_rtmp.conf
+++ b/trunk/conf/rtc_rtmp.conf
@@ -46,7 +46,7 @@ rtc_server {
     rtmp {
         enabled on;
         output  rtmp://127.0.0.1:1935/[app]/[stream];
-        audio_enable off;
+        audio_enabled off;
         audio_foramt rtp;
         req_keyframe   0; 
         keyframe_interval_print 10;

--- a/trunk/configure
+++ b/trunk/configure
@@ -196,6 +196,11 @@ if [[ $SRS_RTC == YES && $SRS_NASM == NO && $SRS_OSX == NO ]]; then
     SrsLinkOptions="${SrsLinkOptions} -lrt";
 fi
 
+# For gb28181 mac os
+if [[ $SRS_GB28181 == YES && $SRS_OSX == YES ]]; then
+    SrsLinkOptions+="  -L/usr/local/lib -liconv"
+fi
+
 #####################################################################################
 # Modules, compile each module, then link to binary
 #
@@ -238,6 +243,11 @@ fi
 if [[ $SRS_GB28181 == YES ]]; then
     MODULE_FILES+=("srs_sip_stack")
 fi
+
+if [[ $SRS_GB28181 == YES && $SRS_OSX == YES ]]; then
+    ModuleLibIncs+="  -I/usr/local/include/"
+fi
+
 if [[ $SRS_FFMPEG_FIT == YES ]]; then
     ModuleLibIncs+=("${LibFfmpegRoot[*]}")
 fi
@@ -281,14 +291,20 @@ MODULE_FILES=("srs_app_server" "srs_app_conn" "srs_app_rtmp_conn" "srs_app_sourc
         "srs_app_coworkers" "srs_app_hybrid")
 if [[ $SRS_RTC == YES ]]; then
     MODULE_FILES+=("srs_app_rtc_conn" "srs_app_rtc_dtls" "srs_app_rtc_sdp"
-        "srs_app_rtc_queue" "srs_app_rtc_server" "srs_app_rtc_source" "srs_app_rtc_api")
+        "srs_app_rtc_queue" "srs_app_rtc_server" "srs_app_rtc_source" "srs_app_rtc_api"
+	"srs_app_rtc_rtp_rtmp")
 fi
 if [[ $SRS_FFMPEG_FIT == YES ]]; then
     MODULE_FILES+=("srs_app_rtc_codec")
 fi
 if [[ $SRS_GB28181 == YES ]]; then
-    MODULE_FILES+=("srs_app_gb28181" "srs_app_gb28181_sip" "srs_app_gb28181_jitbuffer")
+    MODULE_FILES+=("srs_app_gb28181" "srs_app_gb28181_sip")
 fi
+
+if [[ $SRS_GB28181 == YES || $SRS_RTC == YES ]]; then
+    MODULE_FILES+=("srs_app_rtc_rtp_jitbuffer")
+fi
+
 DEFINES=""
 # add each modules for app
 for SRS_MODULE in ${SRS_MODULES[*]}; do

--- a/trunk/research/players/srs_gb28181.html
+++ b/trunk/research/players/srs_gb28181.html
@@ -122,7 +122,7 @@
                   当前通道:<a id="gb28181ChannelId"></a>
                   <div>
                     <textarea class="span6" id="txt_rtmp_url" rows="2"></textarea>
-                    <button class="btn btn-primary" id="btn_play">RTMP播放</button>
+                    <button class="btn btn-primary" id="btn_play">FLV播放</button>
                      
                   </div>
                   <div>
@@ -141,187 +141,17 @@
       </div>
 
       <div id="main_content" class="hide">
-        <div id="link_modal" class="modal hide fade">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-                <h3><a href="https://github.com/ossrs/srs">SRS Link Generator</a></h3>
-            </div>
-            <div class="modal-body">
-                <div class="form-horizontal">
-                    <div class="control-group">
-                        <label class="control-label" for="link_server">服务器地址</label>
-                        <div class="controls">
-                            <span id="link_server" class="span4 uneditable-input"></span>
-                        </div>
-                    </div>
-                    <div class="control-group">
-                        <label class="control-label" for="link_port">服务器端口</label>
-                        <div class="controls">
-                            <span id="link_port" class="span2 uneditable-input"></span>
-                        </div>
-                    </div>
-                    <div class="control-group">
-                        <label class="control-label" for="link_vhost">RTMP Vhost</label>
-                        <div class="controls">
-                            <span id="link_vhost" class="span4 uneditable-input"></span>
-                        </div>
-                    </div>
-                    <div class="control-group">
-                        <label class="control-label" for="link_app">RTMP App</label>
-                        <div class="controls">
-                            <span id="link_app" class="span4 uneditable-input"></span>
-                        </div>
-                    </div>
-                    <div class="control-group">
-                        <label class="control-label" for="link_stream">RTMP Stream</label>
-                        <div class="controls">
-                            <span id="link_stream" class="span4 uneditable-input"></span>
-                        </div>
-                    </div>
-                    <div class="control-group">
-                        <label class="control-label" for="link_rtmp">RTMP地址</label>
-                        <div class="controls">
-                            <span id="link_rtmp" class="span4 uneditable-input"></span>
-                        </div>
-                    </div>
-                    <div class="control-group">
-                        <label class="control-label" for="link_url">播放链接地址</label>
-                        <div class="controls">
-                            <div style="margin-top:5px;"><a href="#" id="link_url" target="_blank">请右键拷贝此链接地址.</a></div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer"></div>
-        </div>
-
         <div id="main_modal" class="modal hide fade">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-                <h3><a href="https://github.com/ossrs/srs">SrsPlayer</a></h3>
+                <h3><a href="https://github.com/ossrs/srs">SrsFlvPlayer</a></h3>
             </div>
             <div class="modal-body">
-                <div id="player"></div>
-                <div class="progress progress-striped active" id="pb_buffer_bg">
-                    <div class="bar" style="width: 0%;" id="pb_buffer"></div>
+                <div>
+                    <video id="video_player" width="98%" autoplay controls></video>
                 </div>
             </div>
             <div class="modal-footer" id="my_modal_footer">
-                <div>
-                    <div class="btn-group dropup">
-                        <button class="btn dropdown-toggle" data-toggle="dropdown">
-                            全屏比例大小<span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu">
-                            <li><a id="btn_fs_size_screen_100" href="#">屏幕大小(100%)</a></li>
-                            <li><a id="btn_fs_size_screen_75" href="#">屏幕大小(75%)</a></li>
-                            <li><a id="btn_fs_size_screen_50" href="#">屏幕大小(50%)</a></li>
-                            <li><a id="btn_fs_size_video_100" href="#">视频大小(100%)</a></li>
-                            <li><a id="btn_fs_size_video_75" href="#">视频大小(75%)</a></li>
-                            <li><a id="btn_fs_size_video_50" href="#">视频大小(50%)</a></li>
-                        </ul>
-                    </div>
-                    <div class="btn-group dropup">
-                        <button class="btn dropdown-toggle" data-toggle="dropdown">显示比例<span class="caret"></span></button>
-                        <ul class="dropdown-menu">
-                            <li><a id="btn_dar_original" href="#">视频原始比例</a></li>
-                            <li><a id="btn_dar_21_9" href="#">宽屏影院(21:9)</a></li>
-                            <li><a id="btn_dar_16_9" href="#">宽屏电视(16:9)</a></li>
-                            <li><a id="btn_dar_4_3" href="#">窄屏(4:3)</a></li>
-                            <li><a id="btn_dar_fill" href="#">填充(容器比例)</a></li>
-                        </ul>
-                    </div>
-                    <div class="btn-group dropup">
-                        <button class="btn dropdown-toggle" data-toggle="dropdown">缓冲区大小<span class="caret"></span></button>
-                        <ul class="dropdown-menu">
-                            <li><a id="btn_bt_0_1" href="#">0.1秒(实时)</a></li>
-                            <li><a id="btn_bt_0_2" href="#">0.2秒(实时)</a></li>
-                            <li><a id="btn_bt_0_3" href="#">0.3秒(实时)</a></li>
-                            <li><a id="btn_bt_0_5" href="#">0.5秒(实时)</a></li>
-                            <li><a id="btn_bt_0_8" href="#">0.8秒(会议)</a></li>
-                            <li><a id="btn_bt_1_0" href="#">1秒(低延迟)</a></li>
-                            <li><a id="btn_bt_2_0" href="#">2秒(较低延时)</a></li>
-                            <li><a id="btn_bt_3_0" href="#">3秒(流畅播放)</a></li>
-                            <li><a id="btn_bt_4_0" href="#">4秒(流畅播放)</a></li>
-                            <li><a id="btn_bt_5_0" href="#">5秒(网速较低)</a></li>
-                            <li><a id="btn_bt_6_0" href="#">6秒(网速较低)</a></li>
-                            <li><a id="btn_bt_8_0" href="#">8秒(网速较低)</a></li>
-                            <li><a id="btn_bt_10_0" href="#">10秒(无所谓延迟)</a></li>
-                            <li><a id="btn_bt_15_0" href="#">15秒(无所谓延迟)</a></li>
-                            <li><a id="btn_bt_20_0" href="#">20秒(无所谓延迟)</a></li>
-                            <li><a id="btn_bt_30_0" href="#">30秒(流畅第一)</a></li>
-                        </ul>
-                    </div>
-                    <div class="btn-group dropup">
-                        <button class="btn dropdown-toggle" data-toggle="dropdown">最大缓冲区<span class="caret"></span></button>
-                        <ul class="dropdown-menu">
-                            <li><a id="btn_mbt_0_6" href="#">0.6秒(实时)</a></li>
-                            <li><a id="btn_mbt_0_9" href="#">0.9秒(实时)</a></li>
-                            <li><a id="btn_mbt_1_2" href="#">1.2秒(实时)</a></li>
-                            <li><a id="btn_mbt_1_5" href="#">1.5秒(实时)</a></li>
-                            <li><a id="btn_mbt_2_4" href="#">2.4秒(会议)</a></li>
-                            <li><a id="btn_mbt_3_0" href="#">3秒(低延迟)</a></li>
-                            <li><a id="btn_mbt_6_0" href="#">6秒(较低延时)</a></li>
-                            <li><a id="btn_mbt_9_0" href="#">9秒(流畅播放)</a></li>
-                            <li><a id="btn_mbt_12_0" href="#">12秒(流畅播放)</a></li>
-                            <li><a id="btn_mbt_15_0" href="#">15秒(网速较低)</a></li>
-                            <li><a id="btn_mbt_18_0" href="#">18秒(网速较低)</a></li>
-                            <li><a id="btn_mbt_24_0" href="#">24秒(网速较低)</a></li>
-                            <li><a id="btn_mbt_30_0" href="#">30秒(无所谓延迟)</a></li>
-                            <li><a id="btn_mbt_45_0" href="#">45秒(无所谓延迟)</a></li>
-                            <li><a id="btn_mbt_60_0" href="#">60秒(无所谓延迟)</a></li>
-                            <li><a id="btn_mbt_90_0" href="#">90秒(流畅第一)</a></li>
-                        </ul>
-                    </div>
-                    <div class="btn-group dropup">
-                        <a id="btn_fullscreen" class="btn">全屏</a>
-                    </div>
-                    <div class="btn-group dropup">
-                        <button id="btn_pause" class="btn">暂停播放</button>
-                        <button id="btn_resume" class="btn hide">继续播放</button>
-                    </div>
-                    <div class="btn-group dropup">
-                        <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">关闭播放器</button>
-                    </div>
-                </div>
-                <div class="hide" id="fullscreen_tips">
-                    请<font color="red">点击视频</font>进入全屏模式~<br/>
-                    由于安全原因，Flash全屏无法使用JS触发
-                </div>
-                <div>
-                    <div class="input-prepend div_play_time" title="BufferLength/BufferTime/MaxBufferTime">
-                        <span class="add-on">@B</span>
-                        <input class="span2" style="width:80px" id="txt_buffer" type="text" placeholder="0/0/0s">
-                    </div>
-                    <div class="input-prepend div_play_time" title="视频的播放流畅度">
-                        <span class="add-on">@F</span>
-                        <input class="span2" style="width:57px" id="txt_fluency" type="text" placeholder="100%">
-                    </div>
-                    <div class="input-prepend div_play_time" title="视频总共卡顿次数">
-                        <span class="add-on">@E</span>
-                        <input class="span2" style="width:45px" id="txt_empty_count" type="text" placeholder="0">
-                    </div>
-                    <div class="input-prepend div_play_time" title="视频当前的帧率FPS">
-                        <span class="add-on">@F</span>
-                        <input class="span2" style="width:55px" id="txt_fps" type="text" placeholder="fps">
-                    </div>
-                    <div class="input-prepend div_play_time" title="视频当前的码率(视频+音频)，单位：Kbps">
-                        <span class="add-on">@B</span>
-                        <input class="span2" style="width:55px" id="txt_bitrate" type="text" placeholder="kbps">
-                    </div>
-                    <div class="input-prepend div_play_time" title="播放时长，格式：天 时:分:秒">
-                        <span class="add-on">@T</span>
-                        <input class="span2" style="width:85px" id="txt_time" type="text" placeholder="天 时:分:秒">
-                    </div>
-                </div>
-                <div style="margin-top:-12px;">
-                    <span id="debug_info"></span>
-                    URL: <a href="#" id="player_url"></a>
-                    <div class="input-prepend div_play_time" title="当前时间：年-月-日 时:分:秒">
-                        <span class="add-on">@N</span>
-                        <input class="span2" style="width:135px" id="player_clock" type="text" placeholder="年-月-日 时:分:秒">
-                    </div>
-                </div>
                 <div>
                     <div class="btn-group dropup">
                         <button class="btn btn-primary" id="btn_ptz_up"> 上↑ </button>
@@ -332,12 +162,7 @@
                         <button class="btn btn-primary" id="btn_ptz_zoomout"> 缩小－ </button>
                     </div>    
                     [注意] !!! 云台控制需要启用内部sip功能
-                    <div class="input-prepend" title="首播时间，点播放到开始播放的时间，秒">
-                        <span class="add-on">@PST</span>
-                        <input class="span1" style="width:60px" id="txt_pst" type="text" placeholder="N秒">
-                    </div>
                 </div>
-              
             </div>
         </div>
 
@@ -410,54 +235,17 @@
 </body>
 <script type="text/javascript" src="js/jquery-1.10.2.min.js"></script>
 <script type="text/javascript" src="js/bootstrap.min.js"></script>
-<script type="text/javascript" src="js/swfobject.js"></script>
 <script type="text/javascript" src="js/json2.js"></script>
 <script type="text/javascript" src="js/srs.page.js"></script>
 <script type="text/javascript" src="js/srs.log.js"></script>
-<script type="text/javascript" src="js/srs.player.js"></script>
-<script type="text/javascript" src="js/srs.publisher.js"></script>
 <script type="text/javascript" src="js/srs.utility.js"></script>
 <script type="text/javascript" src="js/winlin.utility.js"></script>
+<script type="text/javascript" src="js/flv-1.5.0.min.js"></script>
+<script type="text/javascript" src="js/hls-0.14.17.min.js"></script>
 <script type="text/javascript">
-    var __on_flash_ready = null;
-
     $(function(){
-        // 探测Flash是否正常启用。
-        $('#main_flash_hdr').html(
-            '\
-            <object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="100%" height="100%"> \
-                <param name="movie" value="srs_player/release/srs_player.swf"> \
-                <param name="quality" value="autohigh"> \
-                <param name="swliveconnect" value="true"> \
-                <param name="allowScriptAccess" value="always"> \
-                <param name="bgcolor" value="#0"> \
-                <param name="allowFullScreen" value="true"> \
-                <param name="wmode" value="opaque"> \
-                <param name="FlashVars" value="log=1"> \
-                <param name="flashvars" value="id=1&on_player_ready=__on_flash_ready"> \
-                <embed src="srs_player/release/srs_player.swf" width="100%" height="100%" \
-                    quality="autohigh" bgcolor="#0" align="middle" allowfullscreen="true" allowscriptaccess="always" \
-                    type="application/x-shockwave-flash" swliveconnect="true" wmode="opaque" \
-                    flashvars="id=1&on_player_ready=__on_flash_ready" \
-                    pluginspage="http://www.macromedia.com/go/getflashplayer"> \
-            </object> \
-            '
-        );
-        $('#main_flash_hdr').show();
-
-        var showFlashHdr = setTimeout(function(){
-            $('#main_flash_alert').show();
-        }, 300);
-
-        __on_flash_ready = function (id) {
-            clearTimeout(showFlashHdr);
-
-            $('#main_flash_alert').hide();
-            $('#main_flash_hdr').hide();
-            $('#main_content').show();
-
-            autoLoadPage();
-        };
+        $('#main_content').show();
+        autoLoadPage();
     });
 </script>
 <script type="text/javascript">
@@ -471,7 +259,6 @@
     } else {
         $("#txt_api_url").val("http://" + query.host + ":1985");
     }
-
     var __active_dar = null;
     function select_dar(dar_id, num, den) {
         srs_player.set_dar(num, den);
@@ -631,13 +418,13 @@
         $('#gb28181ChannelMessage').html(syntaxHighlight(ret)); 
 
         if (ret.code == 0 && ret.data != undefined ) {
-            $("#txt_rtmp_url").val(ret.data.channels[0].rtmp_url);
+            $("#txt_rtmp_url").val(ret.data.channels[0].flv_url);
 
-            ret.data.channels[0].rtmp_url.split("//") 
+            ret.data.channels[0].flv_url.split("//") 
             
-            var urlObject = parse_rtmp_url(ret.data.channels[0].rtmp_url);
-            var werbrtc_url = "webrtc://"+ urlObject.server + "/" + urlObject.app + "/" + urlObject.stream;
-            $("#txt_rtc_url").val(werbrtc_url);
+            //var urlObject = parse_rtmp_url(ret.data.channels[0].rtmp_url);
+            //var werbrtc_url = "webrtc://"+ urlObject.server + "/" + urlObject.app + "/" + urlObject.stream;
+            $("#txt_rtc_url").val(ret.data.channels[0].webrtc_url);
         }
     } 
 
@@ -658,7 +445,293 @@
         //       $("#lab_chlist").text("("+sessionList.length+")");
     }
 
-   
+
+    // Async-await-promise based SRS RTC Player.
+    function SrsRtcPlayerAsync() {
+        var self = {};
+
+        // @see https://github.com/rtcdn/rtcdn-draft
+        // @url The WebRTC url to play with, for example:
+        //      webrtc://r.ossrs.net/live/livestream
+        // or specifies the API port:
+        //      webrtc://r.ossrs.net:11985/live/livestream
+        // or autostart the play:
+        //      webrtc://r.ossrs.net/live/livestream?autostart=true
+        // or change the app from live to myapp:
+        //      webrtc://r.ossrs.net:11985/myapp/livestream
+        // or change the stream from livestream to mystream:
+        //      webrtc://r.ossrs.net:11985/live/mystream
+        // or set the api server to myapi.domain.com:
+        //      webrtc://myapi.domain.com/live/livestream
+        // or set the candidate(ip) of answer:
+        //      webrtc://r.ossrs.net/live/livestream?eip=39.107.238.185
+        // or force to access https API:
+        //      webrtc://r.ossrs.net/live/livestream?schema=https
+        // or use plaintext, without SRTP:
+        //      webrtc://r.ossrs.net/live/livestream?encrypt=false
+        // or any other information, will pass-by in the query:
+        //      webrtc://r.ossrs.net/live/livestream?vhost=xxx
+        //      webrtc://r.ossrs.net/live/livestream?token=xxx
+        self.play = async function(url) {
+            var conf = self.__internal.prepareUrl(url);
+            self.pc.addTransceiver("audio", {direction: "recvonly"});
+            self.pc.addTransceiver("video", {direction: "recvonly"});
+
+            var offer = await self.pc.createOffer();
+            await self.pc.setLocalDescription(offer);
+            var session = await new Promise(function(resolve, reject) {
+                // @see https://github.com/rtcdn/rtcdn-draft
+                var data = {
+                    api: conf.apiUrl, streamurl: conf.streamUrl, clientip: null, sdp: offer.sdp
+                };
+                console.log("Generated offer: ", data);
+
+                $.ajax({
+                    type: "POST", url: conf.apiUrl, data: JSON.stringify(data),
+                    contentType:'application/json', dataType: 'json'
+                }).done(function(data) {
+                    console.log("Got answer: ", data);
+                    if (data.code) {
+                        reject(data); return;
+                    }
+
+                    resolve(data);
+                }).fail(function(reason){
+                    reject(reason);
+                });
+            });
+            await self.pc.setRemoteDescription(
+                new RTCSessionDescription({type: 'answer', sdp: session.sdp})
+            );
+            return session;
+        };
+
+        // Close the publisher.
+        self.close = function() {
+            self.pc.close();
+        };
+
+        // The callback when got remote stream.
+        self.onaddstream = function (event) {};
+
+        // Internal APIs.
+        self.__internal = {
+            defaultPath: '/rtc/v1/play/',
+            prepareUrl: function (webrtcUrl) {
+                var urlObject = self.__internal.parse(webrtcUrl);
+
+                // If user specifies the schema, use it as API schema.
+                var schema = urlObject.user_query.schema;
+                schema = schema ? schema + ':' : window.location.protocol;
+
+                var port = urlObject.port || 1985;
+                if (schema === 'https:') {
+                    port = urlObject.port || 443;
+                }
+
+                // @see https://github.com/rtcdn/rtcdn-draft
+                var api = urlObject.user_query.play || self.__internal.defaultPath;
+                if (api.lastIndexOf('/') !== api.length - 1) {
+                    api += '/';
+                }
+
+                apiUrl = schema + '//' + urlObject.server + ':' + port + api;
+                for (var key in urlObject.user_query) {
+                    if (key !== 'api' && key !== 'play') {
+                        apiUrl += '&' + key + '=' + urlObject.user_query[key];
+                    }
+                }
+                // Replace /rtc/v1/play/&k=v to /rtc/v1/play/?k=v
+                var apiUrl = apiUrl.replace(api + '&', api + '?');
+
+                var streamUrl = urlObject.url;
+
+                return {apiUrl: apiUrl, streamUrl: streamUrl, schema: schema, urlObject: urlObject, port: port};
+            },
+            parse: function (url) {
+                // @see: http://stackoverflow.com/questions/10469575/how-to-use-location-object-to-parse-url-without-redirecting-the-page-in-javascri
+                var a = document.createElement("a");
+                a.href = url.replace("rtmp://", "http://")
+                    .replace("webrtc://", "http://")
+                    .replace("rtc://", "http://");
+
+                var vhost = a.hostname;
+                var app = a.pathname.substr(1, a.pathname.lastIndexOf("/") - 1);
+                var stream = a.pathname.substr(a.pathname.lastIndexOf("/") + 1);
+
+                // parse the vhost in the params of app, that srs supports.
+                app = app.replace("...vhost...", "?vhost=");
+                if (app.indexOf("?") >= 0) {
+                    var params = app.substr(app.indexOf("?"));
+                    app = app.substr(0, app.indexOf("?"));
+
+                    if (params.indexOf("vhost=") > 0) {
+                        vhost = params.substr(params.indexOf("vhost=") + "vhost=".length);
+                        if (vhost.indexOf("&") > 0) {
+                            vhost = vhost.substr(0, vhost.indexOf("&"));
+                        }
+                    }
+                }
+
+                // when vhost equals to server, and server is ip,
+                // the vhost is __defaultVhost__
+                if (a.hostname === vhost) {
+                    var re = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/;
+                    if (re.test(a.hostname)) {
+                        vhost = "__defaultVhost__";
+                    }
+                }
+
+                // parse the schema
+                var schema = "rtmp";
+                if (url.indexOf("://") > 0) {
+                    schema = url.substr(0, url.indexOf("://"));
+                }
+
+                var port = a.port;
+                if (!port) {
+                    if (schema === 'http') {
+                        port = 80;
+                    } else if (schema === 'https') {
+                        port = 443;
+                    } else if (schema === 'rtmp') {
+                        port = 1935;
+                    }
+                }
+
+                var ret = {
+                    url: url,
+                    schema: schema,
+                    server: a.hostname, port: port,
+                    vhost: vhost, app: app, stream: stream
+                };
+                self.__internal.fill_query(a.search, ret);
+
+                // For webrtc API, we use 443 if page is https, or schema specified it.
+                if (!ret.port) {
+                    if (schema === 'webrtc' || schema === 'rtc') {
+                        if (ret.user_query.schema === 'https') {
+                            ret.port = 443;
+                        } else if (window.location.href.indexOf('https://') === 0) {
+                            ret.port = 443;
+                        } else {
+                            // For WebRTC, SRS use 1985 as default API port.
+                            ret.port = 1985;
+                        }
+                    }
+                }
+
+                return ret;
+            },
+            fill_query: function (query_string, obj) {
+                // pure user query object.
+                obj.user_query = {};
+
+                if (query_string.length === 0) {
+                    return;
+                }
+
+                // split again for angularjs.
+                if (query_string.indexOf("?") >= 0) {
+                    query_string = query_string.split("?")[1];
+                }
+
+                var queries = query_string.split("&");
+                for (var i = 0; i < queries.length; i++) {
+                    var elem = queries[i];
+
+                    var query = elem.split("=");
+                    obj[query[0]] = query[1];
+                    obj.user_query[query[0]] = query[1];
+                }
+
+                // alias domain for vhost.
+                if (obj.domain) {
+                    obj.vhost = obj.domain;
+                }
+            }
+        };
+
+        self.pc = new RTCPeerConnection(null);
+        self.pc.onaddstream = function (event) {
+            if (self.onaddstream) {
+                self.onaddstream(event);
+            }
+        };
+
+        return self;
+    }
+
+    var flvPlayer = null;
+    var hlsPlayer = null;
+
+    var stopPlayers = function () {
+        if (flvPlayer) {
+            flvPlayer.destroy();
+            flvPlayer = null;
+        }
+        if (hlsPlayer) {
+            hlsPlayer.destroy();
+            hlsPlayer = null;
+        }
+    };
+
+    var hide_for_error = function () {
+        $('#main_flash_alert').show();
+        $('#main_info').hide();
+        $('#main_tips').hide();
+        $('#video_player').hide();
+        //$('#btn_play').hide();
+
+        stopPlayers();
+    };
+
+    var show_for_ok = function () {
+        $('#main_flash_alert').hide();
+        $('#main_info').show();
+        $('#main_tips').show();
+        $('#video_player').show();
+        //$('#btn_play').show();
+    };
+
+    var start_play_live = function (r) {
+        stopPlayers();
+        if (!r) return;
+
+        // Start play HTTP-FLV.
+        if (r.stream.indexOf('.flv') > 0) {
+            if (!flvjs.isSupported()) {
+                hide_for_error();
+                return;
+            }
+
+            show_for_ok();
+
+            flvPlayer = flvjs.createPlayer({type: 'flv', url: r.url});
+            flvPlayer.attachMediaElement(document.getElementById('video_player'));
+            flvPlayer.load();
+            flvPlayer.play();
+            return;
+        }
+
+        // Start play HLS.
+        if (r.stream.indexOf('.m3u8') > 0) {
+            if (!Hls.isSupported()) {
+                hide_for_error();
+                return;
+            }
+
+            show_for_ok();
+
+            hlsPlayer = new Hls();
+            hlsPlayer.loadSource(r.url);
+            hlsPlayer.attachMedia(document.getElementById('video_player'));
+            return;
+        }
+
+        console.error('不支持的URL', r.url, r);
+        $('#video_player').hide();
+    };
 
 
     /****
@@ -692,155 +765,12 @@
 
         // the play startup time.
         var pst = new Date();
-
-        var pc = null; // Global handler to do cleanup when replaying.
-
+        
         $("#main_modal").on("show", function(){
-            if (srs_player) {
-                return;
-            }
-
-            $("#div_container").remove();
-            $("#debug_info").text("");
-
-            var div_container = $("<div/>");
-            $(div_container).attr("id", "div_container");
-            $("#player").append(div_container);
-
-            var player = $("<div/>");
-            $(player).attr("id", "player_id");
-            $(div_container).append(player);
-
-            srs_player = new SrsPlayer("player_id", srs_get_player_width(), srs_get_player_height());
-            srs_player.on_player_ready = function() {
-                var buffer_time = 0.5;
-                if (url.indexOf('.m3u8') > 0) {
-                    buffer_time = 2;
-                }
-
-                if (query.buffer) {
-                    for (var i = 0; i < bts.length - 1; i++) {
-                        var cur = bts[i];
-                        var next = bts[i+1];
-                        if (Number(query.buffer) >= cur && Number(query.buffer) < next) {
-                            buffer_time = cur;
-                            break;
-                        }
-                    }
-                }
-
-                select_buffer(buffer_time);
-                this.play(url);
-
-                pst = new Date();
-            };
-            srs_player.on_player_status = function(code, desc) {
-                //console.log("[播放器状态] code=" + code + ", desc=" + desc);
-            };
-            srs_player.on_player_metadata = function(metadata) {
-                $("#btn_dar_original").text("视频原始比例" + "(" + metadata.width + ":" + metadata.height + ")");
-                if (metadata.ip && metadata.pid && metadata.cid) {
-                    $("#debug_info").text("ID:" + metadata.ip + '/' + metadata.pid + '/' + metadata.cid + '');
-                }
-                select_dar("#btn_dar_original", 0, 0);
-                select_fs_size("#btn_fs_size_screen_100", "screen", 100);
-            };
-            srs_player.on_player_timer = function(time, buffer_length, kbps, fps, rtime) {
-                if (time > 0 && pst) {
-                    var diff = (new Date().getTime() - pst.getTime()) / 1000.0;
-                    $("#txt_pst").val(Number(diff).toFixed(2) + "秒");
-                    pst = null;
-                }
-
-                var buffer = buffer_length / this.max_buffer_time * 100;
-                $("#pb_buffer").width(Number(buffer).toFixed(1) + "%");
-
-                $("#pb_buffer_bg").attr("title",
-                    "缓冲区:" + buffer_length.toFixed(1) + "秒, 最大缓冲区:"
-                    + this.max_buffer_time.toFixed(1) + "秒, 当前:"
-                    + buffer.toFixed(1) + "%");
-
-                var bts = this.buffer_time >= 1? this.buffer_time.toFixed(0) : this.buffer_time.toFixed(1);
-                var mbts = this.buffer_time >= 1? this.max_buffer_time.toFixed(0) : this.max_buffer_time.toFixed(1);
-                $("#txt_buffer").val(buffer_length.toFixed(1) + "/" + bts + "/" + mbts + "s");
-
-                $("#txt_bitrate").val(kbps.toFixed(0) + "kbps");
-                $("#txt_fps").val(fps.toFixed(1) + "fps");
-                $("#txt_empty_count").val(srs_player.empty_count() + "次");
-                $("#txt_fluency").val(srs_player.fluency().toFixed(2) + "%");
-
-                var time_str = "";
-                // day
-                time_str = padding(parseInt(time / 24 / 3600), 2, '0') + " ";
-                // hour
-                time = time % (24 * 3600);
-                time_str += padding(parseInt(time / 3600), 2, '0') + ":";
-                // minute
-                time = time % (3600);
-                time_str += padding(parseInt(time / 60), 2, '0') + ":";
-                // seconds
-                time = time % (60);
-                time_str += padding(parseInt(time), 2, '0');
-                // show
-                $("#txt_time").val(time_str);
-
-                var clock = new Date().getTime() / 1000;
-                $("#player_clock").val(absolute_seconds_to_YYYYmmdd(clock) + " " + absolute_seconds_to_HHMMSS(clock));
-            };
-            srs_player.start();
         });
 
         $("#main_modal").on("hide", function(){
-            if (srs_player) {
-                // report the log to backend.
-                //console.log(srs_player.dump_log());
-
-                srs_player.stop();
-                srs_player = null;
-            }
-        });
-
-        var apply_url_change = function() {
-            var rtmp = parse_rtmp_url($("#txt_url").val());
-            var url = "http://" + query.host + query.pathname + "?"
-                + "app=" + rtmp.app + "&stream=" + rtmp.stream
-                + "&server=" + rtmp.server + "&port=" + rtmp.port
-                + "&autostart=true";
-            if (query.shp_identify) {
-                url += "&shp_identify=" + query.shp_identify;
-            }
-            if (rtmp.vhost == "__defaultVhost__") {
-                url += "&vhost=" + rtmp.server;
-            } else {
-                url += "&vhost=" + rtmp.vhost;
-            }
-            if (rtmp.schema == "http") {
-                url += "&schema=http";
-            }
-            if (query.buffer) {
-                url += "&buffer=" + query.buffer;
-            }
-            if (query.api_port) {
-                url += "&api_port=" + query.api_port;
-            }
-
-            var queries = user_extra_params(query);
-            if (queries && queries.length) {
-                url += '&' + queries.join('&');
-            }
-            $("#player_url").text($("#txt_url").val()).attr("href", url);
-
-            $("#link_server").text(rtmp.server);
-            $("#link_port").text(rtmp.port);
-            $("#link_vhost").text(rtmp.vhost);
-            $("#link_app").text(rtmp.app);
-            $("#link_stream").text(rtmp.stream);
-            $("#link_rtmp").text($("#txt_url").val());
-            $("#link_url").attr("href", url);
-        };
-
-        $("#txt_url").change(function(){
-            apply_url_change();
+           
         });
 
         $("#btn_generate_link").click(function(){
@@ -848,90 +778,10 @@
         });
 
         $("#btn_play").click(function(){
-            url = $("#txt_rtmp_url").val();
             $("#main_modal").modal({show:true, keyboard:true});
+            var r = parse_rtmp_url($("#txt_rtmp_url").val());
+            start_play_live(r);
         });
-
-        $("#btn_fullscreen").click(function(){
-            $("#fullscreen_tips").toggle();
-        });
-
-        $("#btn_pause").click(function() {
-            $("#btn_resume").toggle();
-            $("#btn_pause").toggle();
-            srs_player.pause();
-        });
-        $("#btn_resume").click(function(){
-            $("#btn_resume").toggle();
-            $("#btn_pause").toggle();
-            srs_player.resume();
-        });
-
-        if (true) {
-            $("#srs_publish").click(function () {
-                url = $("#srs_publish").text();
-                $("#main_modal").modal({show: true, keyboard: false});
-            });
-            $("#srs_publish_ld").click(function () {
-                url = $("#srs_publish_ld").text();
-                $("#main_modal").modal({show: true, keyboard: false});
-            });
-            $("#srs_publish_sd").click(function () {
-                url = $("#srs_publish_sd").text();
-                $("#main_modal").modal({show: true, keyboard: false});
-            });
-            $("#srs_publish_fw").click(function () {
-                url = $("#srs_publish_fw").text();
-                $("#main_modal").modal({show: true, keyboard: false});
-            });
-            $("#srs_publish_fw_ld").click(function () {
-                url = $("#srs_publish_fw_ld").text();
-                $("#main_modal").modal({show: true, keyboard: false});
-            });
-            $("#srs_publish_fw_sd").click(function () {
-                url = $("#srs_publish_fw_sd").text();
-                $("#main_modal").modal({show: true, keyboard: false});
-            });
-        }
-
-        if (true) {
-            $("#btn_dar_original").click(function(){
-                select_dar("#btn_dar_original", 0, 0);
-            });
-            $("#btn_dar_21_9").click(function(){
-                select_dar("#btn_dar_21_9", 21, 9);
-            });
-            $("#btn_dar_16_9").click(function(){
-                select_dar("#btn_dar_16_9", 16, 9);
-            });
-            $("#btn_dar_4_3").click(function(){
-                select_dar("#btn_dar_4_3", 4, 3);
-            });
-            $("#btn_dar_fill").click(function(){
-                select_dar("#btn_dar_fill", -1, -1);
-            });
-        }
-
-        if (true) {
-            $("#btn_fs_size_video_100").click(function(){
-                select_fs_size("#btn_fs_size_video_100", "video", 100);
-            });
-            $("#btn_fs_size_video_75").click(function(){
-                select_fs_size("#btn_fs_size_video_75", "video", 75);
-            });
-            $("#btn_fs_size_video_50").click(function(){
-                select_fs_size("#btn_fs_size_video_50", "video", 50);
-            });
-            $("#btn_fs_size_screen_100").click(function(){
-                select_fs_size("#btn_fs_size_screen_100", "screen", 100);
-            });
-            $("#btn_fs_size_screen_75").click(function(){
-                select_fs_size("#btn_fs_size_screen_75", "screen", 75);
-            });
-            $("#btn_fs_size_screen_50").click(function(){
-                select_fs_size("#btn_fs_size_screen_50", "screen", 50);
-            });
-        }
 
         if (true) {
             for (var i = 0; i < bts.length; i++) {
@@ -1159,93 +1009,51 @@
 
                 $("#create_channel_modal").modal('hide');
             });
-            
+
+            var sdk = null; // Global handler to do cleanup when replaying.
+            var startPlay = function() {
+                $('#rtc_media_player').show();
+
+                // Close PC when user replay.
+                if (sdk) {
+                    sdk.close();
+                }
+
+                sdk = new SrsRtcPlayerAsync();
+                sdk.onaddstream = function (event) {
+                    console.log('Start play, event: ', event);
+                    $('#rtc_media_player').prop('srcObject', event.stream);
+                };
+
+                // For example:
+                //      webrtc://r.ossrs.net/live/livestream
+                var url = $("#txt_rtc_url").val();
+                sdk.play(url).then(function(session){
+                    $('#sessionid').html(session.sessionid);
+                    $('#simulator-drop').attr('href', session.simulator + '?drop=1&username=' + session.sessionid);
+                }).catch(function (reason) {
+                    sdk.close();
+                    $('#rtc_media_player').hide();
+                    console.error(reason);
+                });
+            };
+
             $("#btn_rtc_play").click(function(){
                 $('#rtc_media_player').width(srs_get_player_width);
                 $('#rtc_media_player').height(srs_get_player_height);
                 $("#rtc_player_modal").modal({show: true, keyboard: false});
-
-                startPlay($("#txt_rtc_url").val());
+                
+                startPlay();
             });
 
 
             $("#rtc_player_modal").on("hide", function(){
-                if (pc) {
-                    pc.close();
-                 }
+                if (sdk) {
+                    sdk.close();
+                }
              });
 
-            var startPlay = function(url) {
-                    $('#rtc_media_player').show();
-                    var urlObject = parse_rtmp_url(url);
-                    var schema = window.location.protocol;
-
-                    // Close PC when user replay.
-                    if (pc) {
-                        pc.close();
-                    }
-
-                    pc = new RTCPeerConnection(null);
-                    pc.onaddstream = function (event) {
-                        console.debug(event.stream);
-                        $('#rtc_media_player').prop('srcObject', event.stream);
-                    };
-                    new Promise(function(resolve, reject) {
-                        pc.addTransceiver("audio", {direction: "recvonly"});
-                        pc.addTransceiver("video", {direction: "recvonly"});
-
-                        pc.createOffer(function(offer){
-                            resolve(offer);
-                        },function(reason){
-                            reject(reason);
-                        });
-                    }).then(function(offer) {
-                        return pc.setLocalDescription(offer).then(function(){ return offer; });
-                    }).then(function(offer) {
-                        return new Promise(function(resolve, reject) {
-                            // var port = urlObject.port || 1985;
-                            var port = 1985;
-
-                            // @see https://github.com/rtcdn/rtcdn-draft
-                            var api = urlObject.user_query.play || '/rtc/v1/play/';
-                            if (api.lastIndexOf('/') != api.length - 1) {
-                                api += '/';
-                            }
-
-                            var url = schema + '//' + urlObject.server + ':' + port + api;
-                            for (var key in urlObject.user_query) {
-                                if (key != 'api' && key != 'play') {
-                                    url += '&' + key + '=' + urlObject.user_query[key];
-                                }
-                            }
-                            // Replace /rtc/v1/play/&k=v to /rtc/v1/play/?k=v
-                            url = url.replace(api + '&', api + '?');
-
-                            // @see https://github.com/rtcdn/rtcdn-draft
-                            var data = {
-                                api: url, streamurl: urlObject.url, clientip: null, sdp: offer.sdp
-                            };
-                            console.log("offer: " + JSON.stringify(data));
-
-                            $.ajax({
-                                type: "POST", url: url, data: JSON.stringify(data),
-                                contentType:'application/json', dataType: 'json'
-                            }).done(function(data) {
-                                console.log("answer: " + JSON.stringify(data));
-                                resolve(data.sdp);
-                            }).fail(function(reason){
-                                reject(reason);
-                            });
-                        });
-                    }).then(function(answer) {
-                        return pc.setRemoteDescription(new RTCSessionDescription({type: 'answer', sdp: answer}));
-                    }).catch(function(reason) {
-                        throw reason;
-                    });
-                };
         }
-
-        apply_url_change();
     };
 </script>
 </html>

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -3651,8 +3651,21 @@ srs_error_t SrsConfig::check_normal_config()
             string n = conf->at(i)->name;
             if (n != "enabled" && n != "listen" && n != "dir" && n != "candidate" && n != "ecdsa"
                 && n != "encrypt" && n != "reuseport" && n != "merge_nalus" && n != "perf_stat" && n != "black_hole"
-                && n != "ip_family") {
+                && n != "ip_family" &&  n != "rtmp") {
                 return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal rtc_server.%s", n.c_str());
+            }
+
+            if (n == "rtmp") {
+                conf =  conf->at(i);
+                
+                for (int j = 0; j < (int)conf->directives.size(); j++) {
+                    string m = conf->at(j)->name;
+                    if (m != "enabled"  && m != "output" && m != "audio_foramt" && m != "source_copy"
+                        && m != "record_path" && m != "record_video" && m != "record_audio" && m != "opus_payload_type"
+                        && m != "keyframe_interval_print" && m != "req_keyframe" && m != "audio_enabled") {
+                        return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal rtc_server.%s", m.c_str());
+                    }
+                }
             }
         }
     }
@@ -3941,7 +3954,7 @@ srs_error_t SrsConfig::check_normal_config()
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
                     if (m != "enabled" && m != "bframe" && m != "aac" && m != "stun_timeout" && m != "stun_strict_check"
-                        && m != "dtls_role" && m != "dtls_version" && m != "drop_for_pt") {
+                        && m != "dtls_role" && m != "dtls_version" && m != "drop_for_pt" ) {
                         return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal vhost.rtc.%s of %s", m.c_str(), vhost->arg0().c_str());
                     }
                 }
@@ -4945,6 +4958,249 @@ std::string SrsConfig::get_rtc_server_black_hole_addr()
 
     return conf->arg0();
 }
+
+int SrsConfig::get_rtc_server_rtmp_opus_payload_type()
+{
+    static int DEFAULT = 0;
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("opus_payload_type");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    return ::atoi(conf->arg0().c_str());
+}
+
+bool SrsConfig::get_rtc_server_rtmp_enabled()
+{
+    static bool DEFAULT = false;
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("enabled");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
+    return SRS_CONF_PERFER_FALSE(conf->arg0());
+}
+
+std::string SrsConfig::get_rtc_server_rtmp_output()
+{
+    static std::string DEFAULT = "";
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("output");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    return conf->arg0().c_str();
+}
+
+bool SrsConfig::get_rtc_server_rtmp_source_copy()
+{
+    static bool DEFAULT = false;
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("source_copy");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
+    return SRS_CONF_PERFER_FALSE(conf->arg0());
+}
+
+std::string SrsConfig::get_rtc_server_rtmp_audio_format()
+{
+   static std::string DEFAULT = "rtp";
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("audio_format");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
+    return conf->arg0().c_str();
+}
+
+std::string SrsConfig::get_rtc_server_rtmp_record_path()
+{
+    static std::string DEFAULT = "record";
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("record_path");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    return conf->arg0().c_str();
+}
+
+int SrsConfig::get_rtc_server_rtmp_keyframe_interval_print()
+{
+    static int DEFAULT = 10;
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("keyframe_interval_print");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    return ::atoi(conf->arg0().c_str());
+}
+
+int SrsConfig::get_rtc_server_rtmp_req_keyframe()
+{
+    static int DEFAULT = 0;
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("req_keyframe");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    return ::atoi(conf->arg0().c_str());
+}
+
+bool SrsConfig::get_rtc_server_rtmp_record_video()
+{
+    static bool DEFAULT = false;
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("record_video");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
+    return SRS_CONF_PERFER_FALSE(conf->arg0());
+}
+
+bool SrsConfig::get_rtc_server_rtmp_record_audio()
+{
+    static bool DEFAULT = false;
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("record_audio");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
+    return SRS_CONF_PERFER_FALSE(conf->arg0());
+}
+
+bool SrsConfig::get_rtc_server_rtmp_audio_enabled()
+{
+    static bool DEFAULT = false;
+
+    SrsConfDirective* conf = root->get("rtc_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("rtmp");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("audio_enabled");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
+    return SRS_CONF_PERFER_FALSE(conf->arg0());
+}
+
 
 SrsConfDirective* SrsConfig::get_rtc(string vhost)
 {

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -3656,14 +3656,14 @@ srs_error_t SrsConfig::check_normal_config()
             }
 
             if (n == "rtmp") {
-                conf =  conf->at(i);
+                SrsConfDirective* obj =  conf->at(i);
                 
-                for (int j = 0; j < (int)conf->directives.size(); j++) {
-                    string m = conf->at(j)->name;
+                for (int j = 0; j < (int)obj->directives.size(); j++) {
+                    string m = obj->at(j)->name;
                     if (m != "enabled"  && m != "output" && m != "audio_foramt" && m != "source_copy"
                         && m != "record_path" && m != "record_video" && m != "record_audio" && m != "opus_payload_type"
                         && m != "keyframe_interval_print" && m != "req_keyframe" && m != "audio_enabled") {
-                        return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal rtc_server.%s", m.c_str());
+                        return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal rtmp.%s", m.c_str());
                     }
                 }
             }

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -536,6 +536,19 @@ public:
     virtual bool get_rtc_server_perf_stat();
     virtual bool get_rtc_server_black_hole();
     virtual std::string get_rtc_server_black_hole_addr();
+
+    virtual int get_rtc_server_rtmp_opus_payload_type();
+    virtual bool get_rtc_server_rtmp_enabled();
+    virtual std::string get_rtc_server_rtmp_output();
+    virtual bool get_rtc_server_rtmp_source_copy();
+    virtual std::string get_rtc_server_rtmp_audio_format();
+    virtual std::string get_rtc_server_rtmp_record_path();
+    virtual int get_rtc_server_rtmp_keyframe_interval_print();
+    virtual int get_rtc_server_rtmp_req_keyframe();
+    virtual bool get_rtc_server_rtmp_record_video();
+    virtual bool get_rtc_server_rtmp_record_audio();
+    virtual bool get_rtc_server_rtmp_audio_enabled();
+
 private:
     virtual int get_rtc_server_reuseport2();
 

--- a/trunk/src/app/srs_app_gb28181.cpp
+++ b/trunk/src/app/srs_app_gb28181.cpp
@@ -2152,6 +2152,9 @@ SrsGb28181StreamChannel::SrsGb28181StreamChannel(){
     rtp_peer_port = 0;
     rtp_peer_ip = "";
     rtmp_url = "";
+    flv_url = "";
+    hls_url = "";
+    webrtc_url = "";
     recv_time = 0;
     recv_time_str = "";
 }
@@ -2176,6 +2179,9 @@ void SrsGb28181StreamChannel::copy(const SrsGb28181StreamChannel *s){
     rtp_peer_port = s->get_rtp_peer_port();
 
     rtmp_url = s->get_rtmp_url();
+    flv_url = s->get_flv_url();
+    hls_url = s->get_hls_url();
+    webrtc_url = s->get_webrtc_url();
     
     recv_time_str = s->get_recv_time_str();
     recv_time = s->get_recv_time();
@@ -2190,6 +2196,9 @@ void SrsGb28181StreamChannel::dumps(SrsJsonObject* obj)
     obj->set("app", SrsJsonAny::str(app.c_str()));
     obj->set("stream", SrsJsonAny::str(stream.c_str()));
     obj->set("rtmp_url", SrsJsonAny::str(rtmp_url.c_str()));
+    obj->set("flv_url", SrsJsonAny::str(flv_url.c_str()));
+    obj->set("hls_url", SrsJsonAny::str(hls_url.c_str()));
+    obj->set("webrtc_url", SrsJsonAny::str(webrtc_url.c_str()));
    
     obj->set("ssrc", SrsJsonAny::integer(ssrc));
     obj->set("rtp_port", SrsJsonAny::integer(rtp_port));
@@ -2584,7 +2593,21 @@ srs_error_t SrsGb28181Manger::create_stream_channel(SrsGb28181StreamChannel *cha
         channel->set_rtmp_port(rtmp_port);
         channel->set_ip(config->host);
         std::string play_url = srs_generate_rtmp_url(config->host, rtmp_port, "", "", app, stream_name, "");
+        
+        std::string flv_url = srs_string_replace(play_url, "rtmp://", "http://");
+        std::stringstream port;
+        port << ":" << rtmp_port;
+        flv_url = srs_string_replace(flv_url, port.str(), ":"+_srs_config->get_http_stream_listen());
+        std::string hls_url = flv_url + ".m3u8";
+        flv_url = flv_url + ".flv";
+     
+        std::string webrtc_url = srs_string_replace(play_url, "rtmp://", "webrtc://");
+        webrtc_url = srs_string_replace(webrtc_url, port.str(), ":"+_srs_config->get_http_api_listen());
+
         channel->set_rtmp_url(play_url);
+        channel->set_flv_url(flv_url);
+        channel->set_hls_url(hls_url);
+        channel->set_webrtc_url(webrtc_url);
 
         request.app = app;
         request.stream = stream_name;

--- a/trunk/src/app/srs_app_gb28181.hpp
+++ b/trunk/src/app/srs_app_gb28181.hpp
@@ -34,13 +34,12 @@
 
 #include <srs_app_st.hpp>
 #include <srs_app_listener.hpp>
-#include <srs_rtsp_stack.hpp>
 #include <srs_kernel_stream.hpp>
 #include <srs_app_log.hpp>
 #include <srs_kernel_file.hpp>
 #include <srs_protocol_json.hpp>
 #include <srs_app_gb28181_sip.hpp>
-#include <srs_app_gb28181_jitbuffer.hpp>
+#include <srs_app_rtc_rtp_jitbuffer.hpp>
 #include <srs_rtmp_stack.hpp>
 #include <srs_app_source.hpp>
 #include <srs_service_conn.hpp>
@@ -90,7 +89,7 @@ class SrsPithyPrint;
 class SrsSimpleRtmpClient;
 class SrsSipStack;
 class SrsGb28181Manger;
-class SrsRtspJitter;
+class SrsRtpTimeJitter;
 class SrsSipRequest;
 class SrsGb28181RtmpMuxer;
 class SrsGb28181Config;
@@ -99,7 +98,7 @@ class SrsGb28181TcpPsRtpProcessor;
 class SrsGb28181SipService;
 class SrsGb28181StreamChannel;
 class SrsGb28181SipSession;
-class SrsPsJitterBuffer;
+class SrsRtpJitterBuffer;
 class SrsServer;
 class SrsSource;
 class SrsRequest;
@@ -316,8 +315,8 @@ private:
     srs_cond_t wait_ps_queue;
 
     SrsSimpleRtmpClient* sdk;
-    SrsRtspJitter* vjitter;
-    SrsRtspJitter* ajitter;
+    SrsRtpTimeJitter* vjitter;
+    SrsRtpTimeJitter* ajitter;
 
     SrsRawH264Stream* avc;
     std::string h264_sps;
@@ -330,8 +329,8 @@ private:
     SrsSource* source;
     SrsServer* server;
 
-    SrsPsJitterBuffer *jitter_buffer;
-    SrsPsJitterBuffer *jitter_buffer_audio;
+    SrsRtpJitterBuffer *jitter_buffer;
+    SrsRtpJitterBuffer *jitter_buffer_audio;
 
     char *ps_buffer;
     char *ps_buffer_audio;
@@ -340,7 +339,6 @@ private:
     int ps_buflen_auido;
 
     uint32_t ps_rtp_video_ts;
-    uint32_t ps_rtp_audio_ts;
 
     bool source_publish; 
 

--- a/trunk/src/app/srs_app_gb28181.hpp
+++ b/trunk/src/app/srs_app_gb28181.hpp
@@ -442,6 +442,9 @@ private:
     std::string app;
     std::string stream;
     std::string rtmp_url;
+    std::string flv_url;
+    std::string hls_url;
+    std::string webrtc_url;
     
     std::string ip;
     int rtp_port;
@@ -470,6 +473,9 @@ public:
     uint32_t get_rtp_peer_port() const { return rtp_peer_port; }
     std::string get_rtp_peer_ip() const { return rtp_peer_ip; }
     std::string get_rtmp_url() const { return rtmp_url; }
+    std::string get_flv_url() const { return flv_url; }
+    std::string get_hls_url() const { return hls_url; }
+    std::string get_webrtc_url() const { return webrtc_url; }
     srs_utime_t get_recv_time() const { return recv_time; }
     std::string get_recv_time_str() const { return recv_time_str; }
 
@@ -484,6 +490,9 @@ public:
     void set_rtp_peer_ip( const std::string &p) { rtp_peer_ip = p; }
     void set_rtp_peer_port( const int &s) { rtp_peer_port = s;}
     void set_rtmp_url( const std::string &u) { rtmp_url = u; }
+    void set_flv_url( const std::string &u) { flv_url = u; }
+    void set_hls_url( const std::string &u) { hls_url = u; }
+    void set_webrtc_url( const std::string &u) { webrtc_url = u; }
     void set_recv_time( const srs_utime_t &u) { recv_time = u; }
     void set_recv_time_str( const std::string &u) { recv_time_str = u; }
 

--- a/trunk/src/app/srs_app_hybrid.cpp
+++ b/trunk/src/app/srs_app_hybrid.cpp
@@ -282,9 +282,6 @@ SrsServerAdapter* SrsHybridServer::srs()
     return NULL;
 }
 
-extern void _srs_coroutine_switch_in();
-extern void _srs_coroutine_switch_out();
-
 srs_error_t SrsHybridServer::setup_ticks()
 {
     srs_error_t err = srs_success;

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -1172,13 +1172,6 @@ srs_error_t SrsRtcPublishStream::on_rtp(char* data, int nb_data)
         }
     }
 
-    //TODO: ?? padding data, may be not unprotect
-    //B0(1011):pad+ext, A0(1010):pad
-    if ((data[0] & 0xFF) == 0xB0 || (data[0] & 0xFF) == 0xA0){
-        uint8_t padding_length = (uint8_t)(data[nb_data-1] & 0xFF);
-        nb_data = nb_data - padding_length;
-    }
-
     // Decrypt the cipher to plaintext RTP data.
     int nb_unprotected_buf = nb_data;
     if ((err = session_->transport_->unprotect_rtp(data, &nb_unprotected_buf)) != srs_success) {

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -542,17 +542,7 @@ srs_error_t SrsRtcPlayStream::cycle()
         return srs_error_wrap(err, "dumps consumer, url=%s", req_->get_stream_url().c_str());
     }
 
-    if (!source->publish_stream()){
 
-        SrsSource* rtmp_source = NULL;
-        if ((err = _srs_sources->fetch_or_create(req_, _srs_hybrid->srs()->instance(), &rtmp_source)) != srs_success) {
-            return srs_error_wrap(err, "create rtmp source");
-        }
-        
-        if (rtmp_source){
-            rtmp_source->on_edge_play();
-        }
-    }
 
     realtime = _srs_config->get_realtime_enabled(req_->vhost, true);
     mw_msgs = _srs_config->get_mw_msgs(req_->vhost, realtime, true);
@@ -1814,6 +1804,17 @@ srs_error_t SrsRtcConnection::add_player(SrsRequest* req, const SrsSdp& remote_s
     if (_srs_rtc_hijacker) {
         if ((err = _srs_rtc_hijacker->on_before_play(this, req)) != srs_success) {
             return srs_error_wrap(err, "before play");
+        }
+    }
+
+    if (true){
+        SrsSource* rtmp_source = NULL;
+        if ((err = _srs_sources->fetch_or_create(req, _srs_hybrid->srs()->instance(), &rtmp_source)) != srs_success) {
+            return srs_error_wrap(err, "create rtmp source");
+        }
+    
+        if (rtmp_source){
+            rtmp_source->on_edge_play();
         }
     }
 

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -1807,7 +1807,7 @@ srs_error_t SrsRtcConnection::add_player(SrsRequest* req, const SrsSdp& remote_s
         }
     }
 
-    if (true){
+    if (_srs_config->get_vhost_is_edge(req->vhost)){
         SrsSource* rtmp_source = NULL;
         if ((err = _srs_sources->fetch_or_create(req, _srs_hybrid->srs()->instance(), &rtmp_source)) != srs_success) {
             return srs_error_wrap(err, "create rtmp source");

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -40,6 +40,9 @@
 #include <srs_app_rtc_dtls.hpp>
 #include <srs_service_conn.hpp>
 #include <srs_app_conn.hpp>
+#include <srs_app_rtc_rtp_jitbuffer.hpp>
+#include <srs_kernel_file.hpp>
+#include <srs_app_rtc_rtp_rtmp.hpp>
 
 #include <string>
 #include <map>
@@ -62,6 +65,7 @@ class SrsRtcConsumer;
 class SrsRtcAudioSendTrack;
 class SrsRtcVideoSendTrack;
 class SrsErrorPithyPrint;
+class SrsRtcRtmpMuxer;
 
 const uint8_t kSR   = 200;
 const uint8_t kRR   = 201;
@@ -332,6 +336,8 @@ private:
     // track vector
     std::vector<SrsRtcAudioRecvTrack*> audio_tracks_;
     std::vector<SrsRtcVideoRecvTrack*> video_tracks_;
+private:
+    SrsRtcRtmpMuxer *rtmpmuxer;
 private:
     int twcc_id_;
     uint8_t twcc_fb_count_;

--- a/trunk/src/app/srs_app_rtc_rtp_jitbuffer.cpp
+++ b/trunk/src/app/srs_app_rtc_rtp_jitbuffer.cpp
@@ -21,13 +21,14 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <srs_app_gb28181_jitbuffer.hpp>
+#include <srs_app_rtc_rtp_jitbuffer.hpp>
 
 #include <srs_kernel_utility.hpp>
 #include <srs_kernel_error.hpp>
 #include <srs_app_st.hpp>
 #include <srs_core_autofree.hpp>
 #include <srs_kernel_buffer.hpp>
+#include <srs_kernel_file.hpp>
 
 
 using namespace std;
@@ -37,9 +38,9 @@ static const int64_t kDefaultRtt = 200;
 
 // Request a keyframe if no continuous frame has been received for this
 // number of milliseconds and NACKs are disabled.
-static const int64_t kMaxDiscontinuousFramesTime = 1000;
+//static const int64_t kMaxDiscontinuousFramesTime = 1000;
 
-typedef std::pair<uint32_t, SrsPsFrameBuffer*> FrameListPair;
+typedef std::pair<uint32_t, SrsRtpFrameBuffer*> FrameListPair;
 
 bool IsKeyFrame(FrameListPair pair)
 {
@@ -51,12 +52,12 @@ bool HasNonEmptyState(FrameListPair pair)
     return pair.second->GetState() != kStateEmpty;
 }
 
-void FrameList::InsertFrame(SrsPsFrameBuffer* frame)
+void FrameList::InsertFrame(SrsRtpFrameBuffer* frame)
 {
     insert(rbegin().base(), FrameListPair(frame->GetTimeStamp(), frame));
 }
 
-SrsPsFrameBuffer* FrameList::PopFrame(uint32_t timestamp)
+SrsRtpFrameBuffer* FrameList::PopFrame(uint32_t timestamp)
 {
     FrameList::iterator it = find(timestamp);
 
@@ -64,17 +65,17 @@ SrsPsFrameBuffer* FrameList::PopFrame(uint32_t timestamp)
         return NULL;
     }
 
-    SrsPsFrameBuffer* frame = it->second;
+    SrsRtpFrameBuffer* frame = it->second;
     erase(it);
     return frame;
 }
 
-SrsPsFrameBuffer* FrameList::Front() const
+SrsRtpFrameBuffer* FrameList::Front() const
 {
     return begin()->second;
 }
 
-SrsPsFrameBuffer* FrameList::FrontNext() const
+SrsRtpFrameBuffer* FrameList::FrontNext() const
 {
     FrameList::const_iterator it = begin();
     it++;
@@ -88,7 +89,7 @@ SrsPsFrameBuffer* FrameList::FrontNext() const
 }
 
 
-SrsPsFrameBuffer* FrameList::Back() const
+SrsRtpFrameBuffer* FrameList::Back() const
 {
     return rbegin()->second;
 }
@@ -116,10 +117,10 @@ int FrameList::RecycleFramesUntilKeyFrame(FrameList::iterator* key_frame_it,
     return drop_count;
 }
 
-void FrameList::CleanUpOldOrEmptyFrames(PsDecodingState* decoding_state, UnorderedFrameList* free_frames)
+void FrameList::CleanUpOldOrEmptyFrames(SrsRtpDecodingState* decoding_state, UnorderedFrameList* free_frames)
 {
     while (!empty()) {
-        SrsPsFrameBuffer* oldest_frame = Front();
+        SrsRtpFrameBuffer* oldest_frame = Front();
         bool remove_frame = false;
 
         if (oldest_frame->GetState() == kStateEmpty && size() > 1) {
@@ -159,9 +160,9 @@ VCMPacket::VCMPacket()
     sizeBytes(0),
     markerBit(false),
     frameType(kEmptyFrame),
-    //codec(kVideoCodecUnknown),
+    codec(kVideoCodecUnknown),
     isFirstPacket(false),
-    //completeNALU(kNaluUnset),
+    completeNALU(kNaluUnset),
     insertStartCode(false),
     width(0),
     height(0)
@@ -174,7 +175,12 @@ VCMPacket::VCMPacket(const uint8_t* ptr,
                      size_t size,
                      uint16_t seq,
                      uint32_t ts,
-                     bool mBit) :
+                     bool mBit,
+                     H264PacketizationTypes type,
+                     RtpVideoCodecTypes rtpType,
+                     bool singlenual,
+                     bool isfirst,
+                     FrameType ftype) :
     payloadType(0),
     timestamp(ts),
     ntp_time_ms_(0),
@@ -182,16 +188,18 @@ VCMPacket::VCMPacket(const uint8_t* ptr,
     dataPtr(ptr),
     sizeBytes(size),
     markerBit(mBit),
-
-    frameType(kVideoFrameDelta),
-    //codec(kVideoCodecUnknown),
+    frameType(ftype),
+    codec(kVideoCodecUnknown),
     isFirstPacket(false),
-    //completeNALU(kNaluComplete),
+    completeNALU(kNaluComplete),
     insertStartCode(false),
     width(0),
-    height(0)
+    height(0),
+    h264packetizationType(type)
     //codecSpecificHeader()
-{}
+{
+    CopyCodecSpecifics(rtpType, singlenual, isfirst);
+}
 
 void VCMPacket::Reset()
 {
@@ -203,17 +211,74 @@ void VCMPacket::Reset()
     sizeBytes = 0;
     markerBit = false;
     frameType = kEmptyFrame;
-    //codec = kVideoCodecUnknown;
+    codec = kVideoCodecUnknown;
     isFirstPacket = false;
-    //completeNALU = kNaluUnset;
+    completeNALU = kNaluUnset;
     insertStartCode = false;
     width = 0;
     height = 0;
     //memset(&codecSpecificHeader, 0, sizeof(RTPVideoHeader));
 }
 
+void VCMPacket::CopyCodecSpecifics(RtpVideoCodecTypes codecType, bool H264single_nalu, bool firstPacket)
+{
+    switch (codecType) {
+    case kRtpVideoVp8:
 
-SrsPsFrameBuffer::SrsPsFrameBuffer()
+        // Handle all packets within a frame as depending on the previous packet
+        // TODO(holmer): This should be changed to make fragments independent
+        // when the VP8 RTP receiver supports fragments.
+        if (isFirstPacket && markerBit) {
+            completeNALU = kNaluComplete;
+        } else if (isFirstPacket) {
+            completeNALU = kNaluStart;
+        } else if (markerBit) {
+            completeNALU = kNaluEnd;
+        } else {
+            completeNALU = kNaluIncomplete;
+        }
+
+        codec = kVideoCodecVP8;
+        return;
+
+    case kRtpVideoH264:
+        isFirstPacket = firstPacket;
+
+        if (isFirstPacket) {
+            insertStartCode = true;
+        }
+
+        if (H264single_nalu) {
+            completeNALU = kNaluComplete;
+        } else if (isFirstPacket) {
+            completeNALU = kNaluStart;
+        } else if (markerBit) {
+            completeNALU = kNaluEnd;
+        } else {
+            completeNALU = kNaluIncomplete;
+        }
+
+        codec = kVideoCodecH264;
+        return;
+    case kRtpVideoPS:
+        isFirstPacket = firstPacket;
+        codec = kVideoCodecH264PS;
+        return;
+
+    case kRtpVideoVp9:
+    case kRtpVideoGeneric:
+    case kRtpVideoNone:
+        codec = kVideoCodecUnknown;
+        return;
+    }
+}
+
+uint16_t BufferToUWord16(const uint8_t* dataBuffer)
+{
+    return (dataBuffer[0] << 8) | dataBuffer[1];
+}
+
+SrsRtpFrameBuffer::SrsRtpFrameBuffer()
 {
     empty_seq_num_low_ = 0;
     empty_seq_num_high_ = 0;
@@ -229,12 +294,12 @@ SrsPsFrameBuffer::SrsPsFrameBuffer()
     _buffer = NULL;
 }
 
-SrsPsFrameBuffer::~SrsPsFrameBuffer()
+SrsRtpFrameBuffer::~SrsRtpFrameBuffer()
 {
     srs_freepa(_buffer);
 }
 
-void SrsPsFrameBuffer::Reset()
+void SrsRtpFrameBuffer::Reset()
 {
     //session_nack_ = false;
     complete_ = false;
@@ -248,15 +313,15 @@ void SrsPsFrameBuffer::Reset()
     _length = 0;
 }
 
-size_t SrsPsFrameBuffer::Length() const
+size_t SrsRtpFrameBuffer::Length() const
 {
     return _length;
 }
 
-PsFrameBufferEnum SrsPsFrameBuffer::InsertPacket(const VCMPacket& packet, const FrameData& frame_data)
+SrsRtpFrameBufferEnum SrsRtpFrameBuffer::InsertPacket(const VCMPacket& packet, const FrameData& frame_data)
 {
     if (packets_.size() == kMaxPacketsInSession) {
-        srs_error("Max number of packets per frame has been reached.");
+        srs_warn("RtpJitterBuffer: Max number of packets per frame has been reached.");
         return kSizeError;
     }
 
@@ -265,7 +330,12 @@ PsFrameBufferEnum SrsPsFrameBuffer::InsertPacket(const VCMPacket& packet, const 
     }
 
     uint32_t requiredSizeBytes = Length() + packet.sizeBytes;
-  
+
+    if (requiredSizeBytes == 0){
+        srs_warn("RtpJitterBuffer: requiredSizeBytes is zero ts:%u, seq:%u", packet.timestamp, packet.seqNum);
+        return kSizeError; 
+    }
+
     if (requiredSizeBytes >= _size) {
         const uint8_t* prevBuffer = _buffer;
         const uint32_t increments = requiredSizeBytes /
@@ -276,22 +346,25 @@ PsFrameBufferEnum SrsPsFrameBuffer::InsertPacket(const VCMPacket& packet, const 
                                  increments * kBufferIncStepSizeBytes;
 
         if (newSize > kMaxJBFrameSizeBytes) {
-            srs_error("Failed to insert packet due to frame being too big.");
+            srs_error("RtpJitterBuffer: Failed to insert packet due to frame being too big.");
             return kSizeError;
         }
 
         VerifyAndAllocate(newSize);
         UpdateDataPointers(prevBuffer, _buffer);
+
+        srs_trace("RtpJitterBuffer: VerifyAndAllocate:newSize:%d, prevBuffer:%d, _buffer:%d", newSize, prevBuffer, _buffer);
     }
 
     // Find the position of this packet in the packet list in sequence number
     // order and insert it. Loop over the list in reverse order.
     ReversePacketIterator rit = packets_.rbegin();
 
-    for (; rit != packets_.rend(); ++rit)
+    for (; rit != packets_.rend(); ++rit){
         if (LatestSequenceNumber(packet.seqNum, (*rit).seqNum) == packet.seqNum) {
             break;
         }
+    }
 
     // Check for duplicate packets.
     if (rit != packets_.rend() &&
@@ -299,17 +372,50 @@ PsFrameBufferEnum SrsPsFrameBuffer::InsertPacket(const VCMPacket& packet, const 
         return kDuplicatePacket;
     }
 
-    if ((packets_.size() == 0)&&
-        (first_packet_seq_num_ == -1 ||
-        IsNewerSequenceNumber(first_packet_seq_num_, packet.seqNum))) {
-        first_packet_seq_num_ = packet.seqNum;
-    }
+    // if ((packets_.size() == 0)&&
+    //     (first_packet_seq_num_ == -1 ||
+    //     IsNewerSequenceNumber(first_packet_seq_num_, packet.seqNum))) {
+    //     first_packet_seq_num_ = packet.seqNum;
+    // }
     
-    //TODO: not check marker, check a complete frame with timestamp
-    if (packet.markerBit &&
-        (last_packet_seq_num_ == -1 ||
-        IsNewerSequenceNumber(packet.seqNum, last_packet_seq_num_))) {
-        last_packet_seq_num_ = packet.seqNum;
+    // //TODO: not check marker, check a complete frame with timestamp
+    // if (packet.markerBit &&
+    //     (last_packet_seq_num_ == -1 ||
+    //     IsNewerSequenceNumber(packet.seqNum, last_packet_seq_num_))) {
+    //     last_packet_seq_num_ = packet.seqNum;
+    // }
+
+    if (packet.codec == kVideoCodecH264) {
+        //   frame_type_ = packet.frameType;
+        if (packet.isFirstPacket &&
+                (first_packet_seq_num_ == -1 ||
+                 IsNewerSequenceNumber(first_packet_seq_num_, packet.seqNum))) {
+            first_packet_seq_num_ = packet.seqNum;
+            frame_type_ = packet.frameType;
+        }
+
+        if (packet.markerBit &&
+                (last_packet_seq_num_ == -1 ||
+                 IsNewerSequenceNumber(packet.seqNum, last_packet_seq_num_))) {
+            last_packet_seq_num_ = packet.seqNum;
+        }
+    } else if (packet.codec == kVideoCodecH264PS) {
+        if (packet.isFirstPacket &&
+                (first_packet_seq_num_ == -1 ||
+                IsNewerSequenceNumber(first_packet_seq_num_, packet.seqNum))) {
+            first_packet_seq_num_ = packet.seqNum;
+            frame_type_ = packet.frameType;
+        }
+    
+        //TODO: not check marker, check a complete frame with timestamp
+        if (packet.markerBit &&
+                (last_packet_seq_num_ == -1 ||
+                IsNewerSequenceNumber(packet.seqNum, last_packet_seq_num_))) {
+            last_packet_seq_num_ = packet.seqNum;
+        }
+    }else {
+        srs_warn("RtpJitterBuffer: no support codec type");
+        return kFlushIndicator;
     }
 
     // The insert operation invalidates the iterator |rit|.
@@ -342,7 +448,7 @@ PsFrameBufferEnum SrsPsFrameBuffer::InsertPacket(const VCMPacket& packet, const 
     return kIncomplete;
 }
 
-void SrsPsFrameBuffer::VerifyAndAllocate(const uint32_t minimumSize)
+void SrsRtpFrameBuffer::VerifyAndAllocate(const uint32_t minimumSize)
 {
     if (minimumSize > _size) {
         // create buffer of sufficient size
@@ -354,7 +460,7 @@ void SrsPsFrameBuffer::VerifyAndAllocate(const uint32_t minimumSize)
             delete [] _buffer;
         }
 
-        srs_info("SrsPsFrameBuffer::VerifyAndAllocate oldbuffer=%d newbuffer=%d, minimumSize=%d, size=%d", 
+        srs_info("RtpJitterBuffer: VerifyAndAllocate oldbuffer=%d newbuffer=%d, minimumSize=%d, size=%d", 
                      _buffer, newBuffer, minimumSize, _size);
 
         _buffer = newBuffer;
@@ -362,7 +468,7 @@ void SrsPsFrameBuffer::VerifyAndAllocate(const uint32_t minimumSize)
     }
 }
 
-void SrsPsFrameBuffer::UpdateDataPointers(const uint8_t* old_base_ptr,
+void SrsRtpFrameBuffer::UpdateDataPointers(const uint8_t* old_base_ptr,
                                         const uint8_t* new_base_ptr)
 {
     for (PacketIterator it = packets_.begin(); it != packets_.end(); ++it)
@@ -373,7 +479,7 @@ void SrsPsFrameBuffer::UpdateDataPointers(const uint8_t* old_base_ptr,
 }
 
 
-size_t SrsPsFrameBuffer::InsertBuffer(uint8_t* frame_buffer,
+size_t SrsRtpFrameBuffer::InsertBuffer(uint8_t* frame_buffer,
                                     PacketIterator packet_it)
 {
     VCMPacket& packet = *packet_it;
@@ -391,25 +497,92 @@ size_t SrsPsFrameBuffer::InsertBuffer(uint8_t* frame_buffer,
     const uint8_t* packet_buffer = packet.dataPtr;
     packet.dataPtr = frame_buffer + offset;
 
+    // We handle H.264 STAP-A packets in a special way as we need to remove the
+    // two length bytes between each NAL unit, and potentially add start codes.
+    const size_t kH264NALHeaderLengthInBytes = 1;
+    const size_t kLengthFieldLength = 2;
+
+    if (packet.codec == kVideoCodecH264 && 
+            packet.h264packetizationType == kH264StapA
+            /*packet.codecSpecificHeader.codecHeader.H264.stap_a*/) {
+
+        size_t required_length = 0;
+        size_t nalu_count = 0;
+        const uint8_t* nalu_ptr = packet_buffer + kH264NALHeaderLengthInBytes;
+
+        while (nalu_ptr < packet_buffer + packet.sizeBytes) {
+            size_t length = BufferToUWord16(nalu_ptr);
+            required_length += length;
+            nalu_ptr += kLengthFieldLength + length;
+            nalu_count++;
+
+            srs_trace("RtpJitterBuffer: H264 stap_a length:%d, nalu_count=%d", length, nalu_count);
+        }
+
+        size_t total_len = required_length + nalu_count * (kLengthFieldLength) + kH264NALHeaderLengthInBytes;
+
+        if (total_len > packet.sizeBytes) {
+            srs_error("RtpJitterBuffer: H264 required len %d is biger than packet len %d", total_len, packet.sizeBytes);
+            return -1;
+        }
+
+        required_length += nalu_count * (packet.insertStartCode ? kH264StartCodeLengthBytes : 0);
+
+        ShiftSubsequentPackets(packet_it, required_length);
+        nalu_ptr = packet_buffer + kH264NALHeaderLengthInBytes;
+        uint8_t* frame_buffer_ptr = frame_buffer + offset;
+        required_length = 0;
+
+        while (nalu_ptr < packet_buffer + packet.sizeBytes) {
+            size_t length = BufferToUWord16(nalu_ptr);
+            nalu_ptr += kLengthFieldLength;
+            size_t naluLen = Insert(nalu_ptr,
+                                    length,
+                                    packet.insertStartCode,
+                                    const_cast<uint8_t*>(frame_buffer_ptr));
+            frame_buffer_ptr += naluLen;
+            nalu_ptr += length;
+            required_length += naluLen;
+        }
+
+        packet.sizeBytes = required_length;
+        return packet.sizeBytes;
+    }
+
     ShiftSubsequentPackets(
         packet_it,
-        packet.sizeBytes);
+        packet.sizeBytes +
+        (packet.insertStartCode ? kH264StartCodeLengthBytes : 0));
 
     packet.sizeBytes = Insert(packet_buffer,
                               packet.sizeBytes,
+                              packet.insertStartCode,
                               const_cast<uint8_t*>(packet.dataPtr));
     return packet.sizeBytes;
 }
 
-size_t SrsPsFrameBuffer::Insert(const uint8_t* buffer,
+
+
+size_t SrsRtpFrameBuffer::Insert(const uint8_t* buffer,
                               size_t length,
+                              bool insert_start_code,
                               uint8_t* frame_buffer)
 {
-    memcpy(frame_buffer, buffer, length);
+    if (insert_start_code) {
+        const unsigned char startCode[] = {0, 0, 0, 1};
+        memcpy(frame_buffer, startCode, kH264StartCodeLengthBytes);
+    }
+
+    memcpy(frame_buffer + (insert_start_code ? kH264StartCodeLengthBytes : 0),
+           buffer,
+           length);
+    length += (insert_start_code ? kH264StartCodeLengthBytes : 0);
+
     return length;
 }
 
-void SrsPsFrameBuffer::ShiftSubsequentPackets(PacketIterator it,
+
+void SrsRtpFrameBuffer::ShiftSubsequentPackets(PacketIterator it,
         int steps_to_shift)
 {
     ++it;
@@ -433,7 +606,7 @@ void SrsPsFrameBuffer::ShiftSubsequentPackets(PacketIterator it,
     memmove(first_packet_ptr + steps_to_shift, first_packet_ptr, shift_length);
 }
 
-void SrsPsFrameBuffer::UpdateCompleteSession()
+void SrsRtpFrameBuffer::UpdateCompleteSession()
 {
     if (HaveFirstPacket() && HaveLastPacket()) {
         // Do we have all the packets in this session?
@@ -455,17 +628,17 @@ void SrsPsFrameBuffer::UpdateCompleteSession()
     }
 }
 
-bool SrsPsFrameBuffer::HaveFirstPacket() const
+bool SrsRtpFrameBuffer::HaveFirstPacket() const
 {
     return !packets_.empty() && (first_packet_seq_num_ != -1);
 }
 
-bool SrsPsFrameBuffer::HaveLastPacket() const
+bool SrsRtpFrameBuffer::HaveLastPacket() const
 {
     return !packets_.empty() && (last_packet_seq_num_ != -1);
 }
 
-bool SrsPsFrameBuffer::InSequence(const PacketIterator& packet_it,
+bool SrsRtpFrameBuffer::InSequence(const PacketIterator& packet_it,
                                 const PacketIterator& prev_packet_it)
 {
     // If the two iterators are pointing to the same packet they are considered
@@ -475,7 +648,7 @@ bool SrsPsFrameBuffer::InSequence(const PacketIterator& packet_it,
              (*packet_it).seqNum));
 }
 
-void SrsPsFrameBuffer::UpdateDecodableSession(const FrameData& frame_data)
+void SrsRtpFrameBuffer::UpdateDecodableSession(const FrameData& frame_data)
 {
     // Irrelevant if session is already complete or decodable
     if (complete_ || decodable_) {
@@ -503,37 +676,37 @@ void SrsPsFrameBuffer::UpdateDecodableSession(const FrameData& frame_data)
     decodable_ = true;
 }
 
-bool SrsPsFrameBuffer::complete() const
+bool SrsRtpFrameBuffer::complete() const
 {
     return complete_;
 }
 
-bool SrsPsFrameBuffer::decodable() const
+bool SrsRtpFrameBuffer::decodable() const
 {
     return decodable_;
 }
 
-int SrsPsFrameBuffer::NumPackets() const
+int SrsRtpFrameBuffer::NumPackets() const
 {
     return packets_.size();
 }
 
-uint32_t SrsPsFrameBuffer::GetTimeStamp() const
+uint32_t SrsRtpFrameBuffer::GetTimeStamp() const
 {
     return timeStamp_;
 }
 
-FrameType SrsPsFrameBuffer::GetFrameType() const
+FrameType SrsRtpFrameBuffer::GetFrameType() const
 {
     return frame_type_;
 }
 
-PsFrameBufferStateEnum SrsPsFrameBuffer::GetState() const
+SrsRtpFrameBufferStateEnum SrsRtpFrameBuffer::GetState() const
 {
     return state_;
 }
 
-int32_t SrsPsFrameBuffer::GetHighSeqNum() const
+int32_t SrsRtpFrameBuffer::GetHighSeqNum() const
 {
     if (packets_.empty()) {
         return empty_seq_num_high_;
@@ -547,7 +720,7 @@ int32_t SrsPsFrameBuffer::GetHighSeqNum() const
 
 }
 
-int32_t SrsPsFrameBuffer::GetLowSeqNum() const
+int32_t SrsRtpFrameBuffer::GetLowSeqNum() const
 {
     if (packets_.empty()) {
         return empty_seq_num_low_;
@@ -556,13 +729,13 @@ int32_t SrsPsFrameBuffer::GetLowSeqNum() const
     return packets_.front().seqNum;
 }
 
-const uint8_t* SrsPsFrameBuffer::Buffer() const
+const uint8_t* SrsRtpFrameBuffer::Buffer() const
 {
     return _buffer;
 }
 
 
-void SrsPsFrameBuffer::InformOfEmptyPacket(uint16_t seq_num)
+void SrsRtpFrameBuffer::InformOfEmptyPacket(uint16_t seq_num)
 {
     // Empty packets may be FEC or filler packets. They are sequential and
     // follow the data packets, therefore, we should only keep track of the high
@@ -581,7 +754,7 @@ void SrsPsFrameBuffer::InformOfEmptyPacket(uint16_t seq_num)
 }
 
 
-size_t SrsPsFrameBuffer::DeletePacketData(PacketIterator start, PacketIterator end)
+size_t SrsRtpFrameBuffer::DeletePacketData(PacketIterator start, PacketIterator end)
 {
     size_t bytes_to_delete = 0;  // The number of bytes to delete.
     PacketIterator packet_after_end = end;
@@ -602,7 +775,7 @@ size_t SrsPsFrameBuffer::DeletePacketData(PacketIterator start, PacketIterator e
     return bytes_to_delete;
 }
 
-size_t SrsPsFrameBuffer::MakeDecodable()
+size_t SrsRtpFrameBuffer::MakeDecodable()
 {
     size_t return_length = 0;
 
@@ -617,7 +790,7 @@ size_t SrsPsFrameBuffer::MakeDecodable()
     return return_length;
 }
 
-void SrsPsFrameBuffer::PrepareForDecode(bool continuous)
+void SrsRtpFrameBuffer::PrepareForDecode(bool continuous)
 {
 
     size_t bytes_removed = MakeDecodable();
@@ -632,7 +805,7 @@ void SrsPsFrameBuffer::PrepareForDecode(bool continuous)
 
 
 
- bool SrsPsFrameBuffer::DeletePacket(int &count)
+ bool SrsRtpFrameBuffer::DeletePacket(int &count)
  {
     return true;
  }
@@ -640,7 +813,7 @@ void SrsPsFrameBuffer::PrepareForDecode(bool continuous)
 
 /////////////////////////////////////////////////////////////////////////////
 
-PsDecodingState::PsDecodingState()
+SrsRtpDecodingState::SrsRtpDecodingState()
     : sequence_num_(0),
       time_stamp_(0),
       //picture_id_(kNoPictureId),
@@ -650,9 +823,9 @@ PsDecodingState::PsDecodingState()
       in_initial_state_(true),
       m_firstPacket(false) {}
 
-PsDecodingState::~PsDecodingState() {}
+SrsRtpDecodingState::~SrsRtpDecodingState() {}
 
-void PsDecodingState::Reset()
+void SrsRtpDecodingState::Reset()
 {
     // TODO(mikhal): Verify - not always would want to reset the sync
     sequence_num_ = 0;
@@ -664,17 +837,17 @@ void PsDecodingState::Reset()
     in_initial_state_ = true;
 }
 
-uint32_t PsDecodingState::time_stamp() const
+uint32_t SrsRtpDecodingState::time_stamp() const
 {
     return time_stamp_;
 }
 
-uint16_t PsDecodingState::sequence_num() const
+uint16_t SrsRtpDecodingState::sequence_num() const
 {
     return sequence_num_;
 }
 
-bool PsDecodingState::IsOldFrame(const SrsPsFrameBuffer* frame) const
+bool SrsRtpDecodingState::IsOldFrame(const SrsRtpFrameBuffer* frame) const
 {
     //assert(frame != NULL);
     if (frame == NULL) {
@@ -688,7 +861,7 @@ bool PsDecodingState::IsOldFrame(const SrsPsFrameBuffer* frame) const
     return !IsNewerTimestamp(frame->GetTimeStamp(), time_stamp_);
 }
 
-bool PsDecodingState::IsOldPacket(const VCMPacket* packet)
+bool SrsRtpDecodingState::IsOldPacket(const VCMPacket* packet)
 {
     //assert(packet != NULL);
     if (packet == NULL) {
@@ -708,7 +881,7 @@ bool PsDecodingState::IsOldPacket(const VCMPacket* packet)
     return !IsNewerTimestamp(packet->timestamp, time_stamp_);
 }
 
-void PsDecodingState::SetState(const SrsPsFrameBuffer* frame)
+void SrsRtpDecodingState::SetState(const SrsRtpFrameBuffer* frame)
 {
     //assert(frame != NULL && frame->GetHighSeqNum() >= 0);
     UpdateSyncState(frame);
@@ -717,7 +890,7 @@ void PsDecodingState::SetState(const SrsPsFrameBuffer* frame)
     in_initial_state_ = false;
 }
 
-void PsDecodingState::CopyFrom(const PsDecodingState& state)
+void SrsRtpDecodingState::CopyFrom(const SrsRtpDecodingState& state)
 {
     sequence_num_ = state.sequence_num_;
     time_stamp_ = state.time_stamp_;
@@ -725,7 +898,7 @@ void PsDecodingState::CopyFrom(const PsDecodingState& state)
     in_initial_state_ = state.in_initial_state_;
 }
 
-bool PsDecodingState::UpdateEmptyFrame(const SrsPsFrameBuffer* frame)
+bool SrsRtpDecodingState::UpdateEmptyFrame(const SrsRtpFrameBuffer* frame)
 {
     bool empty_packet = frame->GetHighSeqNum() == frame->GetLowSeqNum();
 
@@ -746,7 +919,7 @@ bool PsDecodingState::UpdateEmptyFrame(const SrsPsFrameBuffer* frame)
     return false;
 }
 
-void PsDecodingState::UpdateOldPacket(const VCMPacket* packet)
+void SrsRtpDecodingState::UpdateOldPacket(const VCMPacket* packet)
 {
     //assert(packet != NULL);
     if (packet == NULL) {
@@ -760,29 +933,29 @@ void PsDecodingState::UpdateOldPacket(const VCMPacket* packet)
     }
 }
 
-void PsDecodingState::SetSeqNum(uint16_t new_seq_num)
+void SrsRtpDecodingState::SetSeqNum(uint16_t new_seq_num)
 {
     sequence_num_ = new_seq_num;
 }
 
-bool PsDecodingState::in_initial_state() const
+bool SrsRtpDecodingState::in_initial_state() const
 {
     return in_initial_state_;
 }
 
-bool PsDecodingState::full_sync() const
+bool SrsRtpDecodingState::full_sync() const
 {
     return full_sync_;
 }
 
-void PsDecodingState::UpdateSyncState(const SrsPsFrameBuffer* frame)
+void SrsRtpDecodingState::UpdateSyncState(const SrsRtpFrameBuffer* frame)
 {
     if (in_initial_state_) {
         return;
     }
 }
 
-bool PsDecodingState::ContinuousFrame(const SrsPsFrameBuffer* frame) const
+bool SrsRtpDecodingState::ContinuousFrame(const SrsRtpFrameBuffer* frame) const
 {
     // Check continuity based on the following hierarchy:
     // - Temporal layers (stop here if out of sync).
@@ -810,54 +983,102 @@ bool PsDecodingState::ContinuousFrame(const SrsPsFrameBuffer* frame) const
     return ContinuousSeqNum(static_cast<uint16_t>(frame->GetLowSeqNum()));
 }
 
-bool PsDecodingState::ContinuousSeqNum(uint16_t seq_num) const
+bool SrsRtpDecodingState::ContinuousSeqNum(uint16_t seq_num) const
 {
     return seq_num == static_cast<uint16_t>(sequence_num_ + 1);
 }
 
-SrsPsJitterBuffer::SrsPsJitterBuffer(std::string key):
-      running_(false),
-      max_number_of_frames_(kStartNumberOfFrames),
-      free_frames_(),
-      decodable_frames_(),
-      incomplete_frames_(),
-      last_decoded_state_(),
-      first_packet_since_reset_(true),
-      incoming_frame_rate_(0),
-      incoming_frame_count_(0),
-      time_last_incoming_frame_count_(0),
-      incoming_bit_count_(0),
-      incoming_bit_rate_(0),
-      num_consecutive_old_packets_(0),
-      num_packets_(0),
-      num_packets_free_(0),
-      num_duplicated_packets_(0),
-      num_discarded_packets_(0),
-      time_first_packet_ms_(0),
-      //jitter_estimate_(clock),
-      //inter_frame_delay_(clock_->TimeInMilliseconds()),
-      rtt_ms_(kDefaultRtt),
-      nack_mode_(kNoNack),
-      low_rtt_nack_threshold_ms_(-1),
-      high_rtt_nack_threshold_ms_(-1),
-      missing_sequence_numbers_(SequenceNumberLessThan()),
-      nack_seq_nums_(),
-      max_nack_list_size_(0),
-      max_packet_age_to_nack_(0),
-      max_incomplete_time_ms_(0),
-      decode_error_mode_(kNoErrors),
-      average_packets_per_frame_(0.0f),
-      frame_counter_(0),
-      key_(key)
+SrsRtpTimeJitter::SrsRtpTimeJitter()
+{
+    delta = 0;
+    previous_timestamp = 0;
+    pts = 0;
+}
+
+SrsRtpTimeJitter::~SrsRtpTimeJitter()
+{
+}
+
+int64_t SrsRtpTimeJitter::timestamp()
+{
+    return pts;
+}
+
+srs_error_t SrsRtpTimeJitter::correct(int64_t& ts)
+{
+    srs_error_t err = srs_success;
+    
+    if (previous_timestamp == 0) {
+        previous_timestamp = ts;
+    }
+    
+    delta = srs_max(0, (int)(ts - previous_timestamp));
+    if (delta > 90000) {
+        delta = 0;
+    }
+
+    previous_timestamp = ts;
+    
+    ts = pts + delta;
+    pts = ts;
+    
+    return err;
+}
+
+
+void SrsRtpTimeJitter::reset()
+{
+    delta = 0;
+    previous_timestamp = 0;
+    pts = 0;
+}
+
+SrsRtpJitterBuffer::SrsRtpJitterBuffer(std::string key):
+    key_(key),
+    running_(false),
+    max_number_of_frames_(kStartNumberOfFrames),
+    free_frames_(),
+    decodable_frames_(),
+    incomplete_frames_(),
+    last_decoded_state_(),
+    first_packet_since_reset_(true),
+    incoming_frame_rate_(0),
+    incoming_frame_count_(0),
+    time_last_incoming_frame_count_(0),
+    incoming_bit_count_(0),
+    incoming_bit_rate_(0),
+    num_consecutive_old_packets_(0),
+    num_packets_(0),
+    num_packets_free_(0),
+    num_duplicated_packets_(0),
+    num_discarded_packets_(0),
+    time_first_packet_ms_(0),
+    //jitter_estimate_(clock),
+    //inter_frame_delay_(clock_->TimeInMilliseconds()),
+    rtt_ms_(kDefaultRtt),
+    nack_mode_(kNoNack),
+    low_rtt_nack_threshold_ms_(-1),
+    high_rtt_nack_threshold_ms_(-1),
+    missing_sequence_numbers_(SequenceNumberLessThan()),
+    nack_seq_nums_(),
+    max_nack_list_size_(0),
+    max_packet_age_to_nack_(0),
+    max_incomplete_time_ms_(0),
+    decode_error_mode_(kNoErrors),
+    average_packets_per_frame_(0.0f),
+    frame_counter_(0),
+    last_received_timestamp_(0),
+    last_received_sequence_number_(0),
+    first_packet_(0)
 {
     for (int i = 0; i < kStartNumberOfFrames; i++) {
-        free_frames_.push_back(new SrsPsFrameBuffer());
+        free_frames_.push_back(new SrsRtpFrameBuffer());
     }
 
     wait_cond_t = srs_cond_new();
 }
 
-SrsPsJitterBuffer::~SrsPsJitterBuffer()
+SrsRtpJitterBuffer::~SrsRtpJitterBuffer()
 {
     for (UnorderedFrameList::iterator it = free_frames_.begin();
             it != free_frames_.end(); ++it) {
@@ -877,12 +1098,12 @@ SrsPsJitterBuffer::~SrsPsJitterBuffer()
     srs_cond_destroy(wait_cond_t);
 }
 
-void SrsPsJitterBuffer::SetDecodeErrorMode(PsDecodeErrorMode error_mode)
+void SrsRtpJitterBuffer::SetDecodeErrorMode(SrsRtpDecodeErrorMode error_mode)
 {
     decode_error_mode_ = error_mode;
 }
 
-void SrsPsJitterBuffer::Flush()
+void SrsRtpJitterBuffer::Flush()
 {
     //CriticalSectionScoped cs(crit_sect_);
     decodable_frames_.Reset(&free_frames_);
@@ -900,14 +1121,20 @@ void SrsPsJitterBuffer::Flush()
     missing_sequence_numbers_.clear();
 }
 
+void SrsRtpJitterBuffer::ResetJittter()
+{
+    Flush();
+}
 
 
-PsFrameBufferEnum SrsPsJitterBuffer::InsertPacket(const SrsPsRtpPacket &pkt, char *buf, int size,
+SrsRtpFrameBufferEnum SrsRtpJitterBuffer::InsertPacket(uint16_t seq, uint32_t ts, bool maker, char *buf, int size,
         bool* retransmitted)
 {
-    
+    bool isFirstPacketInFrame = IsFirstPacketInFrame(ts, seq);
+   
     const VCMPacket packet((const uint8_t*)buf, size,
-                pkt.sequence_number, pkt.timestamp, pkt.marker);
+        seq, ts, maker,
+        kH264SingleNalu, kRtpVideoPS, true, isFirstPacketInFrame, kVideoFrameDelta);
    
     ++num_packets_;
 
@@ -923,10 +1150,10 @@ PsFrameBufferEnum SrsPsJitterBuffer::InsertPacket(const SrsPsRtpPacket &pkt, cha
 
     //num_consecutive_old_packets_ = 0;
 
-    SrsPsFrameBuffer* frame;
+    SrsRtpFrameBuffer* frame;
     FrameList* frame_list;
 
-    const PsFrameBufferEnum error = GetFrame(packet, &frame, &frame_list);
+    const SrsRtpFrameBufferEnum error = GetFrameByRtpPacket(packet, &frame, &frame_list);
 
     if (error != kNoError) {
         return error;
@@ -939,7 +1166,216 @@ PsFrameBufferEnum SrsPsJitterBuffer::InsertPacket(const SrsPsRtpPacket &pkt, cha
     frame_data.rtt_ms = 0; //rtt_ms_;
     frame_data.rolling_average_packets_per_frame = 25;//average_packets_per_frame_;
 
-    PsFrameBufferEnum buffer_state = frame->InsertPacket(packet, frame_data);
+    SrsRtpFrameBufferEnum buffer_state = frame->InsertPacket(packet, frame_data);
+    
+    if (buffer_state > 0) {
+        incoming_bit_count_ += packet.sizeBytes << 3;
+
+        if (first_packet_since_reset_) {
+            latest_received_sequence_number_ = packet.seqNum;
+            first_packet_since_reset_ = false;
+        } else {
+            // if (IsPacketRetransmitted(packet)) {
+            //     frame->IncrementNackCount();
+            // }
+
+            UpdateNackList(packet.seqNum);
+
+            latest_received_sequence_number_ = LatestSequenceNumber(
+                                                   latest_received_sequence_number_, packet.seqNum);
+        }
+    }
+
+    // Is the frame already in the decodable list?
+    bool continuous = IsContinuous(*frame);
+    
+    switch (buffer_state) {
+    case kGeneralError:
+    case kTimeStampError:
+    case kSizeError: {
+        free_frames_.push_back(frame);
+        break;
+    }
+
+    case kCompleteSession: {
+        //CountFrame(*frame);
+        // if (previous_state != kStateDecodable &&
+        //         previous_state != kStateComplete) {
+        //     /*CountFrame(*frame);*/ //????????????????????�?? by ylr
+        //     if (continuous) {
+        //         // Signal that we have a complete session.
+        //         frame_event_->Set();
+        //     }
+        // }
+    }
+
+    // Note: There is no break here - continuing to kDecodableSession.
+    case kDecodableSession: {
+        // *retransmitted = (frame->GetNackCount() > 0);
+
+        if (true || continuous) {
+            decodable_frames_.InsertFrame(frame);
+            FindAndInsertContinuousFrames(*frame);
+        } else {
+            incomplete_frames_.InsertFrame(frame);
+
+            // If NACKs are enabled, keyframes are triggered by |GetNackList|.
+            // if (nack_mode_ == kNoNack && NonContinuousOrIncompleteDuration() >
+            //         90 * kMaxDiscontinuousFramesTime) {
+            //     return kFlushIndicator;
+            // }
+        }
+
+        break;
+    }
+
+    case kIncomplete: {
+        if (frame->GetState() == kStateEmpty &&
+                last_decoded_state_.UpdateEmptyFrame(frame)) {
+            free_frames_.push_back(frame);
+            return kNoError;
+        } else {
+            incomplete_frames_.InsertFrame(frame);
+
+            // If NACKs are enabled, keyframes are triggered by |GetNackList|.
+            // if (nack_mode_ == kNoNack && NonContinuousOrIncompleteDuration() >
+            //         90 * kMaxDiscontinuousFramesTime) {
+            //     return kFlushIndicator;
+            // }
+        }
+
+        break;
+    }
+
+    case kNoError:
+    case kOutOfBoundsPacket:
+    case kDuplicatePacket: {
+        // Put back the frame where it came from.
+        if (frame_list != NULL) {
+            frame_list->InsertFrame(frame);
+        } else {
+            free_frames_.push_back(frame);
+        }
+
+        ++num_duplicated_packets_;
+        break;
+    }
+
+    case kFlushIndicator:{
+            free_frames_.push_back(frame);
+        }
+        return kFlushIndicator;
+
+    default:
+        assert(false);
+    }
+
+    return buffer_state;
+}
+
+
+SrsRtpFrameBufferEnum SrsRtpJitterBuffer::InsertPacket2(const SrsRtpPacket2 &pkt,
+        bool* retransmitted)
+{
+    bool singlenual = false;
+    H264PacketizationTypes packetyType = kH264SingleNalu;
+
+    //char *buf = pkt.shared_msg->payload; //rtp packet data
+    //int size = pkt.shared_msg->size; //rtp size
+
+    //rtp header: total size - rtp payload size
+    int rtp_header_size = pkt.shared_msg->size - pkt.payload->nb_bytes();
+   
+    char *rtp_payload_buf = pkt.shared_msg->payload + rtp_header_size;  //rtp payload data
+    int rtp_payload_size = pkt.shared_msg->size - rtp_header_size;  //rtp payload size;
+
+    bool is_first_packet_in_frame = false;
+    
+    SrsAvcNaluType nal_unit_type = SrsAvcNaluTypeReserved;
+    FrameType frameType = kVideoFrameDelta;
+
+    int8_t v = (uint8_t)pkt.nalu_type;
+    if (v == kStapA) {
+        singlenual = false;
+        packetyType = kH264StapA;
+
+        is_first_packet_in_frame = true;
+        
+        SrsRtpSTAPPayload *payload = (SrsRtpSTAPPayload*)pkt.payload;
+        if (payload->get_sps() != NULL){
+            nal_unit_type = SrsAvcNaluTypeSPS;
+            frameType = kVideoFrameKey;
+        }
+    } else if (v == kFuA) {
+        SrsRtpFUAPayload2 *payload = (SrsRtpFUAPayload2*)pkt.payload;
+        int8_t nalu_byte0 = ((int8_t)payload->nri & 0xE0) | ((int8_t)payload->nalu_type & 0x1F);
+        nal_unit_type = (SrsAvcNaluType)(nalu_byte0 & 0x1f);
+
+        if (nal_unit_type == SrsAvcNaluTypeIDR){
+            frameType = kVideoFrameKey;
+        }
+ 
+        if (payload->start){
+            //xx xx ....
+            //xx nalu ....
+            rtp_payload_buf[1] = nalu_byte0;
+
+            //nalu ....
+            rtp_payload_buf = rtp_payload_buf + 1;
+            rtp_payload_size = rtp_payload_size - 1;
+
+            is_first_packet_in_frame = true;
+        }else {
+            //xx xx ....
+            //....
+            rtp_payload_buf = rtp_payload_buf + 2;
+            rtp_payload_size = rtp_payload_size - 2;
+        }
+
+        singlenual = false;
+        packetyType = kH264FuA;
+
+    } else {
+        singlenual = true;
+        packetyType = kH264SingleNalu;
+        is_first_packet_in_frame = true;
+    }
+
+    const VCMPacket packet((const uint8_t*)rtp_payload_buf, rtp_payload_size,
+        pkt.header.get_sequence(), pkt.header.get_timestamp(), pkt.header.get_marker(), 
+        packetyType, kRtpVideoH264, singlenual, is_first_packet_in_frame, frameType);
+
+    ++num_packets_;
+
+    if (num_packets_ == 1) {
+        time_first_packet_ms_ =  srs_update_system_time();
+    }
+
+    //Does this packet belong to an old frame?
+    // if (last_decoded_state_.IsOldPacket(&packet)) {
+     
+    //     //return kOldPacket;
+    // }
+
+    //num_consecutive_old_packets_ = 0;
+
+    SrsRtpFrameBuffer* frame;
+    FrameList* frame_list;
+
+    const SrsRtpFrameBufferEnum error = GetFrameByRtpPacket(packet, &frame, &frame_list);
+
+    if (error != kNoError) {
+        return error;
+    }
+
+
+    //srs_utime_t now_ms =  srs_update_system_time();
+
+    FrameData frame_data;
+    frame_data.rtt_ms = 0; //rtt_ms_;
+    frame_data.rolling_average_packets_per_frame = 25;//average_packets_per_frame_;
+
+    SrsRtpFrameBufferEnum buffer_state = frame->InsertPacket(packet, frame_data);
     
     if (buffer_state > 0) {
         incoming_bit_count_ += packet.sizeBytes << 3;
@@ -1047,8 +1483,8 @@ PsFrameBufferEnum SrsPsJitterBuffer::InsertPacket(const SrsPsRtpPacket &pkt, cha
 }
 
 // Gets frame to use for this timestamp. If no match, get empty frame.
-PsFrameBufferEnum SrsPsJitterBuffer::GetFrame(const VCMPacket& packet,
-        SrsPsFrameBuffer** frame,
+SrsRtpFrameBufferEnum SrsRtpJitterBuffer::GetFrameByRtpPacket(const VCMPacket& packet,
+        SrsRtpFrameBuffer** frame,
         FrameList** frame_list)
 {
     *frame = incomplete_frames_.PopFrame(packet.timestamp);
@@ -1085,7 +1521,7 @@ PsFrameBufferEnum SrsPsJitterBuffer::GetFrame(const VCMPacket& packet,
     return kNoError;
 }
 
-SrsPsFrameBuffer* SrsPsJitterBuffer::GetEmptyFrame()
+SrsRtpFrameBuffer* SrsRtpJitterBuffer::GetEmptyFrame()
 {
     if (free_frames_.empty()) {
         if (!TryToIncreaseJitterBufferSize()) {
@@ -1093,25 +1529,25 @@ SrsPsFrameBuffer* SrsPsJitterBuffer::GetEmptyFrame()
         }
     }
 
-    SrsPsFrameBuffer* frame = free_frames_.front();
+    SrsRtpFrameBuffer* frame = free_frames_.front();
     free_frames_.pop_front();
     return frame;
 }
 
-bool SrsPsJitterBuffer::TryToIncreaseJitterBufferSize()
+bool SrsRtpJitterBuffer::TryToIncreaseJitterBufferSize()
 {
     if (max_number_of_frames_ >= kMaxNumberOfFrames) {
         return false;
     }
 
-    free_frames_.push_back(new SrsPsFrameBuffer());
+    free_frames_.push_back(new SrsRtpFrameBuffer());
     ++max_number_of_frames_;
     return true;
 }
 
 // Recycle oldest frames up to a key frame, used if jitter buffer is completely
 // full.
-bool SrsPsJitterBuffer::RecycleFramesUntilKeyFrame()
+bool SrsRtpJitterBuffer::RecycleFramesUntilKeyFrame()
 {
     // First release incomplete frames, and only release decodable frames if there
     // are no incomplete ones.
@@ -1144,8 +1580,8 @@ bool SrsPsJitterBuffer::RecycleFramesUntilKeyFrame()
     return key_frame_found;
 }
 
-bool SrsPsJitterBuffer::IsContinuousInState(const SrsPsFrameBuffer& frame,
-        const PsDecodingState& decoding_state) const
+bool SrsRtpJitterBuffer::IsContinuousInState(const SrsRtpFrameBuffer& frame,
+        const SrsRtpDecodingState& decoding_state) const
 {
     if (decode_error_mode_ == kWithErrors) {
          return true;
@@ -1160,18 +1596,18 @@ bool SrsPsJitterBuffer::IsContinuousInState(const SrsPsFrameBuffer& frame,
            decoding_state.ContinuousFrame(&frame);
 }
 
-bool SrsPsJitterBuffer::IsContinuous(const SrsPsFrameBuffer& frame) const
+bool SrsRtpJitterBuffer::IsContinuous(const SrsRtpFrameBuffer& frame) const
 {
     if (IsContinuousInState(frame, last_decoded_state_)) {
          return true;
     }
 
-    PsDecodingState decoding_state;
+    SrsRtpDecodingState decoding_state;
     decoding_state.CopyFrom(last_decoded_state_);
 
     for (FrameList::const_iterator it = decodable_frames_.begin();
             it != decodable_frames_.end(); ++it)  {
-        SrsPsFrameBuffer* decodable_frame = it->second;
+        SrsRtpFrameBuffer* decodable_frame = it->second;
 
         if (IsNewerTimestamp(decodable_frame->GetTimeStamp(), frame.GetTimeStamp())) {
             break;
@@ -1187,9 +1623,9 @@ bool SrsPsJitterBuffer::IsContinuous(const SrsPsFrameBuffer& frame) const
     return false;
 }
 
-void SrsPsJitterBuffer::FindAndInsertContinuousFrames(const SrsPsFrameBuffer& new_frame)
+void SrsRtpJitterBuffer::FindAndInsertContinuousFrames(const SrsRtpFrameBuffer& new_frame)
 {
-    PsDecodingState decoding_state;
+    SrsRtpDecodingState decoding_state;
     decoding_state.CopyFrom(last_decoded_state_);
     decoding_state.SetState(&new_frame);
 
@@ -1199,7 +1635,7 @@ void SrsPsJitterBuffer::FindAndInsertContinuousFrames(const SrsPsFrameBuffer& ne
     // 2. The end of the list was reached.
     for (FrameList::iterator it = incomplete_frames_.begin();
             it != incomplete_frames_.end();)  {
-        SrsPsFrameBuffer* frame = it->second;
+        SrsRtpFrameBuffer* frame = it->second;
 
         if (IsNewerTimestamp(new_frame.GetTimeStamp(), frame->GetTimeStamp())) {
             ++it;
@@ -1217,7 +1653,7 @@ void SrsPsJitterBuffer::FindAndInsertContinuousFrames(const SrsPsFrameBuffer& ne
 }
 
 // Must be called under the critical section |crit_sect_|.
-void SrsPsJitterBuffer::CleanUpOldOrEmptyFrames()
+void SrsRtpJitterBuffer::CleanUpOldOrEmptyFrames()
 {
     decodable_frames_.CleanUpOldOrEmptyFrames(&last_decoded_state_,
             &free_frames_);
@@ -1225,13 +1661,13 @@ void SrsPsJitterBuffer::CleanUpOldOrEmptyFrames()
             &free_frames_);
 
     if (!last_decoded_state_.in_initial_state()) {
-        //DropPacketsFromNackList(last_decoded_state_.sequence_num());
+        DropPacketsFromNackList(last_decoded_state_.sequence_num());
     }
 }
 
 // Returns immediately or a |max_wait_time_ms| ms event hang waiting for a
 // complete frame, |max_wait_time_ms| decided by caller.
-bool SrsPsJitterBuffer::NextCompleteTimestamp(uint32_t max_wait_time_ms, uint32_t* timestamp)
+bool SrsRtpJitterBuffer::NextCompleteTimestamp(uint32_t max_wait_time_ms, uint32_t* timestamp)
 {
     // crit_sect_->Enter();
 
@@ -1282,17 +1718,17 @@ bool SrsPsJitterBuffer::NextCompleteTimestamp(uint32_t max_wait_time_ms, uint32_
     return true;
 }
 
-bool SrsPsJitterBuffer::NextMaybeIncompleteTimestamp(uint32_t* timestamp)
+bool SrsRtpJitterBuffer::NextMaybeIncompleteTimestamp(uint32_t* timestamp)
 {
     if (decode_error_mode_ == kNoErrors) {
-        srs_warn("gb28181 SrsJitterBuffer::NextMaybeIncompleteTimestamp decode_error_mode_ %d", decode_error_mode_);
+        srs_warn("RTP SrsJitterBuffer::NextMaybeIncompleteTimestamp decode_error_mode_ %d", decode_error_mode_);
         // No point to continue, as we are not decoding with errors.
         return false;
     }
 
     CleanUpOldOrEmptyFrames();
 
-    SrsPsFrameBuffer* oldest_frame;
+    SrsRtpFrameBuffer* oldest_frame;
 
     if (decodable_frames_.empty()) {
         if (incomplete_frames_.size() <= 1) {
@@ -1300,9 +1736,9 @@ bool SrsPsJitterBuffer::NextMaybeIncompleteTimestamp(uint32_t* timestamp)
         }
 
         oldest_frame = incomplete_frames_.Front();
-        PsFrameBufferStateEnum oldest_frame_state = oldest_frame->GetState();
+        SrsRtpFrameBufferStateEnum oldest_frame_state = oldest_frame->GetState();
 
-        SrsPsFrameBuffer* next_frame;
+        SrsRtpFrameBuffer* next_frame;
         next_frame = incomplete_frames_.FrontNext();
     
         if (oldest_frame_state !=  kStateComplete && next_frame &&
@@ -1316,7 +1752,7 @@ bool SrsPsJitterBuffer::NextMaybeIncompleteTimestamp(uint32_t* timestamp)
             int oldest_frame_hight_seq = oldest_frame->GetHighSeqNum();
             int next_frame_low_seq = next_frame->GetLowSeqNum();
 
-            srs_warn("gb28181 SrsPsJitterBuffer::NextMaybeIncompleteTimestamp key(%s) incomplete oldest_frame (%u,%d)->(%u,%d)",
+            srs_warn("RtpJitterBuffer: NextMaybeIncompleteTimestamp key(%s) incomplete oldest_frame (%u,%d)->(%u,%d)",
                     key_.c_str(), oldest_frame->GetTimeStamp(), oldest_frame_hight_seq, 
                     next_frame->GetTimeStamp(), next_frame_low_seq);
             return false;
@@ -1337,10 +1773,10 @@ bool SrsPsJitterBuffer::NextMaybeIncompleteTimestamp(uint32_t* timestamp)
     return true;
 }
 
-SrsPsFrameBuffer* SrsPsJitterBuffer::ExtractAndSetDecode(uint32_t timestamp)
+SrsRtpFrameBuffer* SrsRtpJitterBuffer::ExtractAndSetDecode(uint32_t timestamp)
 {
     // Extract the frame with the desired timestamp.
-    SrsPsFrameBuffer* frame = decodable_frames_.PopFrame(timestamp);
+    SrsRtpFrameBuffer* frame = decodable_frames_.PopFrame(timestamp);
     bool continuous = true;
 
     if (!frame) {
@@ -1371,7 +1807,7 @@ SrsPsFrameBuffer* SrsPsJitterBuffer::ExtractAndSetDecode(uint32_t timestamp)
 
 // Release frame when done with decoding. Should never be used to release
 // frames from within the jitter buffer.
-void SrsPsJitterBuffer::ReleaseFrame(SrsPsFrameBuffer* frame)
+void SrsRtpJitterBuffer::ReleaseFrame(SrsRtpFrameBuffer* frame)
 {
     //CriticalSectionScoped cs(crit_sect_);
     //VCMFrameBuffer* frame_buffer = static_cast<VCMFrameBuffer*>(frame);
@@ -1381,7 +1817,7 @@ void SrsPsJitterBuffer::ReleaseFrame(SrsPsFrameBuffer* frame)
     }
 }
 
-bool SrsPsJitterBuffer::FoundFrame(uint32_t& time_stamp)
+bool SrsRtpJitterBuffer::FoundFrame(uint32_t& time_stamp)
 {
     
     bool found_frame = NextCompleteTimestamp(0, &time_stamp);
@@ -1393,9 +1829,9 @@ bool SrsPsJitterBuffer::FoundFrame(uint32_t& time_stamp)
     return found_frame;
 }
 
-bool SrsPsJitterBuffer::GetPsFrame(char **buffer,  int &buf_len, int &size, const uint32_t time_stamp)
+bool SrsRtpJitterBuffer::GetFrame(char **buffer,  int &buf_len, int &size, bool &keyframe, const uint32_t time_stamp)
 {
-    SrsPsFrameBuffer* frame = ExtractAndSetDecode(time_stamp);
+    SrsRtpFrameBuffer* frame = ExtractAndSetDecode(time_stamp);
 
     if (frame == NULL) {
         return false;
@@ -1410,14 +1846,14 @@ bool SrsPsJitterBuffer::GetPsFrame(char **buffer,  int &buf_len, int &size, cons
         return false;
     }
    
-    //verify and allocate ps buffer
+    //verify and allocate a frame buffer, used to completed frame data
     if (buf_len < size || *buffer == NULL) {
         srs_freepa(*buffer);
 
-        int resize = size + 10240;
+        int resize = size + kBufferIncStepSizeBytes;
         *buffer = new char[resize];
 
-        srs_trace("gb28181: SrsPsJitterBuffer key=%s reallocate ps buffer size(%d>%d) resize(%d)", 
+        srs_trace("RtpJitterBuffer: key=%s reallocate a frame buffer size(%d>%d) resize(%d)", 
             key_.c_str(), size, buf_len, resize);
             
         buf_len = resize;
@@ -1425,14 +1861,17 @@ bool SrsPsJitterBuffer::GetPsFrame(char **buffer,  int &buf_len, int &size, cons
 
     const uint8_t *frame_buffer = frame->Buffer();
     memcpy(*buffer, frame_buffer, size);
-    
+    if (frame->GetFrameType() == kVideoFrameKey){
+        keyframe = true;
+    }
+
     frame->PrepareForDecode(false);
     ReleaseFrame(frame);
     return true;
 }
 
 
-SrsPsFrameBuffer* SrsPsJitterBuffer::NextFrame() const
+SrsRtpFrameBuffer* SrsRtpJitterBuffer::NextFrame() const
 {
     if (!decodable_frames_.empty()) {
         return decodable_frames_.Front();
@@ -1445,7 +1884,7 @@ SrsPsFrameBuffer* SrsPsJitterBuffer::NextFrame() const
     return NULL;
 }
 
-bool SrsPsJitterBuffer::UpdateNackList(uint16_t sequence_number)
+bool SrsRtpJitterBuffer::UpdateNackList(uint16_t sequence_number)
 {
     if (nack_mode_ == kNoNack) {
         return true;
@@ -1466,18 +1905,17 @@ bool SrsPsJitterBuffer::UpdateNackList(uint16_t sequence_number)
             missing_sequence_numbers_.insert(missing_sequence_numbers_.end(), i);
         }
 
-        /*
         if (TooLargeNackList() && !HandleTooLargeNackList()) {
-            srs_warn("gb28181: SrsPsJitterBuffer key(%s) requesting key frame due to too large NACK list.",  key_.c_str());
+            srs_warn("RtpJitterBuffer: key(%s) requesting key frame due to too large NACK list.",  key_.c_str());
             return false;
         }
 
         if (MissingTooOldPacket(sequence_number) &&
                 !HandleTooOldPackets(sequence_number)) {
-            srs_warn("gb28181: SrsPsJitterBuffer key(%s) requesting key frame due to missing too old packets",  key_.c_str());
+            srs_warn("RtpJitterBuffer: key(%s) requesting key frame due to missing too old packets",  key_.c_str());
             return false;
         }
-        */
+        
     } else {
         missing_sequence_numbers_.erase(sequence_number);
     }
@@ -1485,16 +1923,16 @@ bool SrsPsJitterBuffer::UpdateNackList(uint16_t sequence_number)
     return true;
 }
 
-bool SrsPsJitterBuffer::TooLargeNackList() const
+bool SrsRtpJitterBuffer::TooLargeNackList() const
 {
     return missing_sequence_numbers_.size() > max_nack_list_size_;
 }
 
-bool SrsPsJitterBuffer::HandleTooLargeNackList()
+bool SrsRtpJitterBuffer::HandleTooLargeNackList()
 {
     // Recycle frames until the NACK list is small enough. It is likely cheaper to
     // request a key frame than to retransmit this many missing packets.
-    srs_warn("gb28181: SrsPsJitterBuffer NACK list has grown too large: %d > %d", 
+    srs_warn("RtpJitterBuffer: NACK list has grown too large: %d > %d", 
                     missing_sequence_numbers_.size(), max_nack_list_size_);
     bool key_frame_found = false;
 
@@ -1505,7 +1943,7 @@ bool SrsPsJitterBuffer::HandleTooLargeNackList()
     return key_frame_found;
 }
 
-bool SrsPsJitterBuffer::MissingTooOldPacket(uint16_t latest_sequence_number) const
+bool SrsRtpJitterBuffer::MissingTooOldPacket(uint16_t latest_sequence_number) const
 {
     if (missing_sequence_numbers_.empty()) {
         return false;
@@ -1518,12 +1956,12 @@ bool SrsPsJitterBuffer::MissingTooOldPacket(uint16_t latest_sequence_number) con
     return age_of_oldest_missing_packet > max_packet_age_to_nack_;
 }
 
-bool SrsPsJitterBuffer::HandleTooOldPackets(uint16_t latest_sequence_number)
+bool SrsRtpJitterBuffer::HandleTooOldPackets(uint16_t latest_sequence_number)
 {
     bool key_frame_found = false;
     const uint16_t age_of_oldest_missing_packet = latest_sequence_number -
             *missing_sequence_numbers_.begin();
-    srs_warn("gb28181: SrsPsJitterBuffer  NACK list contains too old sequence numbers: %d > %d",
+    srs_warn("RtpJitterBuffer:  NACK list contains too old sequence numbers: %d > %d",
                       age_of_oldest_missing_packet,
                       max_packet_age_to_nack_);
 
@@ -1534,7 +1972,7 @@ bool SrsPsJitterBuffer::HandleTooOldPackets(uint16_t latest_sequence_number)
     return key_frame_found;
 }
 
-void SrsPsJitterBuffer::DropPacketsFromNackList(uint16_t last_decoded_sequence_number)
+void SrsRtpJitterBuffer::DropPacketsFromNackList(uint16_t last_decoded_sequence_number)
 {
     // Erase all sequence numbers from the NACK list which we won't need any
     // longer.
@@ -1543,7 +1981,7 @@ void SrsPsJitterBuffer::DropPacketsFromNackList(uint16_t last_decoded_sequence_n
                                         last_decoded_sequence_number));
 }
 
-void SrsPsJitterBuffer::SetNackMode(PsNackMode mode,
+void SrsRtpJitterBuffer::SetNackMode(SrsRtpNackMode mode,
                                   int64_t low_rtt_nack_threshold_ms,
                                   int64_t high_rtt_nack_threshold_ms)
 {
@@ -1571,7 +2009,7 @@ void SrsPsJitterBuffer::SetNackMode(PsNackMode mode,
     // }
 }
 
-void SrsPsJitterBuffer::SetNackSettings(size_t max_nack_list_size,
+void SrsRtpJitterBuffer::SetNackSettings(size_t max_nack_list_size,
                                       int max_packet_age_to_nack,
                                       int max_incomplete_time_ms)
 {
@@ -1583,13 +2021,13 @@ void SrsPsJitterBuffer::SetNackSettings(size_t max_nack_list_size,
     nack_seq_nums_.resize(max_nack_list_size_);
 }
 
-PsNackMode SrsPsJitterBuffer::nack_mode() const
+SrsRtpNackMode SrsRtpJitterBuffer::nack_mode() const
 {
     return nack_mode_;
 }
 
 
-int SrsPsJitterBuffer::NonContinuousOrIncompleteDuration()
+int SrsRtpJitterBuffer::NonContinuousOrIncompleteDuration()
 {
     if (incomplete_frames_.empty()) {
         return 0;
@@ -1604,7 +2042,7 @@ int SrsPsJitterBuffer::NonContinuousOrIncompleteDuration()
     return incomplete_frames_.Back()->GetTimeStamp() - start_timestamp;
 }
 
-uint16_t SrsPsJitterBuffer::EstimatedLowSequenceNumber(const SrsPsFrameBuffer& frame) const
+uint16_t SrsRtpJitterBuffer::EstimatedLowSequenceNumber(const SrsRtpFrameBuffer& frame) const
 {
     assert(frame.GetLowSeqNum() >= 0);
 
@@ -1617,7 +2055,7 @@ uint16_t SrsPsJitterBuffer::EstimatedLowSequenceNumber(const SrsPsFrameBuffer& f
     return frame.GetLowSeqNum() - 1;
 }
 
-uint16_t* SrsPsJitterBuffer::GetNackList(uint16_t* nack_list_size,
+uint16_t* SrsRtpJitterBuffer::GetNackList(uint16_t* nack_list_size,
                                        bool* request_key_frame)
 {
     //CriticalSectionScoped cs(crit_sect_);
@@ -1629,9 +2067,9 @@ uint16_t* SrsPsJitterBuffer::GetNackList(uint16_t* nack_list_size,
     }
 
     if (last_decoded_state_.in_initial_state()) {
-        SrsPsFrameBuffer* next_frame = NextFrame();
+        SrsRtpFrameBuffer* next_frame = NextFrame();
         const bool first_frame_is_key = next_frame &&
-                                        //next_frame->FrameType() == kVideoFrameKey &&
+                                        next_frame->GetFrameType() == kVideoFrameKey &&
                                         next_frame->HaveFirstPacket();
 
         if (!first_frame_is_key) {
@@ -1697,7 +2135,7 @@ uint16_t* SrsPsJitterBuffer::GetNackList(uint16_t* nack_list_size,
     return &nack_seq_nums_[0];
 }
 
-bool SrsPsJitterBuffer::WaitForRetransmissions()
+bool SrsRtpJitterBuffer::WaitForRetransmissions()
 {
     if (nack_mode_ == kNoNack) {
         // NACK disabled -> don't wait for retransmissions.
@@ -1712,4 +2150,43 @@ bool SrsPsJitterBuffer::WaitForRetransmissions()
     }
 
     return true;
+}
+
+bool SrsRtpJitterBuffer::IsPacketInOrder(uint16_t sequence_number)
+{
+    if (!first_packet_) {
+        return true;
+    }
+
+    if (IsNewerSequenceNumber(sequence_number, last_received_sequence_number_)) {
+        return true;
+    }
+
+    return false;
+}
+
+bool SrsRtpJitterBuffer::IsFirstPacketInFrame(uint32_t ts, uint16_t seq)
+{
+    bool is_first_packet_in_frame = false;
+    bool in_order = IsPacketInOrder(seq);
+
+    if (first_packet_){
+        is_first_packet_in_frame =
+            last_received_sequence_number_ + 1 == seq &&
+            last_received_timestamp_ != ts;
+    }else{
+        is_first_packet_in_frame = true;
+    }
+
+    if (in_order) {
+        first_packet_ = true;
+
+        if (last_received_timestamp_ != ts) {
+            last_received_timestamp_ = ts;
+        }
+
+        last_received_sequence_number_ = seq;
+    }
+
+    return is_first_packet_in_frame;
 }

--- a/trunk/src/app/srs_app_rtc_rtp_jitbuffer.hpp
+++ b/trunk/src/app/srs_app_rtc_rtp_jitbuffer.hpp
@@ -21,8 +21,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef SRS_APP_GB28181_JITBUFFER_HPP
-#define SRS_APP_GB28181_JITBUFFER_HPP
+#ifndef SRS_APP_RTC_RTP_JITBUFFER_HPP
+#define SRS_APP_RTC_RTP_JITBUFFER_HPP
 
 #include <srs_core.hpp>
 
@@ -36,13 +36,15 @@
 
 #include <srs_app_log.hpp>
 #include <srs_kernel_utility.hpp>
-#include <srs_app_gb28181.hpp>
+#include <srs_kernel_rtc_rtp.hpp>
+#include <srs_kernel_flv.hpp>
 
 class SrsPsRtpPacket;
-class SrsPsFrameBuffer;
-class PsDecodingState;
+class SrsRtpFrameBuffer;
+class SrsRtpDecodingState;
 class SrsGb28181RtmpMuxer;
 class VCMPacket;
+class SrsRtpPacket2;
 
 ///jittbuffer
 
@@ -57,7 +59,7 @@ enum FrameType {
 };
 
 // Used to indicate which decode with errors mode should be used.
-enum PsDecodeErrorMode {
+enum SrsRtpDecodeErrorMode {
     kNoErrors,                // Never decode with errors. Video will freeze
     // if nack is disabled.
     kSelectiveErrors,         // Frames that are determined decodable in
@@ -79,7 +81,7 @@ enum { kMaxVideoDelayMs       = 10000 };
 enum { kPacketsPerFrameMultiplier = 5 };
 enum { kFastConvergeThreshold = 5};
 
-enum PsJitterBufferEnum {
+enum SrsRtpJitterBufferEnum {
     kMaxConsecutiveOldFrames        = 60,
     kMaxConsecutiveOldPackets       = 300,
     kMaxPacketsInSession            = 800,
@@ -87,7 +89,7 @@ enum PsJitterBufferEnum {
     kMaxJBFrameSizeBytes            = 4000000  // sanity don't go above 4Mbyte.
 };
 
-enum PsFrameBufferEnum {
+enum SrsRtpFrameBufferEnum {
     kOutOfBoundsPacket    = -7,
     kNotInitialized       = -6,
     kOldPacket            = -5,
@@ -102,17 +104,64 @@ enum PsFrameBufferEnum {
     kDuplicatePacket      = 5     // We're receiving a duplicate packet.
 };
 
-enum PsFrameBufferStateEnum {
+enum SrsRtpFrameBufferStateEnum {
     kStateEmpty,              // frame popped by the RTP receiver
     kStateIncomplete,         // frame that have one or more packet(s) stored
     kStateComplete,           // frame that have all packets
     kStateDecodable           // Hybrid mode - frame can be decoded
 };
 
-enum PsNackMode {
+enum SrsRtpNackMode {
     kNack,
     kNoNack
 };
+
+// Used to indicate if a received packet contain a complete NALU (or equivalent)
+enum VCMNaluCompleteness {
+    kNaluUnset = 0,       // Packet has not been filled.
+    kNaluComplete = 1,    // Packet can be decoded as is.
+    kNaluStart,           // Packet contain beginning of NALU
+    kNaluIncomplete,      // Packet is not beginning or end of NALU
+    kNaluEnd,             // Packet is the end of a NALU
+};
+
+enum RtpVideoCodecTypes {
+    kRtpVideoNone,
+    kRtpVideoGeneric,
+    kRtpVideoVp8,
+    kRtpVideoVp9,
+    kRtpVideoH264,
+    kRtpVideoPS
+};
+
+
+// Video codec types
+enum VideoCodecType {
+    kVideoCodecVP8,
+    kVideoCodecVP9,
+    kVideoCodecH264,
+    kVideoCodecH264SVC,
+    kVideoCodecI420,
+    kVideoCodecRED,
+    kVideoCodecULPFEC,
+    kVideoCodecGeneric,
+    kVideoCodecH264PS,
+    kVideoCodecUnknown
+};
+
+// The packetization types that we support: single, aggregated, and fragmented.
+enum H264PacketizationTypes {
+    kH264SingleNalu,  // This packet contains a single NAL unit.
+    kH264StapA,       // This packet contains STAP-A (single time
+    // aggregation) packets. If this packet has an
+    // associated NAL unit type, it'll be for the
+    // first such aggregated packet.
+    kH264FuA,         // This packet contains a FU-A (fragmentation
+    // unit) packet, meaning it is a part of a frame
+    // that was too large to fit into a single packet.
+};
+
+enum { kH264StartCodeLengthBytes = 4};
 
 // Used to pass data from jitter buffer to session info.
 // This data is then used in determining whether a frame is decodable.
@@ -147,7 +196,7 @@ inline uint32_t LatestTimestamp(uint32_t timestamp1, uint32_t timestamp2)
     return IsNewerTimestamp(timestamp1, timestamp2) ? timestamp1 : timestamp2;
 }
 
-typedef std::list<SrsPsFrameBuffer*> UnorderedFrameList;
+typedef std::list<SrsRtpFrameBuffer*> UnorderedFrameList;
 
 class TimestampLessThan {
 public:
@@ -159,16 +208,16 @@ public:
 };
 
 class FrameList
-    : public std::map<uint32_t, SrsPsFrameBuffer*, TimestampLessThan> {
+    : public std::map<uint32_t, SrsRtpFrameBuffer*, TimestampLessThan> {
 public:
-    void InsertFrame(SrsPsFrameBuffer* frame);
-    SrsPsFrameBuffer* PopFrame(uint32_t timestamp);
-    SrsPsFrameBuffer* Front() const;
-    SrsPsFrameBuffer* FrontNext() const;
-    SrsPsFrameBuffer* Back() const;
+    void InsertFrame(SrsRtpFrameBuffer* frame);
+    SrsRtpFrameBuffer* PopFrame(uint32_t timestamp);
+    SrsRtpFrameBuffer* Front() const;
+    SrsRtpFrameBuffer* FrontNext() const;
+    SrsRtpFrameBuffer* Back() const;
     int RecycleFramesUntilKeyFrame(FrameList::iterator* key_frame_it,
                                    UnorderedFrameList* free_frames);
-    void CleanUpOldOrEmptyFrames(PsDecodingState* decoding_state, UnorderedFrameList* free_frames);
+    void CleanUpOldOrEmptyFrames(SrsRtpDecodingState* decoding_state, UnorderedFrameList* free_frames);
     void Reset(UnorderedFrameList* free_frames);
 };
 
@@ -180,7 +229,13 @@ public:
               size_t size,
               uint16_t seqNum,
               uint32_t timestamp,
-              bool markerBit);
+              bool markerBit,
+              H264PacketizationTypes type,
+              RtpVideoCodecTypes rtpType,
+              bool singlenual,
+              bool isfirst,
+              FrameType ftype
+              );
 
     void Reset();
 
@@ -191,27 +246,35 @@ public:
     uint16_t          seqNum;
     const uint8_t*    dataPtr;
     size_t          sizeBytes;
-    bool                    markerBit;
+    bool            markerBit;
 
     FrameType               frameType;
-    //cloopenwebrtc::VideoCodecType  codec;
+    VideoCodecType  codec;
 
     bool isFirstPacket;                 // Is this first packet in a frame.
-    //VCMNaluCompleteness completeNALU;   // Default is kNaluIncomplete.
+    VCMNaluCompleteness completeNALU;   // Default is kNaluIncomplete.
     bool insertStartCode;               // True if a start code should be inserted before this
     // packet.
     int width;
     int height;
     //RTPVideoHeader codecSpecificHeader;
+    
+
+    //H264 header
+    H264PacketizationTypes h264packetizationType;
+    bool  h264singleNalu;
+  
+public:
+    void CopyCodecSpecifics(RtpVideoCodecTypes codecType, bool H264single_nalu, bool firstPacket);
 };
 
-class SrsPsFrameBuffer {
+class SrsRtpFrameBuffer {
 public:
-    SrsPsFrameBuffer();
-    virtual ~SrsPsFrameBuffer();
+    SrsRtpFrameBuffer();
+    virtual ~SrsRtpFrameBuffer();
 
 public:
-    PsFrameBufferEnum InsertPacket(const VCMPacket& packet,  const FrameData& frame_data);
+    SrsRtpFrameBufferEnum InsertPacket(const VCMPacket& packet,  const FrameData& frame_data);
     void UpdateCompleteSession();
     void UpdateDecodableSession(const FrameData& frame_data);
     bool HaveFirstPacket() const;
@@ -220,7 +283,7 @@ public:
    
     uint32_t GetTimeStamp() const;
     FrameType GetFrameType() const;
-    PsFrameBufferStateEnum GetState() const;
+    SrsRtpFrameBufferStateEnum GetState() const;
 
     int32_t GetHighSeqNum() const;
     int32_t GetLowSeqNum() const;
@@ -233,7 +296,6 @@ public:
     bool complete() const;
     bool decodable() const;
 
-    bool GetPsPlayload(SrsSimpleStream **ps_data, int &count);
     bool DeletePacket(int &count);
     void PrepareForDecode(bool continuous);
    
@@ -248,7 +310,7 @@ private:
                                 const PacketIterator& prev_packet_it);
 
     size_t InsertBuffer(uint8_t* frame_buffer, PacketIterator packet_it);
-    size_t Insert(const uint8_t* buffer, size_t length, uint8_t* frame_buffer);
+    size_t Insert(const uint8_t* buffer, size_t length, bool insert_start_code, uint8_t* frame_buffer);
     void ShiftSubsequentPackets(PacketIterator it,  int steps_to_shift);
     void VerifyAndAllocate(const uint32_t minimumSize);
     void UpdateDataPointers(const uint8_t* old_base_ptr, const uint8_t* new_base_ptr);
@@ -269,11 +331,11 @@ private:
     uint32_t timeStamp_;
     FrameType frame_type_;
 
-    PsDecodeErrorMode decode_error_mode_;
-    PsFrameBufferStateEnum state_;
+    SrsRtpDecodeErrorMode decode_error_mode_;
+    SrsRtpFrameBufferStateEnum state_;
    
-    uint16_t             nackCount_;
-    int64_t              latestPacketTimeMs_;
+    //uint16_t             nackCount_;
+    //int64_t              latestPacketTimeMs_;
 
     // The payload.
     uint8_t* _buffer;
@@ -281,20 +343,20 @@ private:
     size_t _length;
 };
 
-class PsDecodingState {
+class SrsRtpDecodingState {
 public:
-    PsDecodingState();
-    ~PsDecodingState();
+    SrsRtpDecodingState();
+    ~SrsRtpDecodingState();
     // Check for old frame
-    bool IsOldFrame(const SrsPsFrameBuffer* frame) const;
+    bool IsOldFrame(const SrsRtpFrameBuffer* frame) const;
     // Check for old packet
     bool IsOldPacket(const VCMPacket* packet);
     // Check for frame continuity based on current decoded state. Use best method
     // possible, i.e. temporal info, picture ID or sequence number.
-    bool ContinuousFrame(const SrsPsFrameBuffer* frame) const;
-    void SetState(const SrsPsFrameBuffer* frame);
-    void CopyFrom(const PsDecodingState& state);
-    bool UpdateEmptyFrame(const SrsPsFrameBuffer* frame);
+    bool ContinuousFrame(const SrsRtpFrameBuffer* frame) const;
+    void SetState(const SrsRtpFrameBuffer* frame);
+    void CopyFrom(const SrsRtpDecodingState& state);
+    bool UpdateEmptyFrame(const SrsRtpFrameBuffer* frame);
     // Update the sequence number if the timestamp matches current state and the
     // sequence number is higher than the current one. This accounts for packets
     // arriving late.
@@ -309,64 +371,81 @@ public:
     bool full_sync() const;
 
 private:
-    void UpdateSyncState(const SrsPsFrameBuffer* frame);
+    void UpdateSyncState(const SrsRtpFrameBuffer* frame);
     // Designated continuity functions
     //bool ContinuousPictureId(int picture_id) const;
     bool ContinuousSeqNum(uint16_t seq_num) const;
     //bool ContinuousLayer(int temporal_id, int tl0_pic_id) const;
-    //bool UsingPictureId(const SrsPsFrameBuffer* frame) const;
+    //bool UsingPictureId(const SrsRtpFrameBuffer* frame) const;
 
     // Keep state of last decoded frame.
     // TODO(mikhal/stefan): create designated classes to handle these types.
     uint16_t    sequence_num_;
     uint32_t    time_stamp_;
-    int         picture_id_;
-    int         temporal_id_;
-    int         tl0_pic_id_;
     bool        full_sync_;  // Sync flag when temporal layers are used.
     bool        in_initial_state_;
 
     bool        m_firstPacket;
 };
 
-class SrsPsJitterBuffer
+// The time jitter correct for rtp.
+class SrsRtpTimeJitter
+{
+private:
+    int64_t previous_timestamp;
+    int64_t pts;
+    int delta;
+public:
+    SrsRtpTimeJitter();
+    virtual ~SrsRtpTimeJitter();
+public:
+    int64_t timestamp();
+    srs_error_t correct(int64_t& ts);
+    void reset();
+};
+
+class SrsRtpJitterBuffer
 {
 public:
-    SrsPsJitterBuffer(std::string key);
-    virtual ~SrsPsJitterBuffer();
+    SrsRtpJitterBuffer(std::string key);
+    virtual ~SrsRtpJitterBuffer();
 
 public:
     srs_error_t start();
     void Reset();
-    PsFrameBufferEnum InsertPacket(const SrsPsRtpPacket &packet, char *buf, int size, bool* retransmitted);
-    void ReleaseFrame(SrsPsFrameBuffer* frame);
+    SrsRtpFrameBufferEnum InsertPacket2(const SrsRtpPacket2 &pkt, bool* retransmitted);
+    SrsRtpFrameBufferEnum InsertPacket(uint16_t seq, uint32_t ts, bool maker, char *buf, int size,
+        bool* retransmitted);
+    void ReleaseFrame(SrsRtpFrameBuffer* frame);
     bool FoundFrame(uint32_t& time_stamp);
-    bool GetPsFrame(char **buffer, int &buf_len, int &size, const uint32_t time_stamp);
-    void SetDecodeErrorMode(PsDecodeErrorMode error_mode);
-    void SetNackMode(PsNackMode mode,int64_t low_rtt_nack_threshold_ms,
+    bool GetFrame(char **buffer, int &buf_len, int &size, bool &keyframe, const uint32_t time_stamp);
+    void SetDecodeErrorMode(SrsRtpDecodeErrorMode error_mode);
+    void SetNackMode(SrsRtpNackMode mode,int64_t low_rtt_nack_threshold_ms,
                                     int64_t high_rtt_nack_threshold_ms);
     void SetNackSettings(size_t max_nack_list_size,int max_packet_age_to_nack, 
                                     int max_incomplete_time_ms);
     uint16_t* GetNackList(uint16_t* nack_list_size, bool* request_key_frame);
     void Flush();
+    void ResetJittter();
 
+    bool isFirstKeyFrame;
 private:
 
-    PsFrameBufferEnum GetFrame(const VCMPacket& packet, SrsPsFrameBuffer** frame,
+    SrsRtpFrameBufferEnum GetFrameByRtpPacket(const VCMPacket& packet, SrsRtpFrameBuffer** frame,
                               FrameList** frame_list);
-    SrsPsFrameBuffer* GetEmptyFrame();
+    SrsRtpFrameBuffer* GetEmptyFrame();
     bool NextCompleteTimestamp(uint32_t max_wait_time_ms, uint32_t* timestamp);
     bool NextMaybeIncompleteTimestamp(uint32_t* timestamp);
-    SrsPsFrameBuffer* ExtractAndSetDecode(uint32_t timestamp);
-    SrsPsFrameBuffer* NextFrame() const;
+    SrsRtpFrameBuffer* ExtractAndSetDecode(uint32_t timestamp);
+    SrsRtpFrameBuffer* NextFrame() const;
   
 
     bool TryToIncreaseJitterBufferSize();
     bool RecycleFramesUntilKeyFrame();
-    bool IsContinuous(const SrsPsFrameBuffer& frame) const;
-    bool IsContinuousInState(const SrsPsFrameBuffer& frame,
-        const PsDecodingState& decoding_state) const;
-    void FindAndInsertContinuousFrames(const SrsPsFrameBuffer& new_frame);
+    bool IsContinuous(const SrsRtpFrameBuffer& frame) const;
+    bool IsContinuousInState(const SrsRtpFrameBuffer& frame,
+        const SrsRtpDecodingState& decoding_state) const;
+    void FindAndInsertContinuousFrames(const SrsRtpFrameBuffer& new_frame);
     void CleanUpOldOrEmptyFrames();
 
     //nack
@@ -376,10 +455,13 @@ private:
     bool MissingTooOldPacket(uint16_t latest_sequence_number) const;
     bool HandleTooOldPackets(uint16_t latest_sequence_number);
     void DropPacketsFromNackList(uint16_t last_decoded_sequence_number);
-    PsNackMode nack_mode() const;
+    SrsRtpNackMode nack_mode() const;
     int NonContinuousOrIncompleteDuration();
-    uint16_t EstimatedLowSequenceNumber(const SrsPsFrameBuffer& frame) const;
+    uint16_t EstimatedLowSequenceNumber(const SrsRtpFrameBuffer& frame) const;
     bool WaitForRetransmissions();
+
+    bool IsPacketInOrder(uint16_t sequence_number);
+    bool IsFirstPacketInFrame(uint32_t ts, uint16_t seq);
    
 private:
     class SequenceNumberLessThan {
@@ -402,7 +484,7 @@ private:
     UnorderedFrameList free_frames_;
     FrameList decodable_frames_;
     FrameList incomplete_frames_;
-    PsDecodingState last_decoded_state_;
+    SrsRtpDecodingState last_decoded_state_;
     bool first_packet_since_reset_;
 
     // Statistics.
@@ -436,9 +518,9 @@ private:
     //VCMInterFrameDelay inter_frame_delay_;
     //VCMJitterSample waiting_for_completion_;
     int64_t rtt_ms_;
- 
+
     // NACK and retransmissions.
-    PsNackMode nack_mode_;
+    SrsRtpNackMode nack_mode_;
     int64_t low_rtt_nack_threshold_ms_;
     int64_t high_rtt_nack_threshold_ms_;
     // Holds the internal NACK list (the missing sequence numbers).
@@ -449,12 +531,17 @@ private:
     int max_packet_age_to_nack_;  // Measured in sequence numbers.
     int max_incomplete_time_ms_;
 
-    PsDecodeErrorMode decode_error_mode_;
+    SrsRtpDecodeErrorMode decode_error_mode_;
     // Estimated rolling average of packets per frame
     float average_packets_per_frame_;
     // average_packets_per_frame converges fast if we have fewer than this many
     // frames.
     int frame_counter_;
+
+    uint32_t last_received_timestamp_;
+    uint16_t last_received_sequence_number_;
+    bool first_packet_;
+    
 };
 
 #endif

--- a/trunk/src/app/srs_app_rtc_rtp_rtmp.cpp
+++ b/trunk/src/app/srs_app_rtc_rtp_rtmp.cpp
@@ -1,0 +1,1274 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013-2020 Lixin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <srs_app_rtc_rtp_rtmp.hpp>
+using namespace std;
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <sstream>
+
+#include <srs_protocol_utility.hpp>
+#include <srs_raw_avc.hpp>
+#include <srs_app_rtmp_conn.hpp>
+#include <srs_app_rtc_conn.hpp>
+#include <srs_app_rtc_source.hpp>
+
+SrsRtcRtmpRecv::SrsRtcRtmpRecv(SrsRtcConnection* s, SrsRtcRtmpMuxer* m, const SrsContextId& cid)
+{
+    cid_ = cid;
+    trd = new SrsDummyCoroutine();
+    is_started = false;
+    sdk = NULL;
+    session_ = s;
+    muxer_ = m;
+    locker_ = srs_mutex_new();
+}
+
+SrsRtcRtmpRecv::~SrsRtcRtmpRecv()
+{
+    stop();
+    srs_freep(trd);
+    srs_mutex_destroy(locker_);
+}
+
+srs_error_t SrsRtcRtmpRecv::on_reload_vhost_play(std::string vhost)
+{
+    return srs_success;
+}
+
+srs_error_t SrsRtcRtmpRecv::on_reload_vhost_realtime(std::string vhost)
+{
+    return on_reload_vhost_play(vhost);
+}
+
+const SrsContextId& SrsRtcRtmpRecv::context_id()
+{
+    return cid_;
+}
+
+srs_error_t SrsRtcRtmpRecv::start()
+{
+    srs_error_t err = srs_success;
+
+    if (is_started) {
+        return err;
+    }
+
+    srs_freep(trd);
+    trd = new SrsSTCoroutine("rtc_rtmpmuxer_recv", this, cid_);
+    srs_trace("start rtc_rtmpmuxer_recv");
+
+    if ((err = trd->start()) != srs_success) {
+        return srs_error_wrap(err, "rtc_rtmpmuxer_recv");
+    }
+
+    is_started = true;
+
+    return err;
+}
+
+void SrsRtcRtmpRecv::stop()
+{
+    trd->stop();
+}
+
+void SrsRtcRtmpRecv::set_rtmp_client(SrsSimpleRtmpClient* c)
+{
+    //locker RTMP Muxer will be released and reconnected 
+    SrsLocker(locker_);
+    sdk = c;
+    srs_trace("RTC: rtmpmuxer(%s) set rtmp client:%d", muxer_->stream_url().c_str(), sdk);
+}
+
+srs_error_t SrsRtcRtmpRecv::cycle()
+{
+    srs_error_t err = srs_success;
+    int err_count = 0;
+
+    while (true) {
+        if ((err = trd->pull()) != srs_success) {
+            return srs_error_wrap(err, "rtc sender thread");
+        }
+
+        if (muxer_){
+            //locker  RTMP Muxer will be released and reconnected 
+            SrsLocker(locker_);
+            if (sdk) {
+                SrsCommonMessage* msg = NULL;
+                err = sdk->recv_message(&msg);
+                if (err != srs_success && srs_error_code(err) != ERROR_SOCKET_TIMEOUT) {
+                    srs_warn("RTC: rtmp(%s) receive control message err %s", muxer_->stream_url().c_str(), 
+                             srs_error_desc(err).c_str());
+                    //get muxer rtmp cleint, update rtmp client
+                    sdk = muxer_->get_rtmp_client();
+                    err_count++;
+                }else{
+                    err_count = 0;
+                }
+
+                //three consecutive errors, need reconnection
+                if (err_count >= 3){
+                    srs_warn("RTC: rtmp(%s) receive 3 count err, need reconn", muxer_->stream_url().c_str());
+                    err_count = 0;
+
+                    //close rtmp, and reconn
+                    muxer_->republish();
+                    sdk = NULL;
+                }
+
+                srs_error_reset(err);
+                srs_freep(msg);
+            }
+        }
+
+        srs_usleep(200 * SRS_UTIME_MILLISECONDS);
+    }
+}
+
+SrsRtcRtmpMuxer::SrsRtcRtmpMuxer(SrsRtcConnection* s, SrsRtcPublishStream* p, const SrsContextId& cid)
+{
+    cid_ = cid;
+    trd = new SrsDummyCoroutine();
+    rtmp_recv_ = new SrsRtcRtmpRecv(s, this, cid);
+
+    req_ = NULL;
+    source_ = NULL;
+
+    is_started = false;
+    session_ = s;
+    publish_ = p;
+
+    mw_msgs = 0;
+    realtime = true;
+
+    _srs_config->subscribe(this);
+   
+   
+    sdk = NULL;
+    vjitter = new SrsRtpTimeJitter();
+    ajitter = new SrsRtpTimeJitter();
+    jitter_buffer = NULL;
+
+    frame_data_buflen = 0;
+    frame_data_buffer = NULL;
+    
+    avc = new SrsRawH264Stream();
+    aac = new SrsRawAacStream();
+    acodec = new SrsRawAacStreamCodec();
+    recv_audio_rtp_time = 0;
+    recv_video_rtp_time = 0;
+    req_keyframe_time = 0;
+    send_auido_seqheader = true;
+    send_video_seqheader = true;
+    republish_video = false;
+    republish_video = false;
+
+    rtmp_source = NULL;
+    key_frame_count = 0;
+    
+    totals_frame_count = 0;
+    fps_sample_time = 0;
+    frame_rate = 0;
+
+    queue = new SrsMessageQueue();
+
+    audio_enabled = _srs_config->get_rtc_server_rtmp_audio_enabled();
+    audio_format = _srs_config->get_rtc_server_rtmp_audio_format();
+    opus_payload_type = 0;
+
+    source_copy = _srs_config->get_rtc_server_rtmp_source_copy();
+    kerframe_interal_print = _srs_config->get_rtc_server_rtmp_keyframe_interval_print();
+    req_kerframe = _srs_config->get_rtc_server_rtmp_req_keyframe();
+
+
+    record_video = _srs_config->get_rtc_server_rtmp_record_video();
+    record_auido = _srs_config->get_rtc_server_rtmp_record_audio();
+    record_path = _srs_config->get_rtc_server_rtmp_record_path();
+    fw_video = NULL;
+}
+
+SrsRtcRtmpMuxer::~SrsRtcRtmpMuxer()
+{
+    _srs_config->unsubscribe(this);
+    
+    stop();
+    srs_freep(rtmp_recv_);
+    srs_freep(sdk);
+    srs_freep(trd);
+    srs_freep(fw_video);
+   
+    srs_freep(req_);
+   
+    srs_freep(vjitter);
+    srs_freep(ajitter);
+    srs_freep(jitter_buffer);
+    srs_freep(frame_data_buffer);
+
+    srs_freep(avc);
+    srs_freep(aac);
+    srs_freep(acodec);
+
+    //srs_freep(rtmp_source);
+
+    srs_freep(queue);
+}
+
+srs_error_t SrsRtcRtmpMuxer::initialize(SrsRequest* req)
+{
+    srs_error_t err = srs_success;
+
+    req_ = req->copy();
+
+    if (!jitter_buffer) {
+        jitter_buffer = new SrsRtpJitterBuffer(req_->get_stream_url());
+    }
+
+    jitter_buffer->SetDecodeErrorMode(kSelectiveErrors);
+    jitter_buffer->SetNackMode(kNack, -1, -1);
+    jitter_buffer->SetNackSettings(250, 450, 0);
+
+    if (record_video){
+        fw_video = new SrsFileWriter();
+
+        std::string fullname = record_path + req_->get_stream_url() + ".h264";
+        std::string record_dir = srs_path_dirname(fullname);
+    
+        if ((err = srs_create_dir_recursively(record_dir)) != srs_success) {
+            return srs_error_wrap(err, "create %s", record_dir.c_str());
+        }
+
+        if (!fw_video->is_open()){
+            fw_video->open(fullname);
+        }
+    
+        srs_trace("RTC: rtmpmuxer create dir %s ok", record_dir.c_str());
+    }
+
+    if ((err = _srs_rtc_sources->fetch_or_create(req_, &source_)) != srs_success) {
+        return srs_error_wrap(err, "rtc fetch source failed");
+    }
+
+    if (source_copy){
+        if ((err = _srs_sources->fetch_or_create(req, (ISrsSourceHandler*)_srs_hybrid->srs()->instance(), &rtmp_source)) != srs_success) {
+            return srs_error_wrap(err, "create rtmp source");
+        }
+
+        if ((err = rtmp_source->on_publish()) != srs_success) {
+            return srs_error_wrap(err, "on publish");
+        }
+        srs_trace("RTC rtmpmuxer source=%s", rtmp_source->source_id().c_str());
+    }else {
+        if ((err = _srs_sources->fetch_or_create(req, (ISrsSourceHandler*)_srs_hybrid->srs()->instance(), &rtmp_source)) != srs_success) {
+            return srs_error_wrap(err, "create rtmp source");
+        }
+    }
+
+    opus_payload_type = _srs_config->get_rtc_server_rtmp_opus_payload_type();
+    
+    srs_utime_t queue_size = _srs_config->get_queue_length(req->vhost);
+    queue->set_queue_size(queue_size);
+
+    session_->stat_->nn_subscribers++;
+
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::on_reload_vhost_play(std::string vhost)
+{
+    if (req_->vhost != vhost) {
+        return srs_success;
+    }
+
+    realtime = _srs_config->get_realtime_enabled(req_->vhost, true);
+    mw_msgs = _srs_config->get_mw_msgs(req_->vhost, realtime, true);
+
+    srs_trace("Reload play realtime=%d, mw_msgs=%d", realtime, mw_msgs);
+
+    return srs_success;
+}
+
+srs_error_t SrsRtcRtmpMuxer::on_reload_vhost_realtime(std::string vhost)
+{
+    return on_reload_vhost_play(vhost);
+}
+
+const SrsContextId& SrsRtcRtmpMuxer::context_id()
+{
+    return cid_;
+}
+
+SrsSimpleRtmpClient* SrsRtcRtmpMuxer::get_rtmp_client()
+{
+    return sdk;
+}
+
+srs_error_t SrsRtcRtmpMuxer::start()
+{
+    srs_error_t err = srs_success;
+
+    if (is_started) {
+        return err;
+    }
+
+    srs_freep(trd);
+    trd = new SrsSTCoroutine("rtc_rtmpmuxer", this, cid_);
+    srs_trace("start rtc_rtmpmuxer");
+
+    if ((err = trd->start()) != srs_success) {
+        return srs_error_wrap(err, "rtc_rtmpmuxer");
+    }
+
+    if ((err = rtmp_recv_->start()) != srs_success) {
+        return srs_error_wrap(err, "start rtmpmuxer recv");
+    }
+
+    is_started = true;
+
+    return err;
+}
+
+void SrsRtcRtmpMuxer::stop()
+{
+    trd->stop();
+}
+
+#define SYS_MAX_FORWARD_SEND_RTMP_MSGS 128
+#define RECV_RTP_PACKNET_MAX_DUR (1500 * SRS_UTIME_MILLISECONDS)
+#define RTMP_RECONN_DUR (5 * SRS_UTIME_SECONDS)
+srs_error_t SrsRtcRtmpMuxer::cycle()
+{
+    srs_error_t err = srs_success;
+
+    SrsRtcStream* source = source_;
+
+    SrsRtcConsumer* consumer = NULL;
+    SrsAutoFree(SrsRtcConsumer, consumer);
+    if ((err = source->create_consumer(consumer)) != srs_success) {
+        return srs_error_wrap(err, "create consumer, source=%s", req_->get_stream_url().c_str());
+    }
+
+    // TODO: FIXME: Dumps the SPS/PPS from gop cache, without other frames.
+    if ((err = source->consumer_dumps(consumer)) != srs_success) {
+        return srs_error_wrap(err, "dumps consumer, url=%s", req_->get_stream_url().c_str());
+    }
+
+    realtime = _srs_config->get_realtime_enabled(req_->vhost, true);
+    mw_msgs = _srs_config->get_mw_msgs(req_->vhost, realtime, true);
+
+    SrsContextId cid = source->source_id();
+    srs_trace("RTC: start rtmpmuxer url=%s, source_id=[%d][%s], realtime=%d, mw_msgs=%d", req_->get_stream_url().c_str(),
+        ::getpid(), cid.c_str(), realtime, mw_msgs);
+
+    SrsErrorPithyPrint* epp = new SrsErrorPithyPrint();
+    SrsAutoFree(SrsErrorPithyPrint, epp);
+
+    SrsPithyPrint* pprint = SrsPithyPrint::create_rtc_play();
+    SrsAutoFree(SrsPithyPrint, pprint);
+
+    bool stat_enabled = _srs_config->get_rtc_server_perf_stat();
+    SrsStatistic* stat = SrsStatistic::instance();
+
+    vector<SrsRtpPacket2*> pkts;
+    uint64_t total_pkts = 0;
+
+    SrsMessageArray msgs(SYS_MAX_FORWARD_SEND_RTMP_MSGS);
+
+    srs_utime_t last_rtmp_conn_time = 0;
+   
+    bool reconn = false;
+
+    while (true) {
+        if ((err = trd->pull()) != srs_success) {
+            return srs_error_wrap(err, "rtc sender thread");
+        }
+        
+        // republish, may be client offline, after online publish
+        if (republish_video){
+            srs_trace("RTC rtmpmuxer republish(%d) and rtmp close, reconn!!!", republish_video);
+            rtmp_close();
+
+            send_video_seqheader = true;
+            send_auido_seqheader = true;
+            key_frame_count = 0;
+            jitter_buffer->ResetJittter();
+
+            reconn = true;
+            republish_video = false;
+        }
+
+        if (sdk)
+        {
+            //check rtp recv data is timeout
+
+            srs_utime_t diff_v = srs_get_system_time() - recv_video_rtp_time;
+            srs_utime_t diff_a = srs_get_system_time() - recv_audio_rtp_time;
+            srs_utime_t diff_req_keyframe = srs_get_system_time() - req_keyframe_time;
+
+            //if there is no data task RTP packet within RECV_RTP_PACKNET_MAX_DUR, the network will be dropped
+            if (diff_v > RECV_RTP_PACKNET_MAX_DUR){
+                srs_trace("RTC rtmpmuxer %s recv video rtp packet timeout", req_->get_stream_url().c_str());
+               
+                send_video_seqheader = true;
+                key_frame_count = 0;
+                jitter_buffer->ResetJittter();
+                recv_video_rtp_time = srs_get_system_time();
+                totals_frame_count = 0;
+            }
+
+            if (diff_a > RECV_RTP_PACKNET_MAX_DUR){
+                srs_trace("RTC rtmpmuxer %s recv audio rtp packet timeout", req_->get_stream_url().c_str());
+               
+                send_auido_seqheader = true;
+                recv_audio_rtp_time = srs_get_system_time();
+            }
+
+            if (diff_req_keyframe > req_kerframe && req_kerframe != 0 && video_ssrc > 0 && publish_){
+                srs_trace("RTC rtmpmuxer %s req keyframe", req_->get_stream_url().c_str());
+                publish_->do_request_keyframe(video_ssrc, cid);
+                req_keyframe_time = srs_get_system_time();
+            }
+            
+        }else{
+            srs_utime_t diff = srs_get_system_time() - last_rtmp_conn_time;
+            if (diff >= RTMP_RECONN_DUR || reconn){
+
+                if ((err = rtmp_connect()) != srs_success) {
+                    h264_pps = "";
+                    h264_sps = "";
+                    srs_warn("RTC rtmpmuxer %s connect rtmp server failed!", req_->get_stream_url().c_str());
+                    srs_freep(err);
+                }
+                
+                reconn = false;
+                last_rtmp_conn_time = srs_get_system_time();
+            }
+        }
+
+        // Wait for amount of packets.
+        consumer->wait(mw_msgs);
+
+        // TODO: FIXME: Handle error.
+        consumer->dump_packets(pkts);
+      
+        int msg_count = (int)pkts.size();
+        if (!msg_count) {
+            continue;
+        }
+        
+        // Update stats for session.
+        session_->stat_->nn_out_rtp += msg_count;
+        total_pkts += msg_count;
+
+        // All RTP packets to rtmp and do cleanup
+        if (true) {
+
+            if (sdk)
+            {
+                if ((err = on_rtp_packets(source, pkts)) != srs_success) {
+                    uint32_t nn = 0;
+                    if (epp->can_print(err, &nn)) {
+                        srs_warn("RTC rtmpmuxer send packets=%u, nn=%u/%u, err: %s", pkts.size(), epp->nn_count, nn, srs_error_desc(err).c_str());
+                    }
+                    srs_freep(err);
+                }
+            }
+
+            //free rtp pkt
+            for (int i = 0; i < msg_count; i++) {
+                SrsRtpPacket2* pkt = pkts[i];
+                srs_freep(pkt);
+            }
+            pkts.clear();
+        }
+
+#ifdef USE_QUEUE_CACHE 
+        int count = 0;
+        if ((err = queue->dump_packets(msgs.max, msgs.msgs, count)) != srs_success) {
+            return srs_error_wrap(err, "dump packets");
+        }
+
+        // ignore when no messages.
+        if (count <= 0) {
+            continue;
+        }
+        
+        // sendout messages, all messages are freed by send_and_free_messages().
+        if ((err = sdk->send_and_free_messages(msgs.msgs, count)) != srs_success) {
+            rtmp_close();
+            srs_warn("send messages err:%s",srs_error_desc(err).c_str());
+            srs_freep(err);
+        }
+#endif
+
+        // Stat for performance analysis.
+        if (!stat_enabled) {
+            continue;
+        }
+
+        // Stat the original RAW AV frame, maybe h264+aac.
+        // stat->perf_on_msgs(msg_count);
+        // // Stat the RTC packets, RAW AV frame, maybe h.264+opus.
+        // int nn_rtc_packets = srs_max(info.nn_audios, info.nn_extras) + info.nn_videos;
+        // stat->perf_on_rtc_packets(nn_rtc_packets);
+        // // Stat the RAW RTP packets, which maybe group by GSO.
+        // stat->perf_on_rtp_packets(msg_count);
+        // // Stat the bytes and paddings.
+        // stat->perf_on_rtc_bytes(info.nn_bytes, info.nn_rtp_bytes, info.nn_padding_bytes);
+
+        pprint->elapse();
+        if (pprint->can_print()) {
+            // TODO: FIXME: Print stat like frame/s, packet/s, loss_packets.
+            // srs_trace("-> RTC RTMPMUXER %d msgs, %d/%d packets, %d audios, %d extras, %d videos, %d samples, %d/%d/%d bytes, %d pad, %d/%d cache",
+            //     total_pkts, msg_count, info.nn_rtp_pkts, info.nn_audios, info.nn_extras, info.nn_videos, info.nn_samples, info.nn_bytes,
+            //     info.nn_rtp_bytes, info.nn_padding_bytes, info.nn_paddings, msg_count, msg_count);
+            srs_trace("-> RTC RTMPMUXER %s %d msgs, %d packets", req_->get_stream_url().c_str(), total_pkts, msg_count); 
+        }
+    }
+
+}
+
+srs_error_t SrsRtcRtmpMuxer::write_h264_file_by_jitbuffer(char *buf, int size, SrsFileWriter *fw)
+{
+    srs_error_t err = srs_success;
+    if (NULL == buf || size <= 0 || !record_video || !fw->is_open()){
+        return err;
+    }
+
+    fw->write(buf, size, 0);
+
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::write_h264_file(SrsRtpPacket2* pkt, SrsFileWriter *fw)
+{
+    srs_error_t err = srs_success;
+    if (NULL == pkt || NULL == fw || !record_video || !fw->is_open()){
+        return err;
+    }
+
+    int8_t v = (uint8_t)pkt->nalu_type;
+    if (v == kStapA) {
+        SrsRtpSTAPPayload *payload = (SrsRtpSTAPPayload*)pkt->payload;
+    
+        for (int j = 0; j < (int)payload->nalus.size(); j++) {
+            char startcode[] = { 0x00, 0x00, 0x00, 0x01};
+            fw->write(startcode, 4, NULL);
+
+            SrsSample *stream =  payload->nalus.at(j);
+            fw->write(stream->bytes, stream->size, 0);
+        }
+    } else if (v == kFuA) {
+        SrsRtpFUAPayload2 *payload = (SrsRtpFUAPayload2*)pkt->payload;
+    
+        char *buf = payload->payload;
+        int size = payload->size;
+    
+        int8_t nalu_byte0 = ((int8_t)payload->nri & 0xE0) | ((int8_t)payload->nalu_type & 0x1F);
+
+        if (payload->start){
+            char startcode[] = { 0x00, 0x00, 0x00, 0x01};
+            fw->write(startcode, 4, NULL);
+           
+            fw->write(&nalu_byte0, 1, NULL);
+            fw->write(buf, size, 0);
+        }else {
+            fw->write(buf, size, 0);
+        }
+
+    } else {
+        //char *buf = pkt->shared_msg->payload + 12;
+        //int size = pkt->shared_msg->size - 12;
+
+        SrsRtpRawPayload *payload = (SrsRtpRawPayload*)pkt->payload;
+     
+        char startcode[] = { 0x00, 0x00, 0x00, 0x01};
+        fw->write(startcode, 4, NULL);
+        fw->write(payload->payload, payload->nb_bytes(), 0);
+    }
+
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::on_rtp_packets(SrsRtcStream* source, const vector<SrsRtpPacket2*>& pkts)
+{
+    srs_error_t err = srs_success;
+
+    vector<SrsRtpPacket2*> send_pkts;
+
+    // Covert kernel messages to RTP packets.
+    for (int i = 0; i < (int)pkts.size(); i++) {
+        SrsRtpPacket2* pkt = pkts[i];
+       
+        if (pkt->is_audio()) {
+
+            if (opus_payload_type != 0){
+                 pkt->header.set_payload_type(opus_payload_type);
+            }
+
+            if ((err = on_rtp_audio(pkt)) != srs_success){
+                srs_error("RTC: rtmp muxer process rtp audio error(%s)", srs_error_desc(err).c_str());
+                srs_error_reset(err);
+                continue;
+            }
+        } else {
+            //write_h264_file(pkt, fw_video);
+            video_ssrc = pkt->header.get_ssrc();
+
+            if ((err = on_rtp_video(pkt)) != srs_success){
+                srs_error("RTC: rtmp muxer process rtp video error(%s)", srs_error_desc(err).c_str());
+                srs_error_reset(err);
+                continue;
+            }
+        }
+        
+        // Detail log, should disable it in release version.
+        srs_info("RTC: rtmp muxer PT=%u, SSRC=%#x, Time=%u, SEQ=%u, %u bytes", pkt->header.get_payload_type(), pkt->header.get_ssrc(),
+            pkt->header.get_timestamp(), pkt->header.get_sequence(), pkt->nb_bytes());
+    }
+
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::on_rtp_audio(SrsRtpPacket2* pkt)
+{
+    srs_error_t err = srs_success;
+
+    recv_audio_rtp_time = srs_get_system_time();
+
+    if (!audio_enabled)
+        return err;
+
+    // TODO: FIXME: Padding audio to the max payload in RTP packets.
+    int64_t pts = pkt->header.get_timestamp();
+    if ((err = ajitter->correct(pts)) != srs_success) {
+        return srs_error_wrap(err, "a timestmp jitter");
+    }
+    
+    //opus sample rate is 48000;  per ms sample nums:48000/1000=48
+    uint32_t fpts = (uint32_t)(pts / 48);
+
+    if (true) {
+       
+        char* flv = NULL;
+        int nb_flv = 0;
+
+        if (audio_format == "rtp") {
+            if ((err = mux_opusflv_rtp(pkt, &flv, &nb_flv)) != srs_success) {
+                return srs_error_wrap(err, "mux avc rtp opus to flv");
+            }
+        } else if (audio_format == "opus") {
+            if ((err = mux_opusflv(pkt, &flv, &nb_flv)) != srs_success) {
+                return srs_error_wrap(err, "mux avc rtp opus to flv");
+            }
+        }else if (audio_format == "aac"){
+            //TODO: fixme opus to aac
+            return err;
+        }
+        
+        // the timestamp in rtmp message header is dts.
+        uint32_t timestamp = fpts;
+        return rtmp_write_packet(SrsFrameTypeAudio, timestamp, flv, nb_flv);
+    }
+
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::on_rtp_video(SrsRtpPacket2* pkt)
+{
+    srs_error_t err = srs_success;
+    
+    recv_video_rtp_time = srs_get_system_time();
+
+    jitter_buffer->InsertPacket2(*pkt, NULL);
+
+    uint32_t cur_timestamp = 0; 
+    int frame_size = 0;
+    bool keyframe = false;
+
+    if(jitter_buffer->FoundFrame(cur_timestamp)){
+        jitter_buffer->GetFrame(&frame_data_buffer, frame_data_buflen, frame_size, keyframe, cur_timestamp);
+        if (frame_data_buflen > 0){
+            char* bytes = frame_data_buffer;
+            int length = frame_size;
+
+            int64_t pts = cur_timestamp;
+                if ((err = vjitter->correct(pts)) != srs_success) {
+                return srs_error_wrap(err, "v timestamp jitter");
+            }
+
+            uint32_t fdts = (uint32_t)(pts / 90);
+            uint32_t fpts = (uint32_t)(pts / 90);
+
+            statistics_fps();
+            write_h264_file_by_jitbuffer(bytes, length, fw_video);
+
+            //srs_trace("====%u,%u", cur_timestamp, fpts);
+
+            if ((err = replace_startcode_with_nalulen(bytes, length, fdts, fpts)) != srs_success) {
+                return srs_error_wrap(err, "write ibp frame");
+            }
+        }
+    }
+
+    return err;  
+}
+
+srs_error_t SrsRtcRtmpMuxer::mux_opusflv_rtp(SrsRtpPacket2* pkt, char** flv, int* nb_flv)
+{
+    srs_error_t err = srs_success;
+
+    //rtp opus to custom rtmp opus format
+    //rtmp opus rtp fromt:
+    // |rtmp header | rtmp body |
+    // |rtmp header | FF+00+(opus rtp packet)|  
+    
+    // |rtp header | rtp ext header | rtp payload |
+    int head_size = pkt->header.nb_bytes(); //rtp header size
+    int head_ext_size = pkt->shared_msg->size - pkt->payload->nb_bytes(); //rtp header + ext head size
+    int payload_size = pkt->payload->nb_bytes(); //rtp payload size
+
+    //pkt->shared_msg is raw rtp packet data
+    //rtp del extension flag
+    pkt->shared_msg->payload[0] = 0x80; 
+    
+    //update payload type
+    if (opus_payload_type != 0){
+        uint8_t second = pkt->shared_msg->payload[1];
+        uint8_t marker = (second & 0x80);
+  
+        if (marker) {
+            opus_payload_type |= 0x80;
+        }
+
+        pkt->shared_msg->payload[1] = opus_payload_type;
+    }
+    
+    int size = head_size + payload_size + 2;  //del rtp ext header
+   
+    char* data = new char[size];
+    char* p = data;
+    
+    //custom rtmp opus type
+    *p++ = 0xFF;
+    *p++ = 0x00;
+
+    //rtp header, skip extension head 
+    memcpy(p, pkt->shared_msg->payload, head_size);
+    p += head_size;
+
+    //skip ext header, copy payload
+    memcpy(p, pkt->shared_msg->payload + head_ext_size, payload_size);
+
+    *flv = data;
+    *nb_flv = size;
+    
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::mux_opusflv(SrsRtpPacket2* pkt, char** flv, int* nb_flv)
+{
+    srs_error_t err = srs_success;
+    //rtp opus to custom rtmp opus format
+    //rtmp opus fromt:
+    // |rtmp header | rtmp body |
+    // |rtmp header | SoundFormat|SoundRate|SoundSize|SoundType|+00+(opus payload)|  
+    
+    // |rtp header | rtp ext header | rtp payload |
+    int head_size = pkt->header.nb_bytes(); //rtp header size
+    int head_ext_size = pkt->shared_msg->size - pkt->payload->nb_bytes(); //rtp header + ext head size
+    int payload_size = pkt->payload->nb_bytes(); //rtp payload size
+
+    //pkt->shared_msg is raw rtp packet data
+    int size = payload_size + 2;  //del rtp header and ext header
+   
+    char* data = new char[size];
+    char* p = data;
+    
+    //custom rtmp flv opus type
+    char sound_format = SrsAudioCodecIdOpus;
+    // flv audio header define sound_type
+    // 0 = Mono sound
+    // 1 = Stereo sound
+    char sound_type = 0;  
+    // flv audio header define sound_size
+    // 0 = 8-bit samples
+    // 1 = 16-bit samples
+    char sound_size = 1;
+    // flv audio header define sound_rate
+    // 0 = 5.5 kHz
+    // 1 = 11 kHz
+    // 2 = 22 kHz
+    // 3 = 44 kHz
+    char sound_rate = 3;
+    // for audio frame, there is 1 or 2 bytes header:
+    //   1bytes, SoundFormat|SoundRate|SoundSize|SoundType
+    //   1bytes, 00
+    uint8_t audio_header = sound_type & 0x01;
+    audio_header |= (sound_size << 1) & 0x02;
+    audio_header |= (sound_rate << 2) & 0x0c;
+    audio_header |= (sound_format << 4) & 0xf0;
+
+    *p++ = audio_header;
+    *p++ = 0x00;
+
+    //skip rtp header and ext header, copy payload
+    memcpy(p, pkt->shared_msg->payload + head_ext_size, payload_size);
+
+    *flv = data;
+    *nb_flv = size;
+    
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::replace_startcode_with_nalulen(char *video_data, int &size, uint32_t pts, uint32_t dts)
+ {
+    srs_error_t err = srs_success;
+
+    int index = 0;
+    std::list<int> list_index;
+
+    SrsAvcNaluType nal_unit_type = (SrsAvcNaluType)(video_data[0] & 0x1f);
+
+    if ((video_data[0] & 0x0FF) == 0x00 && (video_data[1] & 0xFF)  == 0x00 && 
+        (video_data[2] & 0x0FF) == 0x00 && (video_data[3] & 0xFF)  == 0x01){
+        nal_unit_type = (SrsAvcNaluType)(video_data[4] & 0x1f);
+    }
+
+    for(; index < size; index++){
+        if (index > (size - 4))
+            break;
+
+        if (video_data[index] == 0x00 && video_data[index+1] == 0x00 &&
+             video_data[index+2] == 0x00 && video_data[index+3] == 0x01){
+                 list_index.push_back(index);
+        }
+    }
+
+    if (list_index.size() == 1){
+        int cur_pos = list_index.front();
+        list_index.pop_front();
+
+        //0001xxxxxxxxxx
+        //xxxx0001xxxxxxx
+        uint32_t naluLen = size - cur_pos - 4;
+        char *p = (char*)&naluLen;
+
+        video_data[cur_pos] = p[3];
+        video_data[cur_pos+1] = p[2];
+        video_data[cur_pos+2] = p[1];
+        video_data[cur_pos+3] = p[0];
+
+        //err = write_h264_ipb_frame(nal_unit_type, video_data, size, dts, pts);
+
+    }else if (list_index.size() > 1){//mutle slice
+        int pre_pos = list_index.front();
+        list_index.pop_front();
+        int first_pos = pre_pos;
+
+        while(list_index.size() > 0){
+            int cur_pos = list_index.front();
+            list_index.pop_front();
+
+            //pre=========cur======================
+            //0001xxxxxxxx0001xxxxxxxx0001xxxxxxxxx
+            //xxxxxxxxxxxx0001xxxxxxxx0001xxxxxxxxx
+            uint32_t naluLen = cur_pos - pre_pos - 4;
+            char *p = (char*)&naluLen;
+
+            video_data[pre_pos] = p[3];
+            video_data[pre_pos+1] = p[2];
+            video_data[pre_pos+2] = p[1];
+            video_data[pre_pos+3] = p[0];
+
+          
+            char *frame = video_data + pre_pos + 4;
+            int frame_size = naluLen;
+
+            pre_pos = cur_pos;
+            err = decode_h264_sps_pps(frame, frame_size, dts, pts);
+        }
+        
+        //========================pre==========
+        //0001xxxxxxxx0001xxxxxxxx0001xxxxxxxxx
+        if (first_pos != pre_pos){
+            uint32_t naluLen = size - pre_pos - 4;
+            char *p = (char*)&naluLen;
+
+            video_data[pre_pos] = p[3];
+            video_data[pre_pos+1] = p[2];
+            video_data[pre_pos+2] = p[1];
+            video_data[pre_pos+3] = p[0];
+          
+            char *frame = video_data + pre_pos + 4;
+            int frame_size = naluLen;
+            err = decode_h264_sps_pps(frame, frame_size, dts, pts);
+        }
+
+        //err = write_h264_ipb_frame(nal_unit_type, video_data, size, dts, pts);
+    }else{
+        //xxxxxxxxxxxxxxxxxxx
+        //char *frame = video_data;
+        //int frame_size = size;
+       
+    }
+
+    if (send_video_seqheader){
+        srs_trace("RTC: send video seq header");
+        if ((err = write_h264_sps_pps(dts, pts)) != srs_success) {
+            return srs_error_wrap(err, "write sps/pps");
+        }
+        send_video_seqheader = false;
+    }
+
+    err = write_h264_ipb_frame(nal_unit_type, video_data, size, dts, pts);
+
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::decode_h264_sps_pps(char *frame, int frame_size, uint32_t pts, uint32_t dts)
+{
+    srs_error_t err = srs_success;
+
+    if (!frame){
+        return srs_error_new(ERROR_GB28181_H264_FRAME_FULL, "h264 frame null");
+    }
+
+    if (frame_size <= 0){
+        return srs_error_new(ERROR_GB28181_H264_FRAMESIZE, "h264 frame size");
+    }
+
+    SrsAvcNaluType nal_unit_type = (SrsAvcNaluType)(frame[0] & 0x1f);
+    // ignore the nalu type sei(6) aud(9) 
+    switch (nal_unit_type)
+    {
+    case SrsAvcNaluTypeAccessUnitDelimiter:
+    case SrsAvcNaluTypeSEI:
+        return err;
+    case SrsAvcNaluTypeSPS:
+        //ex kerframe_interal_print=10, per 1..11..21.. counts print log
+        if (key_frame_count >= kerframe_interal_print){
+            key_frame_count = 0; 
+        }
+        key_frame_count++;
+    case SrsAvcNaluTypePPS:
+    case SrsAvcNaluTypeIDR:
+        if (key_frame_count == 1){
+            srs_trace("RTC: rtmpmuxer %s key frame %s FPS:%d", req_->get_stream_url().c_str(), 
+                srs_avc_nalu2str(nal_unit_type).c_str(), frame_rate);
+        }
+        send_video_seqheader = true;
+        break;
+    default:
+        break;
+    }
+
+    // for sps
+    if (avc->is_sps(frame, frame_size)) {
+        std::string sps;
+        if ((err = avc->sps_demux(frame, frame_size, sps)) != srs_success) {
+            return srs_error_wrap(err, "demux sps");
+        }
+        
+        if (h264_sps == sps && !send_video_seqheader) {
+            return err;
+        }
+        h264_sps = sps;
+        
+        return err;
+    }
+
+    // for pps
+    if (avc->is_pps(frame, frame_size)) {
+        std::string pps;
+        if ((err = avc->pps_demux(frame, frame_size, pps)) != srs_success) {
+            return srs_error_wrap(err, "demux pps");
+        }
+        
+        if (h264_pps == pps && !send_video_seqheader) {
+            return err;
+        }
+        h264_pps = pps;
+       
+        return err;
+    }
+
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::write_h264_sps_pps(uint32_t dts, uint32_t pts)
+{
+    srs_error_t err = srs_success;
+
+    if (h264_sps.empty() || h264_pps.empty()) {
+        srs_warn("no sps=%dB or pps=%dB", (int)h264_sps.size(), (int)h264_pps.size());
+        return err;
+    }
+    
+    // h264 raw to h264 packet.
+    std::string sh;
+    if ((err = avc->mux_sequence_header(h264_sps, h264_pps, dts, pts, sh)) != srs_success) {
+        return srs_error_wrap(err, "mux sequence header");
+    }
+    
+    // h264 packet to flv packet.
+    int8_t frame_type = SrsVideoAvcFrameTypeKeyFrame;
+    int8_t avc_packet_type = SrsVideoAvcFrameTraitSequenceHeader;
+    char* flv = NULL;
+    int nb_flv = 0;
+    if ((err = avc->mux_avc2flv(sh, frame_type, avc_packet_type, dts, pts, &flv, &nb_flv)) != srs_success) {
+        return srs_error_wrap(err, "mux avc to flv");
+    }
+    
+    // the timestamp in rtmp message header is dts.
+    uint32_t timestamp = dts;
+    if ((err = rtmp_write_packet(SrsFrameTypeVideo, timestamp, flv, nb_flv)) != srs_success) {
+        return srs_error_wrap(err, "write packet");
+    }
+    
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::write_h264_ipb_frame(SrsAvcNaluType nal_unit_type, char* frame, int frame_size, uint32_t dts, uint32_t pts)
+{
+    srs_error_t err = srs_success;
+    
+    // 5bits, 7.3.1 NAL unit syntax,
+    // ISO_IEC_14496-10-AVC-2003.pdf, page 44.
+    //  7: SPS, 8: PPS, 5: I Frame, 1: P Frame
+    //SrsAvcNaluType nal_unit_type = (SrsAvcNaluType)(frame[4] & 0x1f);
+    
+    // for IDR frame, the frame is keyframe.
+    SrsVideoAvcFrameType frame_type = SrsVideoAvcFrameTypeInterFrame;
+    if (nal_unit_type == SrsAvcNaluTypeIDR || nal_unit_type == SrsAvcNaluTypeSPS) {
+        frame_type = SrsVideoAvcFrameTypeKeyFrame;
+    }
+    
+    string ibp = string(frame, frame_size);
+    
+    int8_t avc_packet_type = SrsVideoAvcFrameTraitNALU;
+    char* flv = NULL;
+    int nb_flv = 0;
+    if ((err = avc->mux_avc2flv(ibp, frame_type, avc_packet_type, dts, pts, &flv, &nb_flv)) != srs_success) {
+        return srs_error_wrap(err, "mux avc to flv");
+    }
+    
+    // the timestamp in rtmp message header is dts.
+    uint32_t timestamp = dts;
+    return rtmp_write_packet(SrsFrameTypeVideo, timestamp, flv, nb_flv);
+}
+
+srs_error_t SrsRtcRtmpMuxer::write_audio_raw_frame(char* frame, int frame_size, SrsRawAacStreamCodec* codec, uint32_t dts)
+{
+    srs_error_t err = srs_success;
+    
+    char* data = NULL;
+    int size = 0;
+    if ((err = aac->mux_aac2flv(frame, frame_size, codec, dts, &data, &size)) != srs_success) {
+        return srs_error_wrap(err, "mux aac to flv");
+    }
+    
+    return rtmp_write_packet(SrsFrameTypeAudio, dts, data, size);
+}
+
+srs_error_t SrsRtcRtmpMuxer::rtmp_write_packet(char type, uint32_t timestamp, char* data, int size)
+{
+    srs_error_t err = srs_success;
+
+    if (NULL != rtmp_source && source_copy){
+        return rtmp_write_packet_by_source(type, timestamp, data, size);
+    }
+
+    if (source_copy){
+        return err;
+    }
+    
+    if ((err = rtmp_connect()) != srs_success) {
+        h264_pps = "";
+        h264_sps = "";
+        return srs_error_wrap(err, "connect");
+    }
+    
+    SrsSharedPtrMessage* msg = NULL;
+    if ((err = srs_rtmp_create_msg(type, timestamp, data, size, sdk->sid(), &msg)) != srs_success) {
+        return srs_error_wrap(err, "create message");
+    }
+    srs_assert(msg);
+
+#ifdef USE_QUEUE_CACHE    
+     if ((err = queue->enqueue(msg)) != srs_success) {
+         return srs_error_wrap(err, "enqueue metadata");
+     }
+#else
+    if ((err = sdk->send_and_free_message(msg)) != srs_success) {
+        rtmp_close();
+        return srs_error_wrap(err, "write message");
+    }
+#endif 
+
+    return err;
+}
+
+srs_error_t SrsRtcRtmpMuxer::rtmp_write_packet_by_source(char type, uint32_t timestamp, char* data, int size)
+{
+    srs_error_t err = srs_success;
+
+    //create a source that will process stream without the need for internal rtmpclient
+    if (type == SrsFrameTypeAudio) {
+        SrsMessageHeader header;
+        header.message_type = RTMP_MSG_AudioMessage;
+        // TODO: FIXME: Maybe the tbn is not 90k.
+        header.timestamp = timestamp & 0x3fffffff;
+
+        SrsCommonMessage* shared_video = new SrsCommonMessage();
+        SrsAutoFree(SrsCommonMessage, shared_video);
+
+        // TODO: FIXME: Check error.
+        shared_video->create(&header, data, size);
+        rtmp_source->on_audio(shared_video);
+
+        
+    }else if(type == SrsFrameTypeVideo) {
+        SrsMessageHeader header;
+        header.message_type = RTMP_MSG_VideoMessage;
+        // TODO: FIXME: Maybe the tbn is not 90k.
+        header.timestamp = timestamp & 0x3fffffff;
+
+        SrsCommonMessage* shared_video = new SrsCommonMessage();
+        SrsAutoFree(SrsCommonMessage, shared_video);
+
+        // TODO: FIXME: Check error.
+        shared_video->create(&header, data, size);
+        rtmp_source->on_video(shared_video);
+    }
+    
+    return err;
+}
+
+void SrsRtcRtmpMuxer::statistics_fps()
+{
+    if (totals_frame_count == 0){
+        fps_sample_time = srs_get_system_time();
+    }
+    totals_frame_count++;
+
+    int64_t  diff = (srs_get_system_time() - fps_sample_time) / SRS_UTIME_SECONDS;
+    if (diff > 0){
+        frame_rate = totals_frame_count / diff;
+    }
+
+    if (diff > 60){// per 60s, restatis 
+        totals_frame_count = 0;
+    }
+}
+
+
+srs_error_t SrsRtcRtmpMuxer::rtmp_connect()
+{
+    srs_error_t err = srs_success;
+
+    if (source_copy){
+        return err;
+    }
+    
+    // Ignore when connected.
+    if (sdk) {
+        return err;
+    }
+    
+    // generate rtmp url to connect to.
+    std::string hostport = "127.0.0.1:1935";
+    std::string url = "rtmp://"+ hostport + req_->get_stream_url();
+
+    std::string output =  _srs_config->get_rtc_server_rtmp_output();
+   
+    if (!output.empty()){
+        url = srs_string_replace(output, "[app]", req_->app);
+        url = srs_string_replace(url, "[stream]", req_->stream);
+    }
+
+    srs_trace("RTC rtmp muxer url:%s", url.c_str());
+    
+    // connect host.
+    srs_utime_t cto = SRS_CONSTS_RTMP_TIMEOUT;
+    srs_utime_t sto = SRS_CONSTS_RTMP_PULSE;
+    sdk = new SrsSimpleRtmpClient(url, cto, sto);
+ 
+    if ((err = sdk->connect()) != srs_success) {
+        rtmp_close();
+        return srs_error_wrap(err, "connect %s failed, cto=%dms, sto=%dms.", url.c_str(), srsu2msi(cto), srsu2msi(sto));
+    }
+    
+    // publish.
+    if ((err = sdk->publish(SRS_CONSTS_RTMP_PROTOCOL_CHUNK_SIZE)) != srs_success) {
+        rtmp_close();
+        return srs_error_wrap(err, "publish %s failed", url.c_str());
+    }
+
+    sdk->set_recv_timeout(SRS_CONSTS_RTMP_PULSE);
+    
+    if (NULL != rtmp_recv_){
+        rtmp_recv_->set_rtmp_client(sdk);
+    }
+
+    jitter_buffer->ResetJittter();
+    vjitter->reset();
+    ajitter->reset();
+    frame_rate = 0;
+    totals_frame_count = 0;
+   
+    return err;
+}
+
+void SrsRtcRtmpMuxer::rtmp_close()
+{
+    h264_pps = "";
+    h264_sps = "";
+    send_video_seqheader = true;
+
+    //first, clear rtmp recv coroutine rtmp client
+    if (NULL != rtmp_recv_){
+        rtmp_recv_->set_rtmp_client(NULL);
+    }
+    srs_freep(sdk);
+}
+
+std::string SrsRtcRtmpMuxer::stream_url()
+{
+    if (req_){
+        return req_->get_stream_url();
+    }
+    return "";
+}
+
+void SrsRtcRtmpMuxer::republish()
+{
+    republish_video = true;
+    republish_audio = true;
+}

--- a/trunk/src/app/srs_app_rtc_rtp_rtmp.hpp
+++ b/trunk/src/app/srs_app_rtc_rtp_rtmp.hpp
@@ -1,0 +1,215 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013-2020 Lixin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef SRS_APP_RTC_RTP_RTMP_HPP
+#define SRS_APP_RTC_RTP_RTMP_HPP
+
+#include <srs_core.hpp>
+#include <srs_app_listener.hpp>
+#include <srs_service_st.hpp>
+#include <srs_kernel_utility.hpp>
+#include <srs_rtmp_stack.hpp>
+#include <srs_kernel_rtc_rtp.hpp>
+#include <srs_kernel_rtc_rtcp.hpp>
+#include <srs_app_rtc_queue.hpp>
+#include <srs_app_rtc_source.hpp>
+#include <srs_app_rtc_dtls.hpp>
+#include <srs_app_rtc_rtp_jitbuffer.hpp>
+#include <srs_kernel_file.hpp>
+#include <srs_raw_avc.hpp>
+#include <srs_app_rtc_conn.hpp>
+#include <srs_app_config.hpp>
+#include <srs_app_hybrid.hpp>
+#include <srs_kernel_log.hpp>
+#include <srs_core_autofree.hpp>
+#include <srs_app_pithy_print.hpp>
+#include <srs_app_statistic.hpp>
+#include <srs_rtmp_msg_array.hpp>
+
+#include <string>
+#include <map>
+#include <vector>
+#include <sys/socket.h>
+
+class SrsSimpleRtmpClient;
+class SrsRawH264Stream;
+class SrsRawAacStream;
+class SrsRtpTimeJitter;
+class SrsRtcRtmpMuxer;
+class SrsRtcRtmpRecv;
+class SrsRtcPublishStream;
+
+//#define USE_QUEUE_CACHE
+
+//It is used for RTMP client in RTC rtmpmuxer to receive RTMP stream
+class SrsRtcRtmpRecv : virtual public ISrsCoroutineHandler, virtual public ISrsReloadHandler
+{
+private:
+    SrsContextId cid_;
+    SrsCoroutine* trd;
+    SrsRtcConnection* session_;
+    SrsRtcRtmpMuxer* muxer_;
+    SrsRequest *req_;
+    srs_mutex_t locker_;
+private:
+    SrsSimpleRtmpClient* sdk;
+    bool is_started;
+public:
+    SrsRtcRtmpRecv(SrsRtcConnection* s, SrsRtcRtmpMuxer* r, const SrsContextId& cid);
+    virtual ~SrsRtcRtmpRecv();
+public:
+    void set_rtmp_client(SrsSimpleRtmpClient* c);
+// interface ISrsReloadHandler
+public:
+    virtual srs_error_t on_reload_vhost_play(std::string vhost);
+    virtual srs_error_t on_reload_vhost_realtime(std::string vhost);
+    virtual const SrsContextId& context_id();
+public:
+    virtual srs_error_t start();
+    virtual void stop();
+public:
+    virtual srs_error_t cycle();
+};
+
+//RTC rtp stream muxer rtmp stream, then  push rtmp server
+class SrsRtcRtmpMuxer : virtual public ISrsCoroutineHandler, virtual public ISrsReloadHandler
+{
+private:
+    SrsContextId cid_;
+    SrsCoroutine* trd;
+    SrsRtcConnection* session_;
+    SrsRtcRtmpRecv *rtmp_recv_;
+    SrsRtcPublishStream* publish_;
+private:
+    SrsRequest* req_;
+    SrsRtcStream* source_;
+
+    // The pithy print for special stage.
+    //SrsErrorPithyPrint* nack_epp;
+private:
+    // For merged-write messages.
+    int mw_msgs;
+    bool realtime;
+
+private:
+    // Whether palyer started.
+    bool is_started;
+    // The statistic for consumer to send packets to player.
+    // SrsRtcPlayStreamStatistic info;
+private:
+    SrsSimpleRtmpClient* sdk;
+    SrsRawH264Stream* avc;
+    std::string h264_sps;
+    std::string h264_pps;
+    uint32_t video_ssrc;
+
+    bool send_video_seqheader;
+    bool send_auido_seqheader;
+    srs_utime_t recv_video_rtp_time;
+    srs_utime_t recv_audio_rtp_time;
+    srs_utime_t req_keyframe_time;
+    bool republish_video;
+    bool republish_audio;
+private:
+    SrsRawAacStream* aac;
+    SrsRawAacStreamCodec* acodec;
+    std::string aac_specific_config;
+    SrsRtpTimeJitter* vjitter;
+    SrsRtpTimeJitter* ajitter;
+    SrsRtpJitterBuffer *jitter_buffer;
+
+    char *frame_data_buffer;
+    int frame_data_buflen;
+
+    SrsSource* rtmp_source;
+    bool source_copy;
+
+    int totals_frame_count;
+    srs_utime_t fps_sample_time;
+    int frame_rate;
+
+    int req_kerframe;
+    int key_frame_count;
+    int kerframe_interal_print;
+    u_int8_t opus_payload_type;
+
+    bool audio_enabled;
+    std::string audio_format;
+ 
+    std::string record_path;
+    bool record_video;
+    bool record_auido;
+    SrsFileWriter *fw_video;
+
+    SrsMessageQueue* queue;
+
+public:
+    SrsRtcRtmpMuxer(SrsRtcConnection* s, SrsRtcPublishStream* p, const SrsContextId& cid);
+    virtual ~SrsRtcRtmpMuxer();
+public:
+    srs_error_t initialize(SrsRequest* request);
+// interface ISrsReloadHandler
+public:
+    virtual srs_error_t on_reload_vhost_play(std::string vhost);
+    virtual srs_error_t on_reload_vhost_realtime(std::string vhost);
+    virtual const SrsContextId& context_id();
+public:
+    virtual srs_error_t start();
+    virtual void stop();
+public:
+    virtual srs_error_t cycle();
+private:
+    srs_error_t on_rtp_packets(SrsRtcStream* source, const std::vector<SrsRtpPacket2*>& pkts);
+
+public:
+    srs_error_t write_h264_file(SrsRtpPacket2* pkt, SrsFileWriter *fw);
+    srs_error_t write_h264_file_by_jitbuffer(char *buf, int size, SrsFileWriter *fw);
+    
+    SrsSimpleRtmpClient* get_rtmp_client();
+    void rtmp_close();
+    std::string stream_url();
+    void republish();
+
+private:
+    srs_error_t on_rtp_video(SrsRtpPacket2* pkt);
+    srs_error_t on_rtp_audio(SrsRtpPacket2* pkt);
+    //srs_error_t kickoff_audio_cache(SrsRtpPacket2* pkt, int64_t dts);
+private:
+    srs_error_t rtmp_connect();
+   
+
+    srs_error_t replace_startcode_with_nalulen(char *video_data, int &size, uint32_t pts, uint32_t dts);
+    srs_error_t write_h264_sps_pps(uint32_t dts, uint32_t pts);
+    srs_error_t decode_h264_sps_pps(char *frame, int frame_size, uint32_t pts, uint32_t dts);
+    srs_error_t write_h264_ipb_frame(SrsAvcNaluType type, char* frame, int frame_size, uint32_t dts, uint32_t pts);
+    srs_error_t write_audio_raw_frame(char* frame, int frame_size, SrsRawAacStreamCodec* codec, uint32_t dts);
+    srs_error_t rtmp_write_packet(char type, uint32_t timestamp, char* data, int size);
+    srs_error_t mux_opusflv_rtp(SrsRtpPacket2* pkt, char** flv, int* nb_flv);
+    srs_error_t mux_opusflv(SrsRtpPacket2* pkt, char** flv, int* nb_flv);
+    srs_error_t rtmp_write_packet_by_source(char type, uint32_t timestamp, char* data, int size);
+    void statistics_fps ();
+    void request_keyframe(uint32_t ssrc);
+};
+
+#endif
+

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -115,10 +115,13 @@ public:
     // @param r the client request.
     // @param pps the matched source, if success never be NULL.
     virtual srs_error_t fetch_or_create(SrsRequest* r, SrsRtcStream** pps);
-private:
+public:
     // Get the exists source, NULL when not exists.
     // update the request and return the exists source.
     virtual SrsRtcStream* fetch(SrsRequest* r);
+
+    size_t get_source_size();
+    srs_error_t remove_idle_source();
 };
 
 // Global singleton instance.
@@ -162,6 +165,7 @@ private:
     ISrsRtcPublishStream* publish_stream_;
     // Transmux RTMP to RTC.
     SrsRtcDummyBridger* bridger_;
+    SrsSource *rtmp_source_;
     // Steam description for this steam.
     SrsRtcStreamDescription* stream_desc_;
 private:
@@ -173,6 +177,8 @@ private:
     bool is_delivering_packets_;
     // Notify stream event to event handler
     std::vector<ISrsRtcStreamEventHandler*> event_handlers_;
+
+    srs_utime_t last_update_time_;
 public:
     SrsRtcStream();
     virtual ~SrsRtcStream();
@@ -187,6 +193,7 @@ public:
     virtual SrsContextId pre_source_id();
     // Get the bridger.
     ISrsSourceBridger* bridger();
+    virtual void set_rtmp_source(SrsSource* source);
 public:
     // Create consumer
     // @param consumer, output the create consumer.
@@ -206,6 +213,13 @@ public:
     virtual srs_error_t on_publish();
     // When stop publish stream.
     virtual void on_unpublish();
+    
+    virtual bool  is_rtc_consumers_empty();
+    virtual srs_utime_t is_alive();
+    virtual void alive();
+
+    virtual void request_publish_stream_keyframe();
+
 public:
     // For event handler
     void subscribe(ISrsRtcStreamEventHandler* h);

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -597,6 +597,8 @@ public:
     //         for when reload the request of client maybe invalid.
     virtual srs_error_t on_publish();
     virtual void on_unpublish();
+    virtual srs_error_t on_edge_play();
+    virtual void on_edge_play_stop();
 public:
     // Create consumer
     // @param consumer, output the create consumer.

--- a/trunk/src/protocol/srs_rtmp_stack.cpp
+++ b/trunk/src/protocol/srs_rtmp_stack.cpp
@@ -1578,6 +1578,7 @@ SrsRequest::SrsRequest()
     duration = -1;
     port = SRS_CONSTS_RTMP_DEFAULT_PORT;
     args = NULL;
+
 }
 
 SrsRequest::~SrsRequest()
@@ -1625,7 +1626,7 @@ void SrsRequest::update_auth(SrsRequest* req)
     param = req->param;
     schema = req->schema;
     duration = req->duration;
-    
+   
     if (args) {
         srs_freep(args);
     }

--- a/trunk/src/protocol/srs_rtmp_stack.hpp
+++ b/trunk/src/protocol/srs_rtmp_stack.hpp
@@ -470,6 +470,7 @@ public:
     // used for edge traverse to origin authentication,
     // @see https://github.com/ossrs/srs/issues/104
     SrsAmf0Object* args;
+
 public:
     SrsRequest();
     virtual ~SrsRequest();


### PR DESCRIPTION
1.增加rtc to rtmp功能 视频h264 音频 opus格式,目前还不支持opus to aac
2.边缘为rtc时, 如果rtc play回触发rtmp回源 
3. rtc source 如果没有推拉流时, 自动资源清理 
4. gb28181 demo去掉flash, 默认开启rtc 与flv 播放 
5. api返回rtmp webrtc, flv, hls等播放地址