### PR TITLE
Fix rtc publish play in Safari or in WKWebView, video or audio views …

### DIFF
--- a/trunk/research/players/rtc_player.html
+++ b/trunk/research/players/rtc_player.html
@@ -50,7 +50,7 @@
     </div>
 
     <label></label>
-    <video id="rtc_media_player" controls autoplay></video>
+    <video id="rtc_media_player" controls autoplay muted></video>
 
     <label></label>
     SessionID: <span id='sessionid'></span>
@@ -76,7 +76,7 @@ $(function(){
         sdk = new SrsRtcPlayerAsync();
 
         // https://webrtc.org/getting-started/remote-streams
-        $('#rtc_media_player').prop('srcObject', sdk.stream);
+        // $('#rtc_media_player').prop('srcObject', sdk.stream);
         // Optional callback, SDK will add track to stream.
         // sdk.ontrack = function (event) { console.log('Got track', event); sdk.stream.addTrack(event.track); };
 
@@ -85,6 +85,9 @@ $(function(){
         sdk.play(url).then(function(session){
             $('#sessionid').html(session.sessionid);
             $('#simulator-drop').attr('href', session.simulator + '?drop=1&username=' + session.sessionid);
+            $('#rtc_media_player').prop('srcObject', sdk.stream);
+            var videoPlayer = document.getElementById("rtc_media_player");
+            videoPlayer.play();
         }).catch(function (reason) {
             sdk.close();
             $('#rtc_media_player').hide();

--- a/trunk/research/players/rtc_publisher.html
+++ b/trunk/research/players/rtc_publisher.html
@@ -50,7 +50,7 @@
     </div>
 
     <label></label>
-    <video id="rtc_media_player" width="320" autoplay muted></video>
+    <video id="rtc_media_player" width="320" autoplay muted playsinline></video>
 
     <label></label>
     SessionID: <span id='sessionid'></span>
@@ -81,7 +81,7 @@ $(function(){
 
         // User should set the stream when publish is done, @see https://webrtc.org/getting-started/media-devices
         // However SRS SDK provides a consist API like https://webrtc.org/getting-started/remote-streams
-        $('#rtc_media_player').prop('srcObject', sdk.stream);
+        // $('#rtc_media_player').prop('srcObject', sdk.stream);
         // Optional callback, SDK will add track to stream.
         // sdk.ontrack = function (event) { console.log('Got track', event); sdk.stream.addTrack(event.track); };
 
@@ -98,6 +98,7 @@ $(function(){
         sdk.publish(url).then(function(session){
             $('#sessionid').html(session.sessionid);
             $('#simulator-drop').attr('href', session.simulator + '?drop=1&username=' + session.sessionid);
+            $('#rtc_media_player').prop('srcObject', sdk.stream);
         }).catch(function (reason) {
             sdk.close();
             $('#rtc_media_player').hide();


### PR DESCRIPTION
… not work
1. 修复publish rtc 流，在Safari浏览器和SFSafariViewController中不显示画面的问题
2. 修复play rtc 流，在Safari浏览器、SFSafariViewController、WKWebView中不显示画面的问题