### PR TITLE
Fix(log): fix compile error when the options --log-info, --log-verbose are enabled

### DIFF
--- a/trunk/src/app/srs_app_edge.cpp
+++ b/trunk/src/app/srs_app_edge.cpp
@@ -588,7 +588,7 @@ srs_error_t SrsEdgeForwarder::do_cycle()
             SrsCommonMessage* msg = NULL;
             err = sdk->recv_message(&msg);
             
-            srs_verbose("edge loop recv message. ret=%d", ret);
+            srs_verbose("edge loop recv message.");
             if (err != srs_success && srs_error_code(err) != ERROR_SOCKET_TIMEOUT) {
                 srs_error("edge push get server control message failed. err=%s", srs_error_desc(err).c_str());
                 send_error_code = srs_error_code(err);

--- a/trunk/src/app/srs_app_pithy_print.cpp
+++ b/trunk/src/app/srs_app_pithy_print.cpp
@@ -187,7 +187,7 @@ int SrsPithyPrint::enter_stage()
     client_id = stage->nb_clients++;
     
     srs_verbose("enter stage, stage_id=%d, client_id=%d, nb_clients=%d, time_ms=%d",
-                stage->stage_id, client_id, stage->nb_clients, stage->pithy_print_time_ms);
+                stage->stage_id, client_id, stage->nb_clients, stage->interval);
     
     return client_id;
 }
@@ -200,7 +200,7 @@ void SrsPithyPrint::leave_stage()
     stage->nb_clients--;
     
     srs_verbose("leave stage, stage_id=%d, client_id=%d, nb_clients=%d, time_ms=%d",
-                stage->stage_id, client_id, stage->nb_clients, stage->pithy_print_time_ms);
+                stage->stage_id, client_id, stage->nb_clients, stage->interval);
 }
 
 void SrsPithyPrint::elapse()

--- a/trunk/src/service/srs_service_http_conn.cpp
+++ b/trunk/src/service/srs_service_http_conn.cpp
@@ -123,7 +123,7 @@ srs_error_t SrsHttpParser::parse_message_imp(ISrsReader* reader)
             // The error is set in http_errno.
             enum http_errno code;
 	        if ((code = HTTP_PARSER_ERRNO(&parser)) != HPE_OK) {
-	            return srs_error_new(ERROR_HTTP_PARSE_HEADER, "parse %dB, nparsed=%d, err=%d/%s %s",
+	            return srs_error_new(ERROR_HTTP_PARSE_HEADER, "parse %dB, consumed=%d, err=%d/%s %s",
 	                buffer->size(), consumed, code, http_errno_name(code), http_errno_description(code));
 	        }
 
@@ -139,7 +139,7 @@ srs_error_t SrsHttpParser::parse_message_imp(ISrsReader* reader)
 	                }
 	            }
 	        }
-            srs_info("size=%d, nparsed=%d, consumed=%d", buffer->size(), (int)nparsed, consumed);
+            srs_info("size=%d, consumed=%d", buffer->size(), consumed);
 
 	        // Only consume the header bytes.
             buffer->read_slice(consumed);


### PR DESCRIPTION
I got errors when I tried to do following commands:

```
cd trunk
./configure --log-info --log-verbose && make
```

After checking, there are few parts need to be corrected. Please help to review, thanks.