### PR TITLE
fix bug:appears CLOSE_WAIT when counts of client connections exceeds …

### DIFF
--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -1570,7 +1570,7 @@ srs_error_t SrsServer::accept_client(SrsListenerType type, srs_netfd_t stfd)
     ISrsStartableConneciton* conn = NULL;
     
     if ((err = fd_to_resource(type, stfd, &conn)) != srs_success) {
-        if (srs_error_code(err) == ERROR_SOCKET_GET_PEER_IP && _srs_config->empty_ip_ok()) {
+        if ((srs_error_code(err) == ERROR_SOCKET_GET_PEER_IP || srs_error_code(err) == ERROR_EXCEED_CONNECTIONS) && _srs_config->empty_ip_ok()) {
             srs_close_stfd(stfd); srs_error_reset(err);
             return srs_success;
         }


### PR DESCRIPTION
http-flv拉流，当拉流的客户端数量大于SRS服务器配置文件里的max_connections时，客户端挂断后，会出现CLOSE_WAIT，出现的CLOESE_WAIT数量是客户端连接数减去max_connections，以上修改解决的是上述情况服务器出现CLOSE_WAIT的情况
