### PR TITLE
Fix bugs for RTC2RTMP.

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -307,7 +307,7 @@ private:
     RtcPacketCache cache_video_pkts_[s_cache_size];
     uint16_t header_sn_;
     uint16_t lost_sn_;
-    int64_t key_frame_ts_;
+    int64_t rtp_key_frame_ts_;
 public:
     SrsRtmpFromRtcBridger(SrsLiveSource *src);
     virtual ~SrsRtmpFromRtcBridger();
@@ -527,6 +527,7 @@ protected:
     SrsNtp last_sender_report_ntp1_;
     int64_t last_sender_report_rtp_time1_;
 
+    double rate_;
     uint64_t last_sender_report_sys_time_;
 public:
     SrsRtcRecvTrack(SrsRtcConnection* session, SrsRtcTrackDescription* stream_descs, bool is_audio);


### PR DESCRIPTION
1. Cache IDR frame's rtp timestamp instead of avsync timestamp.
2. Cache clock rate calculate by sender report.
3. Using srs_rtp_seq_distance instead of direct minus.
4. Add utest of av timestamp sync when duplicated sender report.