### PR TITLE
Forward: support config full rtmp url forward to other server

### DIFF
--- a/trunk/conf/forward.backend.conf
+++ b/trunk/conf/forward.backend.conf
@@ -1,5 +1,5 @@
-# the config for srs to forward
-# @see https://github.com/ossrs/srs/wiki/v1_CN_SampleForward
+# the config for srs to forward to slave service
+# @see https://github.com/ossrs/srs/wiki/v5_CN_SampleForward
 # @see full.conf for detail config.
 
 listen              1935;
@@ -10,6 +10,6 @@ srs_log_tank        console;
 vhost __defaultVhost__ {
     forward {
         enabled on;
-        destination 127.0.0.1:19350;
+        backend http://127.0.0.1:8085/api/v1/forward;
     }
 }

--- a/trunk/conf/forward.backend.conf
+++ b/trunk/conf/forward.backend.conf
@@ -4,7 +4,7 @@
 
 listen              1935;
 max_connections     1000;
-pid                 ./objs/srs.master.pid;
+pid                 ./objs/srs.backend.pid;
 daemon              off;
 srs_log_tank        console;
 vhost __defaultVhost__ {

--- a/trunk/conf/forward.master.conf
+++ b/trunk/conf/forward.master.conf
@@ -10,7 +10,7 @@ srs_log_tank        console;
 vhost __defaultVhost__ {
     forward {
         enabled on;
-        #destination 127.0.0.1:19350;
+        destination 127.0.0.1:19350;
         backend http://127.0.0.1:8085/api/v1/forward;
     }
 }

--- a/trunk/conf/forward.master.conf
+++ b/trunk/conf/forward.master.conf
@@ -10,6 +10,7 @@ srs_log_tank        console;
 vhost __defaultVhost__ {
     forward {
         enabled on;
-        destination 127.0.0.1:19350;
+        #destination 127.0.0.1:19350;
+        backend http://127.0.0.1:8085/api/v1/forward;
     }
 }

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -669,6 +669,34 @@ vhost same.vhost.forward.srs.com {
         # active-active for cdn to build high available fault tolerance system.
         # format: {ip}:{port} {ip_N}:{port_N}
         destination 127.0.0.1:1936 127.0.0.1:1937;
+
+        # when client(encoder) publish to vhost/app/stream, then create forwarder, call the hook,
+        # the request in the POST data string is a object encode by json:
+        #       {
+        #           "action": "on_forward",
+        #           "server_id": "vid-k21d7y2",
+        #           "client_id": "9o7g1330",
+        #           "ip": "127.0.0.1",
+        #           "vhost": "video.test.com",
+        #           "app": "live",
+        #           "tcUrl": "rtmp://127.0.0.1:1935/live",
+        #           "stream": "livestream",
+        #           "param": "?forward=rtmp://ossrs.net/live/livestream"
+        #       }
+        # if valid, the hook must return HTTP code 200(Status OK) and response
+        # an int value specifies the error code(0 corresponding to success):
+        #       {
+        #          "code": 0,
+        #          "data": {
+        #              "urls":[
+        #                 "rtmp://ossrs.net:1935/live/livestream?auth_token=xxx",
+        #                 "rtmp://cdn.com:1935/live/livestream?auth_token=xxx"
+        #              ]
+        #          }
+        #       }
+        # only support one api hook, format:
+        #       backend http://xxx/api0
+        backend http://127.0.0.1:8085/api/v1/forward;
     }
 }
 

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -670,18 +670,18 @@ vhost same.vhost.forward.srs.com {
         # format: {ip}:{port} {ip_N}:{port_N}
         destination 127.0.0.1:1936 127.0.0.1:1937;
 
-        # when client(encoder) publish to vhost/app/stream, then create forwarder, call the hook,
+        # when client(encoder) publish to vhost/app/stream, call the hook in creating backend forwarder.
         # the request in the POST data string is a object encode by json:
         #       {
         #           "action": "on_forward",
         #           "server_id": "vid-k21d7y2",
         #           "client_id": "9o7g1330",
         #           "ip": "127.0.0.1",
-        #           "vhost": "video.test.com",
+        #           "vhost": "__defaultVhost__",
         #           "app": "live",
         #           "tcUrl": "rtmp://127.0.0.1:1935/live",
         #           "stream": "livestream",
-        #           "param": "?forward=rtmp://ossrs.net/live/livestream"
+        #           "param": ""
         #       }
         # if valid, the hook must return HTTP code 200(Status OK) and response
         # an int value specifies the error code(0 corresponding to success):
@@ -689,11 +689,13 @@ vhost same.vhost.forward.srs.com {
         #          "code": 0,
         #          "data": {
         #              "urls":[
-        #                 "rtmp://ossrs.net:1935/live/livestream?auth_token=xxx",
-        #                 "rtmp://cdn.com:1935/live/livestream?auth_token=xxx"
+        #                 "rtmp://127.0.0.1:19350/test/teststream"
         #              ]
         #          }
         #       }
+        # PS: you can transform params to backend service, such as:
+        #       { "param": "?forward=rtmp://127.0.0.1:19351/test/livestream" }
+        #     then backend return forward's url in response.
         # only support one api hook, format:
         #       backend http://xxx/api0
         backend http://127.0.0.1:8085/api/v1/forward;

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -696,6 +696,7 @@ vhost same.vhost.forward.srs.com {
         # PS: you can transform params to backend service, such as:
         #       { "param": "?forward=rtmp://127.0.0.1:19351/test/livestream" }
         #     then backend return forward's url in response.
+        # if backend return empty urls, destanition is still disabled.
         # only support one api hook, format:
         #       backend http://xxx/api0
         backend http://127.0.0.1:8085/api/v1/forward;

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2795,7 +2795,7 @@ srs_error_t SrsConfig::check_normal_config()
             } else if (n == "forward") {
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
-                    if (m != "enabled" && m != "destination") {
+                    if (m != "enabled" && m != "destination" && m != "backend") {
                         return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal vhost.forward.%s of %s", m.c_str(), vhost->arg0().c_str());
                     }
                 }
@@ -4603,6 +4603,21 @@ SrsConfDirective* SrsConfig::get_forwards(string vhost)
     }
     
     return conf->get("destination");
+}
+
+SrsConfDirective* SrsConfig::get_forward_backend(string vhost)
+{
+    SrsConfDirective* conf = get_vhost(vhost);
+    if (!conf) {
+        return NULL;
+    }
+    
+    conf = conf->get("forward");
+    if (!conf) {
+        return NULL;
+    }
+    
+    return conf->get("backend");
 }
 
 SrsConfDirective* SrsConfig::get_vhost_http_hooks(string vhost)

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -607,6 +607,8 @@ public:
     virtual bool get_forward_enabled(SrsConfDirective* vhost);
     // Get the forward directive of vhost.
     virtual SrsConfDirective* get_forwards(std::string vhost);
+    // Get the forward directive of backend.
+    virtual SrsConfDirective* get_forward_backend(std::string vhost);
 
 public:
     // Whether the srt sevice enabled

--- a/trunk/src/app/srs_app_forward.cpp
+++ b/trunk/src/app/srs_app_forward.cpp
@@ -52,6 +52,8 @@ SrsForwarder::~SrsForwarder()
     
     srs_freep(sh_video);
     srs_freep(sh_audio);
+    
+    srs_freep(req);
 }
 
 srs_error_t SrsForwarder::initialize(SrsRequest* r, string ep)
@@ -60,7 +62,7 @@ srs_error_t SrsForwarder::initialize(SrsRequest* r, string ep)
     
     // it's ok to use the request object,
     // SrsLiveSource already copy it and never delete it.
-    req = r;
+    req = r->copy();
     
     // the ep(endpoint) to forward to
     ep_forward = ep;

--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -482,6 +482,100 @@ srs_error_t SrsHttpHooks::discover_co_workers(string url, string& host, int& por
     return err;
 }
 
+// Request:
+//      POST /api/v1/forward
+//      {
+//          "action": "on_forward",
+//          "server_id": "vid-k21d7y2",
+//          "client_id": "9o7g1330",
+//          "ip": "127.0.0.1",
+//          "vhost": "__defaultVhost__",
+//          "app": "live",
+//          "tcUrl": "rtmp://127.0.0.1:1935/live",
+//          "stream": "livestream",
+//          "param": "?forward=rtmp://ossrs.net/live/livestream"
+//      }
+// Response:
+//      {
+//          "code": 0,
+//          "data": {
+//              "forwards":[{
+//                  "url": "rtmp://ossrs.net:1935/live/livestream?auth_token=xxx"
+//               },{
+//                  "url": "rtmp://aliyuncdn.com:1935/live/livestream?auth_token=xxx"
+//               }]
+//          }
+//      }
+srs_error_t SrsHttpHooks::on_forward_backend(string url, SrsRequest* req, std::vector<std::string>& rtmp_urls)
+{
+    srs_error_t err = srs_success;
+
+    SrsContextId cid = _srs_context->get_id();
+
+    SrsStatistic* stat = SrsStatistic::instance();
+
+    SrsJsonObject* obj = SrsJsonAny::object();
+    SrsAutoFree(SrsJsonObject, obj);
+
+    obj->set("action", SrsJsonAny::str("on_forward"));
+    obj->set("server_id", SrsJsonAny::str(stat->server_id().c_str()));
+    obj->set("client_id", SrsJsonAny::str(cid.c_str()));
+    obj->set("ip", SrsJsonAny::str(req->ip.c_str()));
+    obj->set("vhost", SrsJsonAny::str(req->vhost.c_str()));
+    obj->set("app", SrsJsonAny::str(req->app.c_str()));
+    obj->set("tcUrl", SrsJsonAny::str(req->tcUrl.c_str()));
+    obj->set("stream", SrsJsonAny::str(req->stream.c_str()));
+    obj->set("param", SrsJsonAny::str(req->param.c_str()));
+
+    std::string data = obj->dumps();
+    std::string res;
+    int status_code;
+
+    SrsHttpClient http;
+    if ((err = do_post(&http, url, data, status_code, res)) != srs_success) {
+        return srs_error_wrap(err, "http: on_forward_backend failed, client_id=%s, url=%s, request=%s, response=%s, code=%d",
+            cid.c_str(), url.c_str(), data.c_str(), res.c_str(), status_code);
+    }
+
+    // parse string res to json.
+    SrsJsonAny* info = SrsJsonAny::loads(res);
+    if (!info) {
+        return srs_error_new(ERROR_SYSTEM_FORWARD_LOOP, "load json from %s", res.c_str());
+    }
+    SrsAutoFree(SrsJsonAny, info);
+
+    // response error code in string.
+    if (!info->is_object()) {
+        return srs_error_new(ERROR_SYSTEM_FORWARD_LOOP, "response %s", res.c_str());
+    }
+
+    SrsJsonAny* prop = NULL;
+    // response standard object, format in json: {}
+    SrsJsonObject* res_info = info->to_object();
+    if ((prop = res_info->ensure_property_object("data")) == NULL) {
+        return srs_error_new(ERROR_SYSTEM_FORWARD_LOOP, "parse data %s", res.c_str());
+    }
+
+    SrsJsonObject* p = prop->to_object();
+    if ((prop = p->ensure_property_array("forwards")) == NULL) {
+        return srs_error_new(ERROR_SYSTEM_FORWARD_LOOP, "parse forwards %s", res.c_str());
+    }
+
+    SrsJsonArray* forwards = prop->to_array();
+    for (int i = 0; i < forwards->count(); i++) {
+        prop = forwards->at(i);
+        SrsJsonObject* forward = prop->to_object();
+        if ((prop = forward->ensure_property_string("url")) != NULL) {
+            rtmp_urls.push_back(prop->to_str());
+        }
+    }
+
+    srs_trace("http: on_forward_backend ok, client_id=%s, url=%s, request=%s, response=%s",
+        cid.c_str(), url.c_str(), data.c_str(), res.c_str());
+
+    return err;
+}
+
 srs_error_t SrsHttpHooks::do_post(SrsHttpClient* hc, std::string url, std::string req, int& code, string& res)
 {
     srs_error_t err = srs_success;

--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -482,30 +482,6 @@ srs_error_t SrsHttpHooks::discover_co_workers(string url, string& host, int& por
     return err;
 }
 
-// Request:
-//      POST /api/v1/forward
-//      {
-//          "action": "on_forward",
-//          "server_id": "vid-k21d7y2",
-//          "client_id": "9o7g1330",
-//          "ip": "127.0.0.1",
-//          "vhost": "__defaultVhost__",
-//          "app": "live",
-//          "tcUrl": "rtmp://127.0.0.1:1935/live",
-//          "stream": "livestream",
-//          "param": "?forward=rtmp://ossrs.net/live/livestream"
-//      }
-// Response:
-//      {
-//          "code": 0,
-//          "data": {
-//              "forwards":[{
-//                  "url": "rtmp://ossrs.net:1935/live/livestream?auth_token=xxx"
-//               },{
-//                  "url": "rtmp://aliyuncdn.com:1935/live/livestream?auth_token=xxx"
-//               }]
-//          }
-//      }
 srs_error_t SrsHttpHooks::on_forward_backend(string url, SrsRequest* req, std::vector<std::string>& rtmp_urls)
 {
     srs_error_t err = srs_success;
@@ -557,16 +533,16 @@ srs_error_t SrsHttpHooks::on_forward_backend(string url, SrsRequest* req, std::v
     }
 
     SrsJsonObject* p = prop->to_object();
-    if ((prop = p->ensure_property_array("forwards")) == NULL) {
-        return srs_error_new(ERROR_SYSTEM_FORWARD_LOOP, "parse forwards %s", res.c_str());
+    if ((prop = p->ensure_property_array("urls")) == NULL) {
+        return srs_error_new(ERROR_SYSTEM_FORWARD_LOOP, "parse urls %s", res.c_str());
     }
 
-    SrsJsonArray* forwards = prop->to_array();
-    for (int i = 0; i < forwards->count(); i++) {
-        prop = forwards->at(i);
-        SrsJsonObject* forward = prop->to_object();
-        if ((prop = forward->ensure_property_string("url")) != NULL) {
-            rtmp_urls.push_back(prop->to_str());
+    SrsJsonArray* urls = prop->to_array();
+    for (int i = 0; i < urls->count(); i++) {
+        prop = urls->at(i);
+        string rtmp_url = prop->to_str();
+        if (!rtmp_url.empty()) {
+            rtmp_urls.push_back(rtmp_url);
         }
     }
 

--- a/trunk/src/app/srs_app_http_hooks.hpp
+++ b/trunk/src/app/srs_app_http_hooks.hpp
@@ -10,6 +10,7 @@
 #include <srs_core.hpp>
 
 #include <string>
+#include <vector>
 
 class SrsHttpUri;
 class SrsStSocket;
@@ -79,6 +80,10 @@ public:
     static srs_error_t on_hls_notify(SrsContextId cid, std::string url, SrsRequest* req, std::string ts_url, int nb_notify);
     // Discover co-workers for origin cluster.
     static srs_error_t discover_co_workers(std::string url, std::string& host, int& port);
+    // The on_forward_backend hook, when publish stream start to forward
+    // @param url the api server url, to valid the client.
+    //         ignore if empty.
+    static srs_error_t on_forward_backend(std::string url, SrsRequest* req, std::vector<std::string>& rtmp_urls);
 private:
     static srs_error_t do_post(SrsHttpClient* hc, std::string url, std::string req, int& code, std::string& res);
 };

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -1485,9 +1485,7 @@ srs_error_t SrsOriginHub::create_forwarders()
             // create forward by backend
             std::vector<std::string> urls;
             if ((err = SrsHttpHooks::on_forward_backend(backend_url, req, urls)) != srs_success) {
-                // ignore
-                srs_trace("get backend failed, %s", srs_error_desc(err).c_str());
-                continue;
+                return srs_error_wrap(err, "get forward backend failed");
             }
 
             std::vector<std::string>::iterator it;

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -34,6 +34,7 @@ using namespace std;
 #include <srs_app_dash.hpp>
 #include <srs_protocol_format.hpp>
 #include <srs_app_rtc_source.hpp>
+#include <srs_app_http_hooks.hpp>
 
 #define CONST_MAX_JITTER_MS         250
 #define CONST_MAX_JITTER_MS_NEG         -250
@@ -1473,7 +1474,54 @@ srs_error_t SrsOriginHub::create_forwarders()
         return err;
     }
     
-    SrsConfDirective* conf = _srs_config->get_forwards(req->vhost);
+    srs_utime_t queue_size = _srs_config->get_queue_length(req->vhost);
+
+    SrsConfDirective* conf = _srs_config->get_forward_backend(req->vhost);
+    if (conf) {
+        int count = conf->args.size();
+        for (int i = 0; i < count; i++) {
+            std::string backend_url = conf->args.at(i);
+
+            // create forward by backend
+            std::vector<std::string> urls;
+            if ((err = SrsHttpHooks::on_forward_backend(backend_url, req, urls)) != srs_success) {
+                // ignore
+                srs_trace("get backend failed, %s", srs_error_desc(err).c_str());
+                continue;
+            }
+
+            std::vector<std::string>::iterator it;
+            for (it = urls.begin(); it != urls.end(); ++it) {
+                std::string url = *it;
+
+                // create forwarder by url
+                SrsRequest* freq = new SrsRequest();
+                SrsAutoFree(SrsRequest, freq);
+                srs_parse_rtmp_url(url, freq->tcUrl, freq->stream);
+                srs_discovery_tc_url(freq->tcUrl, freq->schema, freq->host, freq->vhost, freq->app, freq->stream, freq->port, freq->param);
+
+                SrsForwarder* forwarder = new SrsForwarder(this);
+                forwarders.push_back(forwarder);
+
+                std::stringstream forward_server;
+                forward_server << freq->host << ":" << freq->port;
+
+                // initialize the forwarder with request.
+                if ((err = forwarder->initialize(freq, forward_server.str())) != srs_success) {
+                    return srs_error_wrap(err, "init forwarder");
+                }
+
+                forwarder->set_queue_size(queue_size);
+
+                if ((err = forwarder->on_publish()) != srs_success) {
+                    return srs_error_wrap(err, "start backend forwarder failed, vhost=%s, app=%s, stream=%s, forward-to=%s",
+                        req->vhost.c_str(), req->app.c_str(), req->stream.c_str(), forward_server.str().c_str());
+                }
+            }
+        }
+    }
+
+    conf = _srs_config->get_forwards(req->vhost);
     for (int i = 0; conf && i < (int)conf->args.size(); i++) {
         std::string forward_server = conf->args.at(i);
         
@@ -1485,7 +1533,6 @@ srs_error_t SrsOriginHub::create_forwarders()
             return srs_error_wrap(err, "init forwarder");
         }
 
-        srs_utime_t queue_size = _srs_config->get_queue_length(req->vhost);
         forwarder->set_queue_size(queue_size);
         
         if ((err = forwarder->on_publish()) != srs_success) {

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -808,7 +808,7 @@ SrsSharedPtrMessage* SrsMixQueue::pop()
 SrsOriginHub::SrsOriginHub()
 {
     source = NULL;
-    req = NULL;
+    req_ = NULL;
     is_active = false;
     
     hls = new SrsHls();
@@ -852,22 +852,22 @@ srs_error_t SrsOriginHub::initialize(SrsLiveSource* s, SrsRequest* r)
 {
     srs_error_t err = srs_success;
     
-    req = r;
+    req_ = r;
     source = s;
     
     if ((err = format->initialize()) != srs_success) {
         return srs_error_wrap(err, "format initialize");
     }
     
-    if ((err = hls->initialize(this, req)) != srs_success) {
+    if ((err = hls->initialize(this, req_)) != srs_success) {
         return srs_error_wrap(err, "hls initialize");
     }
     
-    if ((err = dash->initialize(this, req)) != srs_success) {
+    if ((err = dash->initialize(this, req_)) != srs_success) {
         return srs_error_wrap(err, "dash initialize");
     }
     
-    if ((err = dvr->initialize(this, req)) != srs_success) {
+    if ((err = dvr->initialize(this, req_)) != srs_success) {
         return srs_error_wrap(err, "dvr initialize");
     }
     
@@ -953,7 +953,7 @@ srs_error_t SrsOriginHub::on_audio(SrsSharedPtrMessage* shared_audio)
         
         // when got audio stream info.
         SrsStatistic* stat = SrsStatistic::instance();
-        if ((err = stat->on_audio_info(req, SrsAudioCodecIdAAC, c->sound_rate, c->sound_type, c->aac_object)) != srs_success) {
+        if ((err = stat->on_audio_info(req_, SrsAudioCodecIdAAC, c->sound_rate, c->sound_type, c->aac_object)) != srs_success) {
             return srs_error_wrap(err, "stat audio");
         }
         
@@ -967,7 +967,7 @@ srs_error_t SrsOriginHub::on_audio(SrsSharedPtrMessage* shared_audio)
     if ((err = hls->on_audio(msg, format)) != srs_success) {
         // apply the error strategy for hls.
         // @see https://github.com/ossrs/srs/issues/264
-        std::string hls_error_strategy = _srs_config->get_hls_on_error(req->vhost);
+        std::string hls_error_strategy = _srs_config->get_hls_on_error(req_->vhost);
         if (srs_config_hls_is_on_error_ignore(hls_error_strategy)) {
             srs_warn("hls: ignore audio error %s", srs_error_desc(err).c_str());
             hls->on_unpublish();
@@ -1026,7 +1026,7 @@ srs_error_t SrsOriginHub::on_video(SrsSharedPtrMessage* shared_video, bool is_se
     // user can disable the sps parse to workaround when parse sps failed.
     // @see https://github.com/ossrs/srs/issues/474
     if (is_sequence_header) {
-        format->avc_parse_sps = _srs_config->get_parse_sps(req->vhost);
+        format->avc_parse_sps = _srs_config->get_parse_sps(req_->vhost);
     }
     
     if ((err = format->on_video(msg)) != srs_success) {
@@ -1047,7 +1047,7 @@ srs_error_t SrsOriginHub::on_video(SrsSharedPtrMessage* shared_video, bool is_se
         
         // when got video stream info.
         SrsStatistic* stat = SrsStatistic::instance();
-        if ((err = stat->on_video_info(req, SrsVideoCodecIdAVC, c->avc_profile, c->avc_level, c->width, c->height)) != srs_success) {
+        if ((err = stat->on_video_info(req_, SrsVideoCodecIdAVC, c->avc_profile, c->avc_level, c->width, c->height)) != srs_success) {
             return srs_error_wrap(err, "stat video");
         }
         
@@ -1067,7 +1067,7 @@ srs_error_t SrsOriginHub::on_video(SrsSharedPtrMessage* shared_video, bool is_se
         // TODO: We should support more strategies.
         // apply the error strategy for hls.
         // @see https://github.com/ossrs/srs/issues/264
-        std::string hls_error_strategy = _srs_config->get_hls_on_error(req->vhost);
+        std::string hls_error_strategy = _srs_config->get_hls_on_error(req_->vhost);
         if (srs_config_hls_is_on_error_ignore(hls_error_strategy)) {
             srs_warn("hls: ignore video error %s", srs_error_desc(err).c_str());
             hls->on_unpublish();
@@ -1127,7 +1127,7 @@ srs_error_t SrsOriginHub::on_publish()
     }
     
     // TODO: FIXME: use initialize to set req.
-    if ((err = encoder->on_publish(req)) != srs_success) {
+    if ((err = encoder->on_publish(req_)) != srs_success) {
         return srs_error_wrap(err, "encoder publish");
     }
 
@@ -1140,7 +1140,7 @@ srs_error_t SrsOriginHub::on_publish()
     }
     
     // @see https://github.com/ossrs/srs/issues/1613#issuecomment-961657927
-    if ((err = dvr->on_publish(req)) != srs_success) {
+    if ((err = dvr->on_publish(req_)) != srs_success) {
         return srs_error_wrap(err, "dvr publish");
     }
     
@@ -1152,7 +1152,7 @@ srs_error_t SrsOriginHub::on_publish()
 #endif
     
     // TODO: FIXME: use initialize to set req.
-    if ((err = ng_exec->on_publish(req)) != srs_success) {
+    if ((err = ng_exec->on_publish(req_)) != srs_success) {
         return srs_error_wrap(err, "exec publish");
     }
     
@@ -1237,7 +1237,7 @@ srs_error_t SrsOriginHub::on_reload_vhost_forward(string vhost)
 {
     srs_error_t err = srs_success;
     
-    if (req->vhost != vhost) {
+    if (req_->vhost != vhost) {
         return err;
     }
     
@@ -1264,7 +1264,7 @@ srs_error_t SrsOriginHub::on_reload_vhost_dash(string vhost)
 {
     srs_error_t err = srs_success;
     
-    if (req->vhost != vhost) {
+    if (req_->vhost != vhost) {
         return err;
     }
     
@@ -1306,7 +1306,7 @@ srs_error_t SrsOriginHub::on_reload_vhost_hls(string vhost)
 {
     srs_error_t err = srs_success;
     
-    if (req->vhost != vhost) {
+    if (req_->vhost != vhost) {
         return err;
     }
     
@@ -1356,7 +1356,7 @@ srs_error_t SrsOriginHub::on_reload_vhost_hds(string vhost)
 {
     srs_error_t err = srs_success;
     
-    if (req->vhost != vhost) {
+    if (req_->vhost != vhost) {
         return err;
     }
     
@@ -1383,7 +1383,7 @@ srs_error_t SrsOriginHub::on_reload_vhost_dvr(string vhost)
 {
     srs_error_t err = srs_success;
     
-    if (req->vhost != vhost) {
+    if (req_->vhost != vhost) {
         return err;
     }
     
@@ -1398,12 +1398,12 @@ srs_error_t SrsOriginHub::on_reload_vhost_dvr(string vhost)
     }
     
     // reinitialize the dvr, update plan.
-    if ((err = dvr->initialize(this, req)) != srs_success) {
+    if ((err = dvr->initialize(this, req_)) != srs_success) {
         return srs_error_wrap(err, "reload dvr");
     }
     
     // start to publish by new plan.
-    if ((err = dvr->on_publish(req)) != srs_success) {
+    if ((err = dvr->on_publish(req_)) != srs_success) {
         return srs_error_wrap(err, "dvr publish failed");
     }
     
@@ -1420,7 +1420,7 @@ srs_error_t SrsOriginHub::on_reload_vhost_transcode(string vhost)
 {
     srs_error_t err = srs_success;
     
-    if (req->vhost != vhost) {
+    if (req_->vhost != vhost) {
         return err;
     }
     
@@ -1433,7 +1433,7 @@ srs_error_t SrsOriginHub::on_reload_vhost_transcode(string vhost)
         return err;
     }
     
-    if ((err = encoder->on_publish(req)) != srs_success) {
+    if ((err = encoder->on_publish(req_)) != srs_success) {
         return srs_error_wrap(err, "start encoder failed");
     }
     srs_trace("vhost %s transcode reload success", vhost.c_str());
@@ -1445,7 +1445,7 @@ srs_error_t SrsOriginHub::on_reload_vhost_exec(string vhost)
 {
     srs_error_t err = srs_success;
     
-    if (req->vhost != vhost) {
+    if (req_->vhost != vhost) {
         return err;
     }
     
@@ -1458,7 +1458,7 @@ srs_error_t SrsOriginHub::on_reload_vhost_exec(string vhost)
         return err;
     }
     
-    if ((err = ng_exec->on_publish(req)) != srs_success) {
+    if ((err = ng_exec->on_publish(req_)) != srs_success) {
         return srs_error_wrap(err, "start exec failed");
     }
     srs_trace("vhost %s exec reload success", vhost.c_str());
@@ -1470,63 +1470,19 @@ srs_error_t SrsOriginHub::create_forwarders()
 {
     srs_error_t err = srs_success;
     
-    if (!_srs_config->get_forward_enabled(req->vhost)) {
+    if (!_srs_config->get_forward_enabled(req_->vhost)) {
         return err;
     }
-    
-    srs_utime_t queue_size = _srs_config->get_queue_length(req->vhost);
 
     // For backend config
-    if (true) {
-        SrsConfDirective* conf = _srs_config->get_forward_backend(req->vhost);
-        if (conf) {
-            // only get first backend url
-            std::string backend_url = conf->arg0();
-
-            // get urls on forward backend
-            std::vector<std::string> urls;
-            if ((err = SrsHttpHooks::on_forward_backend(backend_url, req, urls)) != srs_success) {
-                return srs_error_wrap(err, "get forward backend failed");
-            }
-
-            // create forwarders by urls
-            std::vector<std::string>::iterator it;
-            for (it = urls.begin(); it != urls.end(); ++it) {
-                std::string url = *it;
-
-                // create temp SrsRequest by url
-                SrsRequest* freq = new SrsRequest();
-                SrsAutoFree(SrsRequest, freq);
-                srs_parse_rtmp_url(url, freq->tcUrl, freq->stream);
-                srs_discovery_tc_url(freq->tcUrl, freq->schema, freq->host, freq->vhost, freq->app, freq->stream, freq->port, freq->param);
-
-                // create forwarder
-                SrsForwarder* forwarder = new SrsForwarder(this);
-                forwarders.push_back(forwarder);
-
-                std::stringstream forward_server;
-                forward_server << freq->host << ":" << freq->port;
-
-                // initialize the forwarder with request.
-                if ((err = forwarder->initialize(freq, forward_server.str())) != srs_success) {
-                    return srs_error_wrap(err, "init forwarder");
-                }
-
-                forwarder->set_queue_size(queue_size);
-
-                if ((err = forwarder->on_publish()) != srs_success) {
-                    return srs_error_wrap(err, "start backend forwarder failed, vhost=%s, app=%s, stream=%s, forward-to=%s",
-                        req->vhost.c_str(), req->app.c_str(), req->stream.c_str(), forward_server.str().c_str());
-                }
-            }
-
-            // if backend is configured and normal, return directly
-            return err;
-        }
+    // If you configure backend service, return backend status(default: false)
+    bool backend_status = false;
+    if (((err = create_backend_forwarders(backend_status)) != srs_success) || backend_status) {
+        return err;
     }
 
     // For destanition config
-    SrsConfDirective* conf = _srs_config->get_forwards(req->vhost);
+    SrsConfDirective* conf = _srs_config->get_forwards(req_->vhost);
     for (int i = 0; conf && i < (int)conf->args.size(); i++) {
         std::string forward_server = conf->args.at(i);
         
@@ -1534,18 +1490,78 @@ srs_error_t SrsOriginHub::create_forwarders()
         forwarders.push_back(forwarder);
         
         // initialize the forwarder with request.
-        if ((err = forwarder->initialize(req, forward_server)) != srs_success) {
+        if ((err = forwarder->initialize(req_, forward_server)) != srs_success) {
             return srs_error_wrap(err, "init forwarder");
         }
 
+        srs_utime_t queue_size = _srs_config->get_queue_length(req_->vhost);
         forwarder->set_queue_size(queue_size);
         
         if ((err = forwarder->on_publish()) != srs_success) {
             return srs_error_wrap(err, "start forwarder failed, vhost=%s, app=%s, stream=%s, forward-to=%s",
-                req->vhost.c_str(), req->app.c_str(), req->stream.c_str(), forward_server.c_str());
+                req_->vhost.c_str(), req_->app.c_str(), req_->stream.c_str(), forward_server.c_str());
         }
     }
     
+    return err;
+}
+
+srs_error_t SrsOriginHub::create_backend_forwarders(bool& status)
+{
+    srs_error_t err = srs_success;
+
+    // default not configure backend service
+    status = false;
+
+    SrsConfDirective* conf = _srs_config->get_forward_backend(req_->vhost);
+    if (!conf || conf->arg0().empty()) {
+        return err;
+    }
+
+    // configure backend service
+    status = true;
+
+    // only get first backend url
+    std::string backend_url = conf->arg0();
+
+    // get urls on forward backend
+    std::vector<std::string> urls;
+    if ((err = SrsHttpHooks::on_forward_backend(backend_url, req_, urls)) != srs_success) {
+        return srs_error_wrap(err, "get forward backend failed");
+    }
+
+    // create forwarders by urls
+    std::vector<std::string>::iterator it;
+    for (it = urls.begin(); it != urls.end(); ++it) {
+        std::string url = *it;
+
+        // create temp Request by url
+        SrsRequest* req = new SrsRequest();
+        SrsAutoFree(SrsRequest, req);
+        srs_parse_rtmp_url(url, req->tcUrl, req->stream);
+        srs_discovery_tc_url(req->tcUrl, req->schema, req->host, req->vhost, req->app, req->stream, req->port, req->param);
+
+        // create forwarder
+        SrsForwarder* forwarder = new SrsForwarder(this);
+        forwarders.push_back(forwarder);
+
+        std::stringstream forward_server;
+        forward_server << req->host << ":" << req->port;
+
+        // initialize the forwarder with request.
+        if ((err = forwarder->initialize(req, forward_server.str())) != srs_success) {
+            return srs_error_wrap(err, "init forwarder");
+        }
+
+        srs_utime_t queue_size = _srs_config->get_queue_length(req_->vhost);
+        forwarder->set_queue_size(queue_size);
+
+        if ((err = forwarder->on_publish()) != srs_success) {
+            return srs_error_wrap(err, "start backend forwarder failed, vhost=%s, app=%s, stream=%s, forward-to=%s",
+                req_->vhost.c_str(), req_->app.c_str(), req_->stream.c_str(), forward_server.str().c_str());
+        }
+    }
+
     return err;
 }
 

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -375,7 +375,7 @@ public:
     virtual srs_error_t on_reload_vhost_exec(std::string vhost);
 private:
     virtual srs_error_t create_forwarders();
-    virtual srs_error_t create_backend_forwarders(bool& status);
+    virtual srs_error_t create_backend_forwarders(bool& applied);
     virtual void destroy_forwarders();
 };
 

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -310,7 +310,7 @@ class SrsOriginHub : public ISrsReloadHandler
 {
 private:
     SrsLiveSource* source;
-    SrsRequest* req;
+    SrsRequest* req_;
     bool is_active;
 private:
     // The format, codec information.
@@ -375,6 +375,7 @@ public:
     virtual srs_error_t on_reload_vhost_exec(std::string vhost);
 private:
     virtual srs_error_t create_forwarders();
+    virtual srs_error_t create_backend_forwarders(bool& status);
     virtual void destroy_forwarders();
 };
 

--- a/trunk/src/utest/srs_utest_config.cpp
+++ b/trunk/src/utest/srs_utest_config.cpp
@@ -2914,6 +2914,13 @@ VOID TEST(ConfigMainTest, CheckVhostConfig2)
         EXPECT_EQ(5000000, conf.get_publish_normal_timeout("ossrs.net"));
         EXPECT_FALSE(conf.get_forward_enabled("ossrs.net"));
         EXPECT_TRUE(conf.get_forwards("ossrs.net") == NULL);
+        EXPECT_TRUE(conf.get_forward_backend("ossrs.net") == NULL);
+    }
+
+    if (true) {
+        MockSrsConfig conf;
+        HELPER_ASSERT_SUCCESS(conf.parse(_MIN_OK_CONF "vhost ossrs.net{forward {backend xxx;}}"));
+        EXPECT_TRUE(conf.get_forward_backend("ossrs.net") != NULL);
     }
 
     if (true) {


### PR DESCRIPTION
You can specify livestream  forward the full rtmp address to other server, for example:
```
    forward {
        enabled on;
        destination 127.0.0.1:1936 127.0.0.1:1937;
        backend http://127.0.0.1:8085/api/v1/forward;
    }
```
### Scene: client publish url carry `forward=`
forward url has domain and port
```
rtmp://ossrs.net/live/livestream?forward=aliyuncdn.com:1936&token=xxxxxx
```
forward url is full rtmp address
```
rtmp://ossrs.net/live/livestream?token=xxxxxx&forward=rtmp://cdn.com/myapp/mystream
```
### Scene: backend server configure forward address
```
class RESTForward(object):
    def __init__(self):
        self.__forwards = []

        self.__forwards.append({
            "vhost":"ossrs.net",
            "app":"live",
            "stream":"livestream",
            "url":"push.ossrs.com",
        })

        self.__forwards.append({
            "app":"live",
            "stream":"livestream",
            "url":"rtmp://push.ossrs.com/test/teststream?auth_token=123456",
        })
```