### PR TITLE
Put the statistics code after http callback

### DIFF
--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -513,13 +513,7 @@ srs_error_t SrsRtmpConn::stream_service_cycle()
         return srs_error_wrap(err, "rtmp: fetch source");
     }
     srs_assert(source != NULL);
-    
-    // update the statistic when source disconveried.
-    SrsStatistic* stat = SrsStatistic::instance();
-    if ((err = stat->on_client(_srs_context->get_id().c_str(), req, this, info->type)) != srs_success) {
-        return srs_error_wrap(err, "rtmp: stat client");
-    }
-    
+
     bool enabled_cache = _srs_config->get_gop_cache(req->vhost);
     srs_trace("source url=%s, ip=%s, cache=%d, is_edge=%d, source_id=%s/%s",
         req->get_stream_url().c_str(), ip.c_str(), enabled_cache, info->edge, source->source_id().c_str(), source->pre_source_id().c_str());
@@ -697,6 +691,12 @@ srs_error_t SrsRtmpConn::do_playing(SrsLiveSource* source, SrsLiveConsumer* cons
     SrsRequest* req = info->req;
     srs_assert(req);
     srs_assert(consumer);
+
+    // update the statistic when source disconveried.
+    SrsStatistic* stat = SrsStatistic::instance();
+    if ((err = stat->on_client(_srs_context->get_id().c_str(), req, this, info->type)) != srs_success) {
+        return srs_error_wrap(err, "rtmp: stat client");
+    }
     
     // initialize other components
     SrsPithyPrint* pprint = SrsPithyPrint::create_rtmp_play();
@@ -861,7 +861,13 @@ srs_error_t SrsRtmpConn::do_publishing(SrsLiveSource* source, SrsPublishRecvThre
     SrsRequest* req = info->req;
     SrsPithyPrint* pprint = SrsPithyPrint::create_rtmp_publish();
     SrsAutoFree(SrsPithyPrint, pprint);
-    
+
+    // update the statistic when source disconveried.
+    SrsStatistic* stat = SrsStatistic::instance();
+    if ((err = stat->on_client(_srs_context->get_id().c_str(), req, this, info->type)) != srs_success) {
+        return srs_error_wrap(err, "rtmp: stat client");
+    }
+
     // start isolate recv thread.
     // TODO: FIXME: Pass the callback here.
     if ((err = rtrd->start()) != srs_success) {


### PR DESCRIPTION
https://github.com/ossrs/srs/issues/1444

**Phenomenon**
RTMP process: Due to the statistics on_client being placed before the authentication module, when authentication fails, the cleanup statistics process will not be triggered, resulting in residual information.

---------

`TRANS_BY_GPT3`