### PR TITLE
fix(rtc): fix crash when pkt->payload() if pkt is nullptr

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -1567,6 +1567,10 @@ srs_error_t SrsRtmpFromRtcBridger::packet_video_rtmp(const uint16_t start, const
         uint16_t sn = start + i;
         uint16_t index = cache_index(sn);
         SrsRtpPacket* pkt = cache_video_pkts_[index].pkt;
+
+        // fix crash when pkt->payload() if pkt is nullptr;
+        if (!pkt) continue;
+
         // calculate nalu len
         SrsRtpFUAPayload2* fua_payload = dynamic_cast<SrsRtpFUAPayload2*>(pkt->payload());
         if (fua_payload && fua_payload->size > 0) {
@@ -1624,6 +1628,10 @@ srs_error_t SrsRtmpFromRtcBridger::packet_video_rtmp(const uint16_t start, const
     for (uint16_t i = 0; i < cnt; ++i) {
         uint16_t index = cache_index((start + i));
         SrsRtpPacket* pkt = cache_video_pkts_[index].pkt;
+
+        // fix crash when pkt->payload() if pkt is nullptr;
+        if (!pkt) continue;
+
         cache_video_pkts_[index].in_use = false;
         cache_video_pkts_[index].pkt = NULL;
         cache_video_pkts_[index].ts = 0;


### PR DESCRIPTION
详见gdb日志
```
Program received signal SIGSEGV, Segmentation fault.
0x0000000000617774 in SrsRtpPacket::payload (this=0x0) at src/kernel/srs_kernel_rtc_rtp.hpp:317
317	    ISrsRtpPayloader* payload() { return payload_; }
Missing separate debuginfos, use: debuginfo-install glibc-2.17-325.el7_9.x86_64 libgcc-4.8.5-44.el7.x86_64 libstdc++-4.8.5-44.el7.x86_64
(gdb) bt
#0  0x0000000000617774 in SrsRtpPacket::payload (this=0x0) at src/kernel/srs_kernel_rtc_rtp.hpp:317
#1  0x0000000000611a2e in SrsRtmpFromRtcBridger::packet_video_rtmp (this=0x18b1310, start=0, end=17707) at src/app/srs_app_rtc_source.cpp:1632
#2  0x0000000000610b61 in SrsRtmpFromRtcBridger::packet_video (this=0x18b1310, src=0x207ef20) at src/app/srs_app_rtc_source.cpp:1452
#3  0x0000000000610446 in SrsRtmpFromRtcBridger::on_rtp (this=0x18b1310, pkt=0x207ef20) at src/app/srs_app_rtc_source.cpp:1350
#4  0x000000000060d9ac in SrsRtcSource::on_rtp (this=0x1869330, pkt=0x207ef20) at src/app/srs_app_rtc_source.cpp:634
#5  0x0000000000616334 in SrsRtcVideoRecvTrack::on_rtp (this=0x133b090, source=0x1869330, pkt=0x207ef20) at src/app/srs_app_rtc_source.cpp:2653
#6  0x00000000005ccc0d in SrsRtcPublishStream::do_on_rtp_plaintext (this=0x174c5e0, pkt=@0x7ffff66e8758: 0x207ef20, buf=0x7ffff66e8740)
    at src/app/srs_app_rtc_conn.cpp:1471
#7  0x00000000005cc9c8 in SrsRtcPublishStream::on_rtp_plaintext (this=0x174c5e0,
    plaintext=0xeac9b0 "\220fE,\030\066\357\264\232\070\334\231\276\336", nb_plaintext=1128) at src/app/srs_app_rtc_conn.cpp:1438
#8  0x00000000005cc6fa in SrsRtcPublishStream::on_rtp (this=0x174c5e0, data=0xeac9b0 "\220fE,\030\066\357\264\232\070\334\231\276\336",
    nb_data=1138) at src/app/srs_app_rtc_conn.cpp:1405
#9  0x00000000005d0f1a in SrsRtcConnection::on_rtp (this=0xf70ce0, data=0xeac9b0 "\220fE,\030\066\357\264\232\070\334\231\276\336", nb_data=1138)
    at src/app/srs_app_rtc_conn.cpp:2333
...

(gdb) p this
$1 = (SrsRtpPacket * const) 0x0
(gdb) frame 1
#1  0x0000000000611a2e in SrsRtmpFromRtcBridger::packet_video_rtmp (this=0x18b1310, start=0, end=17707) at src/app/srs_app_rtc_source.cpp:1632
1632	        SrsRtpFUAPayload2* fua_payload = dynamic_cast<SrsRtpFUAPayload2*>(pkt->payload());
(gdb) p pkt
$2 = (SrsRtpPacket *) 0x0
(gdb) frame 2
#2  0x0000000000610b61 in SrsRtmpFromRtcBridger::packet_video (this=0x18b1310, src=0x207ef20) at src/app/srs_app_rtc_source.cpp:1452
1452	                if ((err = packet_video_rtmp(header_sn_, tail_sn)) != srs_success) {
(gdb)
```