### PR TITLE
fix ffmpeg compile error in file 'auto/depends.sh'

### DIFF
--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -701,15 +701,15 @@ if [[ $SRS_FFMPEG_FIT == YES ]]; then
             cd ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit && cp -R ../../../3rdparty/ffmpeg-4-fit/* . &&
             # Build source code.
             $FFMPEG_CONFIGURE \
-              --prefix=`pwd`/_release --pkg-config=pkg-config ${FFMPEG_OPTIONS} \
-               --disable-everything --pkg-config-flags="--static" --extra-libs="-lpthread" --extra-libs="-lm" \
+              --prefix=`pwd`/_release --pkg-config=pkg-config --disable-everything  ${FFMPEG_OPTIONS} \
+              --pkg-config-flags="--static" --extra-libs="-lpthread" --extra-libs="-lm" \
               --disable-programs --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages \
               --disable-avdevice --disable-avformat --disable-swscale --disable-postproc --disable-avfilter --disable-network \
               --disable-dct --disable-dwt --disable-error-resilience --disable-lsp --disable-lzo --disable-faan --disable-pixelutils \
               --disable-hwaccels --disable-devices --disable-audiotoolbox --disable-videotoolbox --disable-cuvid \
               --disable-d3d11va --disable-dxva2 --disable-ffnvcodec --disable-nvdec --disable-nvenc --disable-v4l2-m2m --disable-vaapi \
               --disable-vdpau --disable-appkit --disable-coreimage --disable-avfoundation --disable-securetransport --disable-iconv \
-              --disable-lzma --disable-sdl2 --disable-everything --enable-decoder=aac --enable-decoder=aac_fixed --enable-decoder=aac_latm \
+              --disable-lzma --disable-sdl2 --enable-decoder=aac --enable-decoder=aac_fixed --enable-decoder=aac_latm \
               --enable-encoder=aac &&
             # See https://www.laoyuyu.me/2019/05/23/android/clang_compile_ffmpeg/
             if [[ $SRS_CROSS_BUILD == YES ]]; then


### PR DESCRIPTION
这个commit([Squash #1685, #1282, #1547: Support ARM platform. 5.0.5](a594678e3dab9544762e854e34b0571173be696e))引入的新BUG。

**现象**：开启rtc后，ffmpeg推流失败，提示查找编码器失败，错误日志如下
```
serve error code=5011 : service cycle : rtmp: stream service : bridger init : init codec : enc init codec:13, channels:2, samplerate:48000, bitrate:48000 : Codec not found by name(13,libopus)
```
**原因**：在`auto/depends.sh`文件，ffmpeg编译模块，`--enable-encoder=libopus` 在 `--disable-everything`之前，导致配置未生效。
**解决**：调换顺序即可。