### PR TITLE
bugfix: SrsAsyncCallWorker::cycle to crash

### DIFF
--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -279,7 +279,13 @@ bool srs_config_apply_filter(SrsConfDirective* dvr_apply, SrsRequest* req)
 {
     static bool DEFAULT = true;
     
-    if (!dvr_apply || dvr_apply->args.empty()) {
+    // if dvr_apply is null, return false to keep consistency with get_dvr_enabled() function
+    // if not, will occasionally cause SrsAsyncCallWorker::cycle to crash down with trd == 0x00
+    if ( !dvr_apply ){
+        return false;
+    }
+    
+    if ( dvr_apply->args.empty()) {
         return DEFAULT;
     }
     


### PR DESCRIPTION
```
    dvr {
        # the filter for dvr to apply to.
        #       all, dvr all streams of all apps.
        #       <app>/<stream>, apply to specified stream of app.
        # for example, to dvr the following two streams:
        #       live/stream1 live/stream2
        # default: all
        dvr_apply       all;
    }
```