### PR TITLE
解决gb推流和rtmp推流冲突bug

### DIFF
--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -960,6 +960,15 @@ srs_error_t SrsRtmpConn::acquire_publish(SrsLiveSource* source)
     srs_error_t err = srs_success;
     
     SrsRequest* req = info->req;
+	
+	// @see https://github.com/ossrs/srs/issues/2364
+    // Check whether GB28181 stream is busy.
+#if defined(SRS_GB28181)
+    SrsGb28181RtmpMuxer* gb28181 = _srs_gb28181->fetch_rtmpmuxer(req->stream);
+    if (gb28181 != NULL) {
+        return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "gb28181 stream %s busy", req->get_stream_url().c_str());
+    }
+#endif
 
     // Check whether RTC stream is busy.
 #ifdef SRS_RTC


### PR DESCRIPTION
#### 现象描述：
1. 开启GB28181功能，ipc注册之后，会生成stream name 为`34020000001320000001@34020000001320000001`的source。
2. 然后用ffmpeg推送rtmp，url为`rtmp://ip:port/live/34020000001320000001@34020000001320000001`，二者发生冲突

详见 https://github.com/ossrs/srs/issues/2364

#### 解决办法：
在`SrsRtmpConn::acquire_publish`增加判断逻辑即可。