### PR TITLE
fix srs_string_replace deap loop when new_str inclue old_str

### DIFF
--- a/trunk/src/kernel/srs_kernel_utility.cpp
+++ b/trunk/src/kernel/srs_kernel_utility.cpp
@@ -308,6 +308,7 @@ string srs_string_replace(string str, string old_str, string new_str)
     size_t pos = 0;
     while ((pos = ret.find(old_str, pos)) != std::string::npos) {
         ret = ret.replace(pos, old_str.length(), new_str);
+        pos += new_str.length();
     }
     
     return ret;

--- a/trunk/src/utest/srs_utest_kernel.cpp
+++ b/trunk/src/utest/srs_utest_kernel.cpp
@@ -2079,6 +2079,15 @@ VOID TEST(KernelUtilityTest, UtilityString)
     str1 = srs_string_replace(str, "o", "XX");
     EXPECT_STREQ("HellXX, WXXrld! HellXX, SRS!", str1.c_str());
 
+    // origin_str == old_str
+    std::string origin_str = "xxd";
+    str1 = srs_string_replace(origin_str, "xxd", "x1d");
+    EXPECT_STREQ("x1d", str1.c_str());
+
+    // new_str include old_str.
+    str1 = srs_string_replace(str, "Hello", "HelloN");
+    EXPECT_STREQ("HelloN, World! HelloN, SRS!", str1.c_str());
+
     str1 = srs_string_trim_start(str, "x");
     EXPECT_STREQ("Hello, World! Hello, SRS!", str1.c_str());
 


### PR DESCRIPTION
fix srs_string_replace deap loop when new_str inclue old_str

bug: https://github.com/ossrs/srs/issues/2084