### PR TITLE
Calculate the correct payload_size which pure padding data, in the process of rtc2rtmp, make Chrome happy

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -1517,8 +1517,7 @@ srs_error_t SrsRtmpFromRtcBridger::packet_video_rtmp(const uint16_t start, const
 {
     srs_error_t err = srs_success;
 
-    //type_codec1 + avc_type + composition time + nalu size + nalu
-    int nb_payload = 1 + 1 + 3;
+    int nb_payload = 0;
     uint16_t cnt = end - start + 1;
 
     for (uint16_t i = 0; i < cnt; ++i) {
@@ -1553,10 +1552,13 @@ srs_error_t SrsRtmpFromRtcBridger::packet_video_rtmp(const uint16_t start, const
         }
     }
 
-    if (5 == nb_payload) {
+    if (0 == nb_payload) {
         srs_warn("empty nalu");
         return err;
     }
+	
+    //type_codec1 + avc_type + composition time + nalu size + nalu
+    nb_payload += 1 + 1 + 3;
 
     SrsCommonMessage rtmp;
     SrsRtpPacket* header = cache_video_pkts_[cache_index(start)].pkt;

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -1587,7 +1587,7 @@ srs_error_t SrsRtmpFromRtcBridger::packet_video_rtmp(const uint16_t start, const
         cache_video_pkts_[index].sn = 0;
 
         SrsRtpFUAPayload2* fua_payload = dynamic_cast<SrsRtpFUAPayload2*>(pkt->payload());
-        if (fua_payload) {
+        if (fua_payload && fua_payload->size > 0) {
             if (fua_payload->start) {
                 nalu_len = fua_payload->size + 1;
                 //skip 4 bytes to write nalu_len future
@@ -1612,15 +1612,17 @@ srs_error_t SrsRtmpFromRtcBridger::packet_video_rtmp(const uint16_t start, const
         if (stap_payload) {
             for (int j = 0; j < (int)stap_payload->nalus.size(); ++j) {
                 SrsSample* sample = stap_payload->nalus.at(j);
-                payload.write_4bytes(sample->size);
-                payload.write_bytes(sample->bytes, sample->size);
+		if (sample->size > 0) {  
+		    payload.write_4bytes(sample->size);
+                    payload.write_bytes(sample->bytes, sample->size);
+		}
             }
             srs_freep(pkt);
             continue;
         }
 
         SrsRtpRawPayload* raw_payload = dynamic_cast<SrsRtpRawPayload*>(pkt->payload());
-        if (raw_payload) {
+        if (raw_payload && raw_payload->nn_payload > 0) {
             payload.write_4bytes(raw_payload->nn_payload);
             payload.write_bytes(raw_payload->payload, raw_payload->nn_payload);
             srs_freep(pkt);

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -1527,7 +1527,7 @@ srs_error_t SrsRtmpFromRtcBridger::packet_video_rtmp(const uint16_t start, const
         SrsRtpPacket* pkt = cache_video_pkts_[index].pkt;
         // calculate nalu len
         SrsRtpFUAPayload2* fua_payload = dynamic_cast<SrsRtpFUAPayload2*>(pkt->payload());
-        if (fua_payload) {
+        if (fua_payload && fua_payload->size > 0) {
             if (fua_payload->start) {
                 nb_payload += 1 + 4;
             }
@@ -1539,16 +1539,23 @@ srs_error_t SrsRtmpFromRtcBridger::packet_video_rtmp(const uint16_t start, const
         if (stap_payload) {
             for (int j = 0; j < (int)stap_payload->nalus.size(); ++j) {
                 SrsSample* sample = stap_payload->nalus.at(j);
-                nb_payload += 4 + sample->size;
+                if (sample->size > 0) {    
+                    nb_payload += 4 + sample->size;
+                }
             }
             continue;
         }
 
         SrsRtpRawPayload* raw_payload = dynamic_cast<SrsRtpRawPayload*>(pkt->payload());
-        if (raw_payload) {
+        if (raw_payload && raw_payload->nn_payload > 0) {
             nb_payload += 4 + raw_payload->nn_payload;
             continue;
         }
+    }
+
+    if (5 == nb_payload) {
+        srs_warn("empty nalu");
+        return err;
     }
 
     SrsCommonMessage rtmp;


### PR DESCRIPTION
**现象**：使用rtc2rtmp时，开启twcc之后（默认开启），用getDisplayMedia推流，播放flv出错。关闭twcc之后，播放正常。

**原因**：
1. 开启twcc
1.1. 如果实际编码带宽低于预测带宽，会主动发送padding。
1.2. 通过抓包分析，有些packet是纯padding，也就是有效负载的payload_size为0。
由于代码的漏洞（没错，这是个bug），flv包会填充很多0x00。如下图所示。
1.3. Firefox或者ffplay面对这种空包，会提示错误，但选择忽略并继续播放。而Chrome校验严格，直接报错，也就导致了flv无法播放。
2. 关闭twcc时，不会有padding包，所以能够播放正常。

**解决**：
1. 计算出正确的payload_size即可。见代码。


> 参考文章： [WebRTC m79中的RTP padding](https://blog.csdn.net/dobe_yang/article/details/104944949)

![微信图片_20210706182243](https://user-images.githubusercontent.com/4254164/124584792-3b31c200-de87-11eb-8482-9b76392f87aa.png)