### PR TITLE
修复gb28181无法使用rtc播放

### DIFF
--- a/trunk/src/app/srs_app_gb28181.cpp
+++ b/trunk/src/app/srs_app_gb28181.cpp
@@ -51,6 +51,7 @@ using namespace std;
 #include <srs_protocol_utility.hpp>
 #include <srs_protocol_format.hpp>
 #include <srs_app_sip.hpp>
+#include <srs_app_rtc_source.hpp>
 
 //#define W_PS_FILE
 //#define W_VIDEO_FILE
@@ -1436,10 +1437,38 @@ srs_error_t SrsGb28181RtmpMuxer::initialize(SrsServer *s, SrsRequest* r)
         return srs_error_wrap(err, "create source");
     }
 
-    //TODO: ???
-    // if (!source->can_publish(false)) {
-    //     return srs_error_new(ERROR_GB28181_SESSION_IS_EXIST, "stream %s busy", req->get_stream_url().c_str());
-    // }
+ #ifdef SRS_RTC
+    SrsRtcSource *rtc = NULL;
+    bool rtc_server_enabled = _srs_config->get_rtc_server_enabled();
+    bool rtc_enabled = _srs_config->get_rtc_enabled(req->vhost);
+    if (rtc_server_enabled && rtc_enabled) {
+        if ((err = _srs_rtc_sources->fetch_or_create(req, &rtc)) != srs_success) {
+            return srs_error_wrap(err, "create source");
+        }
+
+        if (!rtc->can_publish()) {
+            return srs_error_new(ERROR_RTC_SOURCE_BUSY, "gb28181 rtc stream %s busy", req->get_stream_url().c_str());
+        }
+    }
+#endif
+
+    // Check whether RTMP stream is busy.
+    if (!source->can_publish(false)) {
+        return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "gb28181 rtmp: stream %s is busy", req->get_stream_url().c_str());
+    }
+
+    // Bridge to RTC streaming.
+#if defined(SRS_RTC) && defined(SRS_FFMPEG_FIT)
+    if (rtc) {
+        SrsRtcFromRtmpBridger *bridger = new SrsRtcFromRtmpBridger(rtc);
+        if ((err = bridger->initialize(req)) != srs_success) {
+            srs_freep(bridger);
+            return srs_error_wrap(err, "bridger init");
+        }
+
+        source->set_bridger(bridger);
+    }
+#endif
 
     if ((err = source->on_publish()) != srs_success) {
         return srs_error_wrap(err, "on publish");

--- a/trunk/src/app/srs_app_rtc_jitbuffer.cpp
+++ b/trunk/src/app/srs_app_rtc_jitbuffer.cpp
@@ -1201,7 +1201,7 @@ SrsRtpFrameBufferEnum SrsRtpJitterBuffer::InsertPacket(uint16_t seq, uint32_t ts
         //CountFrame(*frame);
         // if (previous_state != kStateDecodable &&
         //         previous_state != kStateComplete) {
-        //     /*CountFrame(*frame);*/ //????????????????????�?? by ylr
+        //     /*CountFrame(*frame);
         //     if (continuous) {
         //         // Signal that we have a complete session.
         //         frame_event_->Set();
@@ -1213,7 +1213,7 @@ SrsRtpFrameBufferEnum SrsRtpJitterBuffer::InsertPacket(uint16_t seq, uint32_t ts
     case kDecodableSession: {
         // *retransmitted = (frame->GetNackCount() > 0);
 
-        if (true || continuous) {
+        if (continuous) {
             decodable_frames_.InsertFrame(frame);
             FindAndInsertContinuousFrames(*frame);
         } else {
@@ -1522,7 +1522,9 @@ bool SrsRtpJitterBuffer::NextMaybeIncompleteTimestamp(uint32_t* timestamp)
     SrsRtpFrameBuffer* oldest_frame;
 
     if (decodable_frames_.empty()) {
-        if (incomplete_frames_.size() <= 1) {
+        //in order to solve the problem of bad network, we can wait for more incomplete frames
+        //ex fps=15
+        if (incomplete_frames_.size() < 15) {
             return false;
         }
 


### PR DESCRIPTION
问题描述:https://github.com/ossrs/srs/issues/2355
原因:
最新版本rtmp to rtc 桥接已经移到SrsRtmpConn 之前在SrsSource, gb28181默认转发流是通过SrsSource,没有触发桥接
修改功能:  
1. jiterbuffer网络不好的情况, 等待更多的不完整的帧,
2. 修复gb28181无法使用rtc播放 