### PR TITLE
RTC: Trim SDP line space for pion/webrtc client.

### DIFF
--- a/trunk/src/app/srs_app_rtc_sdp.cpp
+++ b/trunk/src/app/srs_app_rtc_sdp.cpp
@@ -747,6 +747,9 @@ srs_error_t SrsSdp::parse(const std::string& sdp_str)
             line.erase(line.size()-1, 1);
         }
 
+        // Strip the space of line, for pion WebRTC client.
+        line = srs_string_trim_end(line, " ");
+
         if ((err = parse_line(line)) != srs_success) {
             return srs_error_wrap(err, "parse sdp line failed");
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2777660/124848201-f7e26b00-dfce-11eb-86a3-1d9b8302a62a.png)

导致服务器没有识别到offer中的nack信息。