### PR TITLE
fix #2704, no sound when play webrtc if the audio codec is G.711a or G711mu

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -866,7 +866,9 @@ srs_error_t SrsRtcFromRtmpBridger::on_audio(SrsSharedPtrMessage* msg)
     }
 
     // When drop aac audio packet, never transcode.
-    if (acodec != SrsAudioCodecIdAAC) {
+    if (acodec != SrsAudioCodecIdAAC && 
+        acodec != SrsAudioCodecIdReservedG711AlawLogarithmicPCM && 
+        acodec != SrsAudioCodecIdReservedG711MuLawLogarithmicPCM) {
         return err;
     }
 


### PR DESCRIPTION
fix #2704, no sound when play webrtc if the audio codec is G.711a or G711mu