### PR TITLE
打开rtmp转rtc，当rtmp重复推流时，第2路会影响第1路流的正常播放。

### DIFF
--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -960,7 +960,7 @@ srs_error_t SrsRtmpConn::acquire_publish(SrsLiveSource* source)
         }
 
         if (!rtc->can_publish()) {
-            return srs_error_new(ERROR_RTC_SOURCE_BUSY, "rtc stream %s busy", req->get_stream_url().c_str());
+            return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "rtc stream %s busy", req->get_stream_url().c_str());
         }
     }
 #endif

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -944,6 +944,11 @@ srs_error_t SrsRtmpConn::acquire_publish(SrsLiveSource* source)
     
     SrsRequest* req = info->req;
 
+    // Check whether RTMP stream is busy.
+    if (!source->can_publish(info->edge)) {
+        return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "rtmp: stream %s is busy", req->get_stream_url().c_str());
+    }
+    
     // Check whether RTC stream is busy.
 #ifdef SRS_RTC
     SrsRtcSource *rtc = NULL;
@@ -959,11 +964,6 @@ srs_error_t SrsRtmpConn::acquire_publish(SrsLiveSource* source)
         }
     }
 #endif
-
-    // Check whether RTMP stream is busy.
-    if (!source->can_publish(info->edge)) {
-        return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "rtmp: stream %s is busy", req->get_stream_url().c_str());
-    }
 
     // Bridge to RTC streaming.
 #if defined(SRS_RTC) && defined(SRS_FFMPEG_FIT)


### PR DESCRIPTION
修复推重复的RTMP流导致的RTC和RTMP播放的问题