### PR TITLE
GB28181: Check is es_info_length overflow es_map_length

### DIFF
--- a/trunk/src/app/srs_app_gb28181.cpp
+++ b/trunk/src/app/srs_app_gb28181.cpp
@@ -552,7 +552,10 @@ srs_error_t SrsPsStreamDemixer::on_ps_stream(char* ps_data, int ps_size, uint32_
                 }
            
                 /* skip program_stream_info */
-                buf.skip(es_info_length);
+                if (es_info_length + 4 < es_map_length){ 
+                    //check is es_info_length overflow es_map_length
+                    buf.skip(es_info_length);
+                }
                 es_map_length -= 4 + es_info_length;
             }
     


### PR DESCRIPTION
 解析ps流中 program stream map 时 es_info_length overflow es_map_length, 导致core的问题