### PR TITLE
RTC: Fix NACK negotiation bug for Firefox.

### DIFF
--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -3099,6 +3099,10 @@ srs_error_t SrsRtcConnection::negotiate_play_capability(SrsRtcUserConfig* ruc, s
             // We should clear the extmaps of source(publisher).
             // @see https://github.com/ossrs/srs/issues/2370
             track->extmaps_.clear();
+			
+            // We should clear the rtcp_fbs of source(publisher).
+            // @see https://github.com/ossrs/srs/issues/2371
+            track->media_->rtcp_fbs_.clear();
 
             // Use remote/source/offer PayloadType.
             track->media_->pt_of_publisher_ = track->media_->pt_;
@@ -3116,7 +3120,7 @@ srs_error_t SrsRtcConnection::negotiate_play_capability(SrsRtcUserConfig* ruc, s
             uint32_t publish_ssrc = track->ssrc_;
 
             vector<string> rtcp_fb;
-            track->media_->rtcp_fbs_.swap(rtcp_fb);
+            remote_payload.rtcp_fb_.swap(rtcp_fb);
             for (int j = 0; j < (int)rtcp_fb.size(); j++) {
                 if (nack_enabled) {
                     if (rtcp_fb.at(j) == "nack" || rtcp_fb.at(j) == "nack pli") {


### PR DESCRIPTION
#### 原因
1. SRS回复的answer sdp里面，没有rtcp-fb nack字段。
1. Chrome默认**开启**nack，所以尽管SRS的answer没有开启NACK，也没问题。
1. Firefox默认**关闭**nack，所以SRS的answer没有开启NACK，就会有丢包导致的卡顿。

#### 结论
   网络抖动时，由于Firefox不会发送nack，造成视频卡顿。

#### 解决
   增加rtcp-fb nack字段，相当于手动开启firefox的nack功能，解决丢包造成的卡顿。

@see https://github.com/ossrs/srs/issues/2371