### PR TITLE
fix bug: correct the client ip of http-flv player, for statistic

### DIFF
--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -587,6 +587,9 @@ srs_error_t SrsLiveStream::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMess
     SrsHttpMessage* hr = dynamic_cast<SrsHttpMessage*>(r);
     SrsHttpConn* hc = dynamic_cast<SrsHttpConn*>(hr->connection());
     
+    // update client ip
+    req->ip = hc->remote_ip();    
+
     // update the statistic when source disconveried.
     SrsStatistic* stat = SrsStatistic::instance();
     if ((err = stat->on_client(_srs_context->get_id().c_str(), req, hc, SrsRtmpConnPlay)) != srs_success) {


### PR DESCRIPTION
> 惢畾 提问：rtmp推流，http-flv拉流时，控制台中的所有客户端ip全部是推流机器的ip，rtmp拉流时正常，请问如何解决？

fix bug for https://t.zsxq.com/EqNbUrN