### PR TITLE
当在线人数超过60s为0时自动清理国标视频流

### DIFF
--- a/trunk/src/app/srs_app_statistic.hpp
+++ b/trunk/src/app/srs_app_statistic.hpp
@@ -15,6 +15,7 @@
 
 #include <srs_kernel_codec.hpp>
 #include <srs_rtmp_stack.hpp>
+#include <srs_app_hourglass.hpp>
 
 class SrsKbps;
 class SrsWallClock;
@@ -45,6 +46,8 @@ public:
 struct SrsStatisticStream
 {
 public:
+    srs_utime_t last_non_zero_client; // 最近有客户端时间
+
     std::string id;
     SrsStatisticVhost* vhost;
     std::string app;
@@ -107,8 +110,13 @@ public:
     virtual srs_error_t dumps(SrsJsonObject* obj);
 };
 
-class SrsStatistic
+class SrsStatistic:public ISrsFastTimer
 {
+private:
+    // auto clean gb streams
+    SrsFastTimer *timer30s_;
+    virtual srs_error_t on_timer(srs_utime_t interval);
+
 private:
     static SrsStatistic *_instance;
     // The id to identify the sever.


### PR DESCRIPTION
 国标直播流无在线观看超过一定时间后自动通知GB28181发送BYE指令，停止推流，达到降低网络拥塞的目的
