### PR TITLE
Rtc2Rtmp: using rtp timestamp to distinguish different video frame

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -300,6 +300,7 @@ private:
         bool in_use;
         uint16_t sn;
         uint32_t ts;
+        uint32_t rtp_ts;
         SrsRtpPacket* pkt;
     };
     const static uint16_t s_cache_size = 512;
@@ -325,7 +326,7 @@ private:
     int32_t find_next_lost_sn(uint16_t current_sn, uint16_t& end_sn);
     void clear_cached_video();
     inline uint16_t cache_index(uint16_t current_sn) {
-        return current_sn%s_cache_size;
+        return current_sn % s_cache_size;
     }
     bool check_frame_complete(const uint16_t start, const uint16_t end);
 };


### PR DESCRIPTION
用SR同步时间戳的时候, 因为计算偏差会导致同一个视频帧的时间戳有1/-1的差距
RTC转RTMP时, 某些情况下会把同一帧划分成两个帧, 导致视频卡顿.