### PR TITLE
Refuse edge request when state is stopping

### DIFF
--- a/trunk/src/app/srs_app_edge.cpp
+++ b/trunk/src/app/srs_app_edge.cpp
@@ -916,6 +916,8 @@ srs_error_t SrsPlayEdge::on_client_play()
     if (state == SrsEdgeStateInit) {
         state = SrsEdgeStatePlay;
         err = ingester->start();
+    } else if (state == SrsEdgeStateIngestStopping) {
+        return srs_error_new(ERROR_RTMP_EDGE_PLAY_STATE, "state is stopping");
     }
     
     return err;


### PR DESCRIPTION
**问题：** Edge: 最后一个拉流断开后，在3秒内再次请求相同的流，无法正常顺畅播放 https://github.com/ossrs/srs/issues/2215
**分析：** 3秒内再次请求时，state处于stopping状态
**解决：** 当处于stopping时，返回错误，给用户一个明确的提示

**TODO：** @IAmCodingCoding 给出了一个优化的方案，可以快速退出，不必等待3秒。见https://github.com/ossrs/srs/issues/2215#issuecomment-901682601 。

