### PR TITLE
Fix bug for HTTP, 2GB录制的大文件下载失败 #2780

### DIFF
--- a/trunk/src/app/srs_app_http_static.cpp
+++ b/trunk/src/app/srs_app_http_static.cpp
@@ -137,7 +137,7 @@ srs_error_t SrsVodStream::serve_flv_stream(ISrsHttpResponseWriter* w, ISrsHttpMe
     return err;
 }
 
-srs_error_t SrsVodStream::serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, string fullpath, int start, int end)
+srs_error_t SrsVodStream::serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, string fullpath, int start, long end)
 {
     srs_error_t err = srs_success;
     
@@ -154,7 +154,7 @@ srs_error_t SrsVodStream::serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMe
     
     // parse -1 to whole file.
     if (end == -1) {
-        end = (int)(fs->filesize() - 1);
+        end = fs->filesize() - 1;
     }
     
     if (end > fs->filesize() || start > end || end < 0) {
@@ -180,8 +180,8 @@ srs_error_t SrsVodStream::serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMe
     fs->seek2(start);
     
     // send data
-    if ((err = copy(w, fs, r, (int)left)) != srs_success) {
-        return srs_error_wrap(err, "read mp4=%s size=%d", fullpath.c_str(), (int)left);
+    if ((err = copy(w, fs, r, left)) != srs_success) {
+        return srs_error_wrap(err, "read mp4=%s size=%" PRId64 , fullpath.c_str(), left);
     }
     
     return err;

--- a/trunk/src/app/srs_app_http_static.hpp
+++ b/trunk/src/app/srs_app_http_static.hpp
@@ -31,7 +31,7 @@ public:
     virtual ~SrsVodStream();
 protected:
     virtual srs_error_t serve_flv_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int offset);
-    virtual srs_error_t serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int start, int end);
+    virtual srs_error_t serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int start, long end);
     virtual srs_error_t serve_m3u8_ctx(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath);
 private:
     virtual bool ctx_is_exist(std::string ctx);

--- a/trunk/src/protocol/srs_http_stack.cpp
+++ b/trunk/src/protocol/srs_http_stack.cpp
@@ -513,7 +513,7 @@ srs_error_t SrsHttpFileServer::serve_mp4_file(ISrsHttpResponseWriter* w, ISrsHtt
     }
     
     // parse end in query string.
-    int end = -1;
+    long end = -1;
     if (pos < range.length() - 1) {
         end = ::atoi(range.substr(pos + 1).c_str());
     }
@@ -538,7 +538,7 @@ srs_error_t SrsHttpFileServer::serve_flv_stream(ISrsHttpResponseWriter* w, ISrsH
     return serve_file(w, r, fullpath);
 }
 
-srs_error_t SrsHttpFileServer::serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, string fullpath, int start, int end)
+srs_error_t SrsHttpFileServer::serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, string fullpath, int start, long end)
 {
     // @remark For common http file server, we don't support stream request, please use SrsVodStream instead.
     // TODO: FIXME: Support range in header https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Range_requests

--- a/trunk/src/protocol/srs_http_stack.hpp
+++ b/trunk/src/protocol/srs_http_stack.hpp
@@ -293,7 +293,7 @@ protected:
     // @param start the start offset in bytes.
     // @param end the end offset in bytes. -1 to end of file.
     // @remark response data in [start, end].
-    virtual srs_error_t serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int start, int end);
+    virtual srs_error_t serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int start, long end);
     // For HLS protocol.
     // When the request url, like as "http://127.0.0.1:8080/live/livestream.m3u8", 
     // returns the response like as "http://127.0.0.1:8080/live/livestream.m3u8?hls_ctx=12345678" .


### PR DESCRIPTION
我是做Java的，对C++一窍不通，根据我的个人理解对#2780做了修复，如果有修改不当的地方敬请谅解，关闭这个pr就好，目前根据我的判断大部分的修改应该问题不大，但是有一行代码的修改感觉有一定的风险
```
if ((err = copy(w, fs, r, (int)left)) != srs_success)   >> if ((err = copy(w, fs, r, left)) != srs_success)
```
一行这个修改有两个疑虑
1.不确定stl的copy是否支持long的传参
2.在文件过大时是否对内存产生不良影响