### PR TITLE
Ingest: Exit if child process redirect io failed

### DIFF
--- a/trunk/src/app/srs_app_process.cpp
+++ b/trunk/src/app/srs_app_process.cpp
@@ -183,22 +183,21 @@ srs_error_t SrsProcess::start()
         signal(SIGINT, SIG_IGN);
         signal(SIGTERM, SIG_IGN);
 
-        srs_error_t child_err = srs_success;
         // for the stdout, ignore when not specified.
         // redirect stdout to file if possible.
         if ((err = srs_redirect_output(stdout_file, STDOUT_FILENO)) != srs_success) {
-            child_err = srs_error_wrap(err, "redirect output");
+            err = srs_error_wrap(err, "redirect output");
         }
         
         // for the stderr, ignore when not specified.
         // redirect stderr to file if possible.
         if ((err = srs_redirect_output(stderr_file, STDERR_FILENO)) != srs_success) {
-            child_err = srs_error_wrap(err, "redirect output");
+            err = srs_error_wrap(err, "redirect output");
         }
 
         // No stdin for process, @bug https://github.com/ossrs/srs/issues/1592
         if ((err = srs_redirect_output("/dev/null", STDIN_FILENO)) != srs_success) {
-            child_err = srs_error_wrap(err, "redirect input");
+            err = srs_error_wrap(err, "redirect input");
         }
 
         // should never close the fd 3+, for it myabe used.
@@ -214,8 +213,8 @@ srs_error_t SrsProcess::start()
         }
         
         // output error to stdout and exit child process.
-        if (child_err != srs_success) {
-            fprintf(stdout, "child process error, %s\n", srs_error_desc(child_err).c_str());
+        if (err != srs_success) {
+            fprintf(stdout, "child process error, %s\n", srs_error_desc(err).c_str());
             exit(-1);
         }
         

--- a/trunk/src/app/srs_app_process.cpp
+++ b/trunk/src/app/srs_app_process.cpp
@@ -206,7 +206,13 @@ srs_error_t SrsProcess::start()
         // ignore the SIGINT and SIGTERM
         signal(SIGINT, SIG_IGN);
         signal(SIGTERM, SIG_IGN);
-
+        
+        // redirect standard I/O, if it failed, output error to stdout, and exit child process.
+        if ((err = redirect_io()) != srs_success) {
+            fprintf(stdout, "child process error, %s\n", srs_error_desc(err).c_str());
+            exit(-1);
+        }
+        
         // should never close the fd 3+, for it myabe used.
         // for fd should close at exec, use fnctl to set it.
         
@@ -217,12 +223,6 @@ srs_error_t SrsProcess::start()
                 ppid, cid.c_str(), getpid(), STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO);
             fprintf(stdout, "process binary=%s, cli: %s\n", bin.c_str(), cli.c_str());
             fprintf(stdout, "process actual cli: %s\n", actual_cli.c_str());
-        }
-        
-        // output error to stdout and exit child process.
-        if ((err = redirect_io()) != srs_success) {
-            fprintf(stdout, "child process error, %s\n", srs_error_desc(err).c_str());
-            exit(-1);
         }
         
         // memory leak in child process, it's ok.

--- a/trunk/src/app/srs_app_process.cpp
+++ b/trunk/src/app/srs_app_process.cpp
@@ -153,6 +153,30 @@ srs_error_t srs_redirect_output(string from_file, int to_fd)
     return err;
 }
 
+srs_error_t SrsProcess::redirect_io()
+{
+    srs_error_t err = srs_success;
+
+    // for the stdout, ignore when not specified.
+    // redirect stdout to file if possible.
+    if ((err = srs_redirect_output(stdout_file, STDOUT_FILENO)) != srs_success) {
+        return srs_error_wrap(err, "redirect stdout");
+    }
+
+    // for the stderr, ignore when not specified.
+    // redirect stderr to file if possible.
+    if ((err = srs_redirect_output(stderr_file, STDERR_FILENO)) != srs_success) {
+        return srs_error_wrap(err, "redirect stderr");
+    }
+
+    // No stdin for process, @bug https://github.com/ossrs/srs/issues/1592
+    if ((err = srs_redirect_output("/dev/null", STDIN_FILENO)) != srs_success) {
+        return srs_error_wrap(err, "redirect /dev/null");
+    }
+
+    return err;
+}
+
 srs_error_t SrsProcess::start()
 {
     srs_error_t err = srs_success;
@@ -183,23 +207,6 @@ srs_error_t SrsProcess::start()
         signal(SIGINT, SIG_IGN);
         signal(SIGTERM, SIG_IGN);
 
-        // for the stdout, ignore when not specified.
-        // redirect stdout to file if possible.
-        if ((err = srs_redirect_output(stdout_file, STDOUT_FILENO)) != srs_success) {
-            err = srs_error_wrap(err, "redirect output");
-        }
-        
-        // for the stderr, ignore when not specified.
-        // redirect stderr to file if possible.
-        if ((err = srs_redirect_output(stderr_file, STDERR_FILENO)) != srs_success) {
-            err = srs_error_wrap(err, "redirect output");
-        }
-
-        // No stdin for process, @bug https://github.com/ossrs/srs/issues/1592
-        if ((err = srs_redirect_output("/dev/null", STDIN_FILENO)) != srs_success) {
-            err = srs_error_wrap(err, "redirect input");
-        }
-
         // should never close the fd 3+, for it myabe used.
         // for fd should close at exec, use fnctl to set it.
         
@@ -213,7 +220,7 @@ srs_error_t SrsProcess::start()
         }
         
         // output error to stdout and exit child process.
-        if (err != srs_success) {
+        if ((err = redirect_io()) != srs_success) {
             fprintf(stdout, "child process error, %s\n", srs_error_desc(err).c_str());
             exit(-1);
         }

--- a/trunk/src/app/srs_app_process.hpp
+++ b/trunk/src/app/srs_app_process.hpp
@@ -53,6 +53,9 @@ public:
     // @param argv the argv for binary path, the argv[0] generally is the binary.
     // @remark the argv[0] must be the binary.
     virtual srs_error_t initialize(std::string binary, std::vector<std::string> argv);
+private:
+    // Redirect standard I/O.
+    virtual srs_error_t redirect_io();
 public:
     // Start the process, ignore when already started.
     virtual srs_error_t start();


### PR DESCRIPTION
Fix #1695 
srs进程fork后，因为输出重定向写错误而返回，导致fork的子进程未能退出，从而导致系统资源耗尽。