### PR TITLE
pass parameter ‘cid’ from outside in on_play/stop/unpublish, to resolve ‘client_id’ error when asynchronous call

### DIFF
--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -151,12 +151,10 @@ srs_error_t SrsHttpHooks::on_publish(string url, SrsRequest* req)
     return err;
 }
 
-void SrsHttpHooks::on_unpublish(string url, SrsRequest* req)
+void SrsHttpHooks::on_unpublish(SrsContextId cid, string url, SrsRequest* req)
 {
     srs_error_t err = srs_success;
-    
-    SrsContextId cid = _srs_context->get_id();
-    
+
     SrsStatistic* stat = SrsStatistic::instance();
 
     SrsJsonObject* obj = SrsJsonAny::object();

--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -188,11 +188,9 @@ void SrsHttpHooks::on_unpublish(SrsContextId cid, string url, SrsRequest* req)
     return;
 }
 
-srs_error_t SrsHttpHooks::on_play(string url, SrsRequest* req)
+srs_error_t SrsHttpHooks::on_play(SrsContextId cid, string url, SrsRequest* req)
 {
     srs_error_t err = srs_success;
-    
-    SrsContextId cid = _srs_context->get_id();
     
     SrsStatistic* stat = SrsStatistic::instance();
 

--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -227,12 +227,10 @@ srs_error_t SrsHttpHooks::on_play(string url, SrsRequest* req)
     return err;
 }
 
-void SrsHttpHooks::on_stop(string url, SrsRequest* req)
+void SrsHttpHooks::on_stop(SrsContextId cid, string url, SrsRequest* req)
 {
     srs_error_t err = srs_success;
-    
-    SrsContextId cid = _srs_context->get_id();
-    
+
     SrsStatistic* stat = SrsStatistic::instance();
 
     SrsJsonObject* obj = SrsJsonAny::object();

--- a/trunk/src/app/srs_app_http_hooks.hpp
+++ b/trunk/src/app/srs_app_http_hooks.hpp
@@ -43,7 +43,7 @@ public:
     // The on_unpublish hook, when client(encoder) stop publish stream.
     // @param url the api server url, to process the event.
     //         ignore if empty.
-    static void on_unpublish(std::string url, SrsRequest* req);
+    static void on_unpublish(SrsContextId cid, std::string url, SrsRequest* req);
     // The on_play hook, when client start to play stream.
     // @param url the api server url, to valid the client.
     //         ignore if empty.

--- a/trunk/src/app/srs_app_http_hooks.hpp
+++ b/trunk/src/app/srs_app_http_hooks.hpp
@@ -51,7 +51,7 @@ public:
     // The on_stop hook, when client stop to play the stream.
     // @param url the api server url, to process the event.
     //         ignore if empty.
-    static void on_stop(std::string url, SrsRequest* req);
+    static void on_stop(SrsContextId cid, std::string url, SrsRequest* req);
     // The on_dvr hook, when reap a dvr file.
     // @param url the api server url, to process the event.
     //         ignore if empty.

--- a/trunk/src/app/srs_app_http_hooks.hpp
+++ b/trunk/src/app/srs_app_http_hooks.hpp
@@ -47,7 +47,7 @@ public:
     // The on_play hook, when client start to play stream.
     // @param url the api server url, to valid the client.
     //         ignore if empty.
-    static srs_error_t on_play(std::string url, SrsRequest* req);
+    static srs_error_t on_play(SrsContextId cid, std::string url, SrsRequest* req);
     // The on_stop hook, when client stop to play the stream.
     // @param url the api server url, to process the event.
     //         ignore if empty.

--- a/trunk/src/app/srs_app_http_static.hpp
+++ b/trunk/src/app/srs_app_http_static.hpp
@@ -36,8 +36,8 @@ protected:
 private:
     virtual bool ctx_is_exist(std::string ctx);
     virtual void alive(std::string ctx, SrsRequest* req);
-    virtual srs_error_t http_hooks_on_play(SrsRequest* req);
-    virtual void http_hooks_on_stop(SrsRequest* req);
+    virtual srs_error_t http_hooks_on_play(SrsContextId cid, SrsRequest* req);
+    virtual void http_hooks_on_stop(SrsContextId cid, SrsRequest* req);
 // interface ISrsFastTimer
 private:
     srs_error_t on_timer(srs_utime_t interval);

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -727,7 +727,7 @@ srs_error_t SrsLiveStream::http_hooks_on_play(ISrsHttpMessage* r)
     
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_play(url, nreq)) != srs_success) {
+        if ((err = SrsHttpHooks::on_play(_srs_context->get_id(), url, nreq)) != srs_success) {
             return srs_error_wrap(err, "http on_play %s", url.c_str());
         }
     }

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -764,7 +764,7 @@ void SrsLiveStream::http_hooks_on_stop(ISrsHttpMessage* r)
     
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_stop(url, nreq);
+        SrsHttpHooks::on_stop(_srs_context->get_id(), url, nreq);
     }
     
     return;

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -272,7 +272,7 @@ srs_error_t SrsGoApiRtcPlay::http_hooks_on_play(SrsRequest* req)
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_play(url, req)) != srs_success) {
+        if ((err = SrsHttpHooks::on_play(_srs_context->get_id(), url, req)) != srs_success) {
             return srs_error_wrap(err, "on_play %s", url.c_str());
         }
     }

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -388,7 +388,7 @@ srs_error_t SrsRtcAsyncCallOnStop::call()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_stop(url, req);
+        SrsHttpHooks::on_stop(cid, url, req);
     }
 
     return err;

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -1033,7 +1033,7 @@ srs_error_t SrsRtcAsyncCallOnUnpublish::call()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_unpublish(url, req);
+        SrsHttpHooks::on_unpublish(cid, url, req);
     }
 
     return err;

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -1431,7 +1431,7 @@ void SrsRtmpConn::http_hooks_on_stop()
     
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_stop(url, req);
+        SrsHttpHooks::on_stop(_srs_context->get_id(), url, req);
     }
     
     return;

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -1398,7 +1398,7 @@ srs_error_t SrsRtmpConn::http_hooks_on_play()
     
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_play(url, req)) != srs_success) {
+        if ((err = SrsHttpHooks::on_play(_srs_context->get_id(), url, req)) != srs_success) {
             return srs_error_wrap(err, "rtmp on_play %s", url.c_str());
         }
     }

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -1367,7 +1367,7 @@ void SrsRtmpConn::http_hooks_on_unpublish()
     
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_unpublish(url, req);
+        SrsHttpHooks::on_unpublish(_srs_context->get_id(), url, req);
     }
 }
 


### PR DESCRIPTION
SrsHttpHooks类 会将当前协程的cid赋值给`client_id`，然后回调。
同步使用时没有问题，但是rtc的on_stop/unpublish，以及hls的on_play/stop都是异步调用，会导致每次回调的`client_id`都相同。
也就是这个 https://github.com/ossrs/srs/issues/2626  提到的。
这个pr解决了上述问题。