### PR TITLE
fix #2797  rtmp推流 rtc播放时 http hooks on_connect on_play 收到的app stream 不一致

### DIFF
--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -321,13 +321,34 @@ string srs_generate_stream_url(string vhost, string app, string stream)
 
 void srs_parse_rtmp_url(string url, string& tcUrl, string& stream)
 {
+    // url example: 
+    // [schema]://[vhost]/[app]/[stream]
+    // 1. webrtc://localhost/live/stream1
+    // 2. webrtc://localhost/live/user1/stream1
+
     size_t pos;
+    string path=url;
+
+    // default value for tcUrl
+    tcUrl = url; 
+
+    // remove schema
+    if ((pos = path.find("://")) != std::string::npos) {
+        path = path.substr(path.substr(0, pos).length() + 3);
+    }
     
-    if ((pos = url.rfind("/")) != string::npos) {
-        stream = url.substr(pos + 1);
-        tcUrl = url.substr(0, pos);
-    } else {
-        tcUrl = url;
+    // remove vhost
+    if ((pos = path.find("/")) != std::string::npos) {
+        path = path.substr(path.substr(0, pos).length() + 1);
+    }
+
+    // split app and stream by the first slash
+    if ((pos = path.find("/")) != string::npos) {
+        stream = path.substr(pos + 1);
+        if ((pos = url.find(stream)) != string::npos){
+            tcUrl = url.substr(0, pos);
+            tcUrl = srs_string_trim_end(tcUrl, "/");
+        }
     }
 }
 

--- a/trunk/src/utest/srs_utest_rtmp.cpp
+++ b/trunk/src/utest/srs_utest_rtmp.cpp
@@ -3219,15 +3219,15 @@ VOID TEST(ProtocolRTMPTest, ParseRTMPURL)
     if (true) {
         string url("rtmp://ossrs.net/live/show/livestream?token=abc"), tcUrl, stream;
         srs_parse_rtmp_url(url, tcUrl, stream);
-        EXPECT_STREQ("rtmp://ossrs.net/live/show", tcUrl.c_str());
-        EXPECT_STREQ("livestream?token=abc", stream.c_str());
+        EXPECT_STREQ("rtmp://ossrs.net/live", tcUrl.c_str());
+        EXPECT_STREQ("show/livestream?token=abc", stream.c_str());
     }
 
     if (true) {
         string url("rtmp://ossrs.net/live/show/livestream"), tcUrl, stream;
         srs_parse_rtmp_url(url, tcUrl, stream);
-        EXPECT_STREQ("rtmp://ossrs.net/live/show", tcUrl.c_str());
-        EXPECT_STREQ("livestream", stream.c_str());
+        EXPECT_STREQ("rtmp://ossrs.net/live", tcUrl.c_str());
+        EXPECT_STREQ("show/livestream", stream.c_str());
     }
 
     if (true) {


### PR DESCRIPTION
我不是个c++的码农，根据自己理解尝试改了一下，不知道改的对不对，麻烦老师傅们看一下，不对的话，close掉就好。

跟了一下代码，发现webrtc play的时候 以webrtc://localhost/live/123/uuid 从右边开始找第一个斜线，将第一个斜线右边做stream,前面部分做为tcUrl，导致最后匹配出来，app=live/123 stream=uuid.

rtmp推流端，实测是app=live stream=123/uuid, 看起来是从左边开始匹配。这部分代码没能找到位置。

