### PR TITLE
fix bug: last segment of ts not trigger 'on_hls'

### DIFF
--- a/trunk/src/app/srs_app_hls.cpp
+++ b/trunk/src/app/srs_app_hls.cpp
@@ -923,16 +923,16 @@ srs_error_t SrsHlsController::on_unpublish()
 {
     srs_error_t err = srs_success;
 
-    if ((err = muxer->on_unpublish()) != srs_success) {
-        return srs_error_wrap(err, "muxer unpublish");
-    }
-    
     if ((err = muxer->flush_audio(tsmc)) != srs_success) {
         return srs_error_wrap(err, "hls: flush audio");
     }
     
     if ((err = muxer->segment_close()) != srs_success) {
         return srs_error_wrap(err, "hls: segment close");
+    }
+
+    if ((err = muxer->on_unpublish()) != srs_success) {
+        return srs_error_wrap(err, "muxer unpublish");
     }
     
     return err;


### PR DESCRIPTION
fix bug: last segment of ts not trigger 'on_hls', because of 'on_unpublish' earlier than 'segment_close',
see https://github.com/ossrs/srs/issues/2068

**现象**：推流结束后，最后一个hls切片没有触发`on_hls` 
**原因**：在`SrsHlsController::on_unpublish()`这个函数里面，`on_unpublish`早于 `segment_close`，导致最后一个切片通知被**遗忘**在tasks里面。
**解决**：将`on_unpublish`置于 `segment_close`后面即可。
```
srs_error_t SrsHlsController::on_unpublish()
{
    srs_error_t err = srs_success;

    if ((err = muxer->on_unpublish()) != srs_success) {    
        return srs_error_wrap(err, "muxer unpublish");                
    }           
                                                                                   
    if ((err = muxer->flush_audio(tsmc)) != srs_success) {           
        return srs_error_wrap(err, "hls: flush audio");                     
    }       
                                                                                       
    if ((err = muxer->segment_close()) != srs_success) {              
        return srs_error_wrap(err, "hls: segment close");                
    }     
                                                       
    return err;
}
```