### PR TITLE
RTC: Support av1 for Chrome M90 enabled it. 4.0.91

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Other important wiki:
 
 ## V4 changes
 
+* v4.0, 2021-04-29, RTC: Support av1 for Chrome M90. 4.0.91
 * v4.0, 2021-04-24, Change push-RTSP as deprecated feature.
 * v4.0, 2021-04-24, Player: Change the default from RTMP to HTTP-FLV.
 * v4.0, 2021-04-24, Disable CherryPy by --cherrypy=off. 4.0.90

--- a/trunk/research/players/js/srs.sdk.js
+++ b/trunk/research/players/js/srs.sdk.js
@@ -470,3 +470,32 @@ function SrsRtcPlayerAsync() {
     return self;
 }
 
+// Format the codec of RTCRtpSender, kind(audio/video) is optional filter.
+// https://developer.mozilla.org/en-US/docs/Web/Media/Formats/WebRTC_codecs#getting_the_supported_codecs
+function SrsRtcFormatSenders(senders, kind) {
+    var codecs = [];
+    senders.forEach(function (sender) {
+        sender.getParameters().codecs.forEach(function(c) {
+            if (kind && sender.track.kind !== kind) {
+                return;
+            }
+
+            if (c.mimeType.indexOf('/red') > 0 || c.mimeType.indexOf('/rtx') > 0 || c.mimeType.indexOf('/fec') > 0) {
+                return;
+            }
+
+            var s = '';
+
+            s += c.mimeType.replace('audio/', '').replace('video/', '');
+            s += ', ' + c.clockRate + 'HZ';
+            if (sender.track.kind === "audio") {
+                s += ', channels: ' + c.channels;
+            }
+            s += ', pt: ' + c.payloadType;
+
+            codecs.push(s);
+        });
+    });
+    return codecs.join(", ");
+}
+

--- a/trunk/research/players/rtc_publisher.html
+++ b/trunk/research/players/rtc_publisher.html
@@ -56,6 +56,10 @@
     SessionID: <span id='sessionid'></span>
 
     <label></label>
+    Audio: <span id='acodecs'></span><br/>
+    Video: <span id='vcodecs'></span>
+
+    <label></label>
     Simulator: <a href='#' id='simulator-drop'>Drop</a>
 
     <footer>
@@ -79,6 +83,14 @@
             sdk.onaddstream = function (event) {
                 console.log('Start publish, event: ', event);
                 $('#rtc_media_player').prop('srcObject', event.stream);
+            };
+
+            // https://developer.mozilla.org/en-US/docs/Web/Media/Formats/WebRTC_codecs#getting_the_supported_codecs
+            sdk.pc.onicegatheringstatechange = function (event) {
+                if (sdk.pc.iceGatheringState === "complete") {
+                    $('#acodecs').html(SrsRtcFormatSenders(sdk.pc.getSenders(), "audio"));
+                    $('#vcodecs').html(SrsRtcFormatSenders(sdk.pc.getSenders(), "video"));
+                }
             };
 
             // For example:

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -134,18 +134,20 @@ srs_error_t SrsGoApiRtcPlay::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
 
     // For client to specifies the EIP of server.
     string eip = r->query_get("eip");
+    string codec = r->query_get("codec");
     // For client to specifies whether encrypt by SRTP.
     string srtp = r->query_get("encrypt");
     string dtls = r->query_get("dtls");
 
-    srs_trace("RTC play %s, api=%s, clientip=%s, app=%s, stream=%s, offer=%dB, eip=%s, srtp=%s, dtls=%s",
+    srs_trace("RTC play %s, api=%s, clientip=%s, app=%s, stream=%s, offer=%dB, eip=%s, codec=%s, srtp=%s, dtls=%s",
         streamurl.c_str(), api.c_str(), clientip.c_str(), app.c_str(), stream_name.c_str(), remote_sdp_str.length(), eip.c_str(),
-        srtp.c_str(), dtls.c_str()
+        codec.c_str(), srtp.c_str(), dtls.c_str()
     );
 
     // The RTC user config object.
     SrsRtcUserConfig ruc;
     ruc.eip_ = eip;
+    ruc.codec_ = codec;
     ruc.publish_ = false;
     ruc.dtls_ = (dtls != "false");
 
@@ -500,14 +502,17 @@ srs_error_t SrsGoApiRtcPublish::do_serve_http(ISrsHttpResponseWriter* w, ISrsHtt
 
     // For client to specifies the EIP of server.
     string eip = r->query_get("eip");
+    string codec = r->query_get("codec");
 
-    srs_trace("RTC publish %s, api=%s, clientip=%s, app=%s, stream=%s, offer=%dB, eip=%s",
-        streamurl.c_str(), api.c_str(), clientip.c_str(), app.c_str(), stream_name.c_str(), remote_sdp_str.length(), eip.c_str()
+    srs_trace("RTC publish %s, api=%s, clientip=%s, app=%s, stream=%s, offer=%dB, eip=%s, codec=%s",
+        streamurl.c_str(), api.c_str(), clientip.c_str(), app.c_str(), stream_name.c_str(), remote_sdp_str.length(), eip.c_str(),
+        codec.c_str()
     );
 
     // The RTC user config object.
     SrsRtcUserConfig ruc;
     ruc.eip_ = eip;
+    ruc.codec_ = codec;
     ruc.publish_ = true;
     ruc.dtls_ = ruc.srtp_ = true;
 

--- a/trunk/src/app/srs_app_rtc_server.hpp
+++ b/trunk/src/app/srs_app_rtc_server.hpp
@@ -92,6 +92,7 @@ public:
     // Original variables from API.
     SrsSdp remote_sdp_;
     std::string eip_;
+    std::string codec_;
 
     // Generated data.
     SrsRequest* req_;

--- a/trunk/src/core/srs_core_version4.hpp
+++ b/trunk/src/core/srs_core_version4.hpp
@@ -26,6 +26,6 @@
 
 #define VERSION_MAJOR       4
 #define VERSION_MINOR       0
-#define VERSION_REVISION    90
+#define VERSION_REVISION    91
 
 #endif


### PR DESCRIPTION
Use query `?codec=av1` to publish and play with AV1:

* Publish stream: [webrtc://localhost/live/livestream?codec=av1](http://localhost:8080/players/rtc_publisher.html?autostart=true&codec=av1)
* Play stream: [webrtc://localhost/live/livestream?codec=av1](http://localhost:8080/players/rtc_player.html?autostart=true&codec=av1)

First, please upgrade your Chrome to M90+:

![image](https://user-images.githubusercontent.com/2777660/116630834-98406180-a986-11eb-9de3-f877026761f7.png)

The video codec is `Video: AV1X, 90000HZ, pt: 35`

![image](https://user-images.githubusercontent.com/2777660/116630887-aee6b880-a986-11eb-97d7-97c510a7fd9e.png)

