### PR TITLE
fix: fix build for ./configure --osx --rtc=off  && make

### DIFF
--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -3304,7 +3304,7 @@ srs_error_t SrsRtcConnection::generate_play_local_sdp(SrsRequest* req, SrsSdp& l
             local_media_desc.sendonly_ = true;
         } else if (audio_track->direction_ == "sendrecv") {
             local_media_desc.sendrecv_ = true;
-        } else if (audio_track->direction_ == "inactive_") {
+        } else if (audio_track->direction_ == "inactive") {
             local_media_desc.inactive_ = true;
         }
 


### PR DESCRIPTION
Undefined symbols for architecture x86_64:
  "__srs_pps_conn", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_pps_objs_drop", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_pps_objs_rbuf", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_pps_objs_rfua", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_pps_objs_rothers", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_pps_objs_rraw", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_pps_objs_rtps", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_pps_pub", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_rtp_cache", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_rtp_fua_cache", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_rtp_msg_cache_buffers", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_rtp_msg_cache_objs", referenced from:
      SrsSharedPtrMessage::copy2() in srs_kernel_flv.o
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o
  "__srs_rtp_raw_cache", referenced from:
      SrsHybridServer::notify(int, long long, long long) in srs_app_hybrid.o