### PR TITLE
fix(sctp): fix build for debug or verbose.

### DIFF
--- a/trunk/src/app/srs_app_sctp.hpp
+++ b/trunk/src/app/srs_app_sctp.hpp
@@ -32,7 +32,7 @@
 #include <map>
 #include <vector>
 
-#ifdef SRS_VERBOSE
+#if defined(SRS_VERBOSE) || defined(SRS_DEBUG)
 #define SCTP_DEBUG 1
 #endif
 


### PR DESCRIPTION
Report an error as follows

```
./configure --osx --sctp=on --debug=on && make
```
For details
```
src/app/srs_app_sctp.cpp:161:38: error: use of undeclared identifier 'SCTP_DEBUG_ALL'
    usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_ALL);
```
This issue is fixed.