### PR TITLE
fix bug: application crash, when 'stream_caster disable' in config file, and '--gb28181=on' in configure

### DIFF
--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -961,12 +961,14 @@ srs_error_t SrsRtmpConn::acquire_publish(SrsLiveSource* source)
     
     SrsRequest* req = info->req;
 	
-	// @see https://github.com/ossrs/srs/issues/2364
+    // @see https://github.com/ossrs/srs/issues/2364
     // Check whether GB28181 stream is busy.
 #if defined(SRS_GB28181)
-    SrsGb28181RtmpMuxer* gb28181 = _srs_gb28181->fetch_rtmpmuxer(req->stream);
-    if (gb28181 != NULL) {
-        return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "gb28181 stream %s busy", req->get_stream_url().c_str());
+    if (_srs_gb28181 != NULL) {
+        SrsGb28181RtmpMuxer* gb28181 = _srs_gb28181->fetch_rtmpmuxer(req->stream);
+        if (gb28181 != NULL) {
+            return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "gb28181 stream %s busy", req->get_stream_url().c_str());
+        }
     }
 #endif
 


### PR DESCRIPTION
**修复这个pr的bug**。 https://github.com/ossrs/srs/pull/2366

bug描述：

当编译脚本开启GB28181协议，`--gb28181=on`
但配置文件禁用GB28181 stream_caster
```
stream_caster {
     enabled             off;
     caster              gb28181;
      ...
```
由于`_srs_gb28181`未初始化，会导致程序崩溃