### PR TITLE
HTTP: Fix mp4/flv file size exceed 2GB download error

### DIFF
--- a/trunk/src/app/srs_app_http_static.hpp
+++ b/trunk/src/app/srs_app_http_static.hpp
@@ -30,8 +30,8 @@ public:
     SrsVodStream(std::string root_dir);
     virtual ~SrsVodStream();
 protected:
-    virtual srs_error_t serve_flv_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int offset);
-    virtual srs_error_t serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int start, int end);
+    virtual srs_error_t serve_flv_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int64_t offset);
+    virtual srs_error_t serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int64_t start, int64_t end);
     virtual srs_error_t serve_m3u8_ctx(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath);
 private:
     virtual bool ctx_is_exist(std::string ctx);

--- a/trunk/src/protocol/srs_http_stack.cpp
+++ b/trunk/src/protocol/srs_http_stack.cpp
@@ -456,8 +456,8 @@ srs_error_t SrsHttpFileServer::serve_file(ISrsHttpResponseWriter* w, ISrsHttpMes
     
     // write body.
     int64_t left = length;
-    if ((err = copy(w, fs, r, (int)left)) != srs_success) {
-        return srs_error_wrap(err, "copy file=%s size=%d", fullpath.c_str(), (int)left);
+    if ((err = copy(w, fs, r, left)) != srs_success) {
+        return srs_error_wrap(err, "copy file=%s size=%" PRId64, fullpath.c_str(), left);
     }
     
     if ((err = w->final_request()) != srs_success) {
@@ -474,7 +474,7 @@ srs_error_t SrsHttpFileServer::serve_flv_file(ISrsHttpResponseWriter* w, ISrsHtt
         return serve_file(w, r, fullpath);
     }
     
-    int offset = ::atoi(start.c_str());
+    int64_t offset = ::atoll(start.c_str());
     if (offset <= 0) {
         return serve_file(w, r, fullpath);
     }
@@ -507,15 +507,15 @@ srs_error_t SrsHttpFileServer::serve_mp4_file(ISrsHttpResponseWriter* w, ISrsHtt
     }
     
     // parse the start in query string
-    int start = 0;
+    int64_t start = 0;
     if (pos > 0) {
-        start = ::atoi(range.substr(0, pos).c_str());
+        start = ::atoll(range.substr(0, pos).c_str());
     }
     
     // parse end in query string.
-    int end = -1;
+    int64_t end = -1;
     if (pos < range.length() - 1) {
-        end = ::atoi(range.substr(pos + 1).c_str());
+        end = ::atoll(range.substr(pos + 1).c_str());
     }
     
     // invalid param, serve as whole mp4 file.
@@ -531,14 +531,14 @@ srs_error_t SrsHttpFileServer::serve_m3u8_file(ISrsHttpResponseWriter * w, ISrsH
     return serve_m3u8_ctx(w, r, fullpath);
 }
 
-srs_error_t SrsHttpFileServer::serve_flv_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, string fullpath, int offset)
+srs_error_t SrsHttpFileServer::serve_flv_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, string fullpath, int64_t offset)
 {
     // @remark For common http file server, we don't support stream request, please use SrsVodStream instead.
     // TODO: FIXME: Support range in header https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Range_requests
     return serve_file(w, r, fullpath);
 }
 
-srs_error_t SrsHttpFileServer::serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, string fullpath, int start, int end)
+srs_error_t SrsHttpFileServer::serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, string fullpath, int64_t start, int64_t end)
 {
     // @remark For common http file server, we don't support stream request, please use SrsVodStream instead.
     // TODO: FIXME: Support range in header https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Range_requests
@@ -552,11 +552,11 @@ srs_error_t SrsHttpFileServer::serve_m3u8_ctx(ISrsHttpResponseWriter * w, ISrsHt
     return serve_file(w, r, fullpath);
 }
 
-srs_error_t SrsHttpFileServer::copy(ISrsHttpResponseWriter* w, SrsFileReader* fs, ISrsHttpMessage* r, int size)
+srs_error_t SrsHttpFileServer::copy(ISrsHttpResponseWriter* w, SrsFileReader* fs, ISrsHttpMessage* r, int64_t size)
 {
     srs_error_t err = srs_success;
     
-    int left = size;
+    int64_t left = size;
     char* buf = new char[SRS_HTTP_TS_SEND_BUFFER_SIZE];
     SrsAutoFreeA(char, buf);
     
@@ -564,12 +564,12 @@ srs_error_t SrsHttpFileServer::copy(ISrsHttpResponseWriter* w, SrsFileReader* fs
         ssize_t nread = -1;
         int max_read = srs_min(left, SRS_HTTP_TS_SEND_BUFFER_SIZE);
         if ((err = fs->read(buf, max_read, &nread)) != srs_success) {
-            return srs_error_wrap(err, "read limit=%d, left=%d", max_read, left);
+            return srs_error_wrap(err, "read limit=%d, left=%" PRId64, max_read, left);
         }
         
         left -= nread;
         if ((err = w->write(buf, (int)nread)) != srs_success) {
-            return srs_error_wrap(err, "write limit=%d, bytes=%d, left=%d", max_read, (int)nread, left);
+            return srs_error_wrap(err, "write limit=%d, bytes=%d, left=%" PRId64, max_read, (int)nread, left);
         }
     }
     

--- a/trunk/src/protocol/srs_http_stack.hpp
+++ b/trunk/src/protocol/srs_http_stack.hpp
@@ -288,12 +288,12 @@ private:
     virtual srs_error_t serve_m3u8_file(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath);
 protected:
     // When access flv file with x.flv?start=xxx
-    virtual srs_error_t serve_flv_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int offset);
+    virtual srs_error_t serve_flv_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int64_t offset);
     // When access mp4 file with x.mp4?range=start-end
     // @param start the start offset in bytes.
     // @param end the end offset in bytes. -1 to end of file.
     // @remark response data in [start, end].
-    virtual srs_error_t serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int start, int end);
+    virtual srs_error_t serve_mp4_stream(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath, int64_t start, int64_t end);
     // For HLS protocol.
     // When the request url, like as "http://127.0.0.1:8080/live/livestream.m3u8", 
     // returns the response like as "http://127.0.0.1:8080/live/livestream.m3u8?hls_ctx=12345678" .
@@ -306,7 +306,7 @@ protected:
     virtual srs_error_t serve_m3u8_ctx(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, std::string fullpath);
 protected:
     // Copy the fs to response writer in size bytes.
-    virtual srs_error_t copy(ISrsHttpResponseWriter* w, SrsFileReader* fs, ISrsHttpMessage* r, int size);
+    virtual srs_error_t copy(ISrsHttpResponseWriter* w, SrsFileReader* fs, ISrsHttpMessage* r, int64_t size);
 };
 
 // The mux entry for server mux.

--- a/trunk/src/protocol/srs_service_http_conn.cpp
+++ b/trunk/src/protocol/srs_service_http_conn.cpp
@@ -755,7 +755,7 @@ srs_error_t SrsHttpResponseWriter::write(char* data, int size)
     // check the bytes send and content length.
     written += size;
     if (content_length != -1 && written > content_length) {
-        return srs_error_new(ERROR_HTTP_CONTENT_LENGTH, "overflow writen=%d, max=%d", (int)written, (int)content_length);
+        return srs_error_new(ERROR_HTTP_CONTENT_LENGTH, "overflow writen=%" PRId64 ", max=%" PRId64, written, content_length);
     }
     
     // ignore NULL content.


### PR DESCRIPTION
背景：#2780 #2781 ，http服务分发超过2GB大文件时(如flv、mp4)，会出现连接超时或者overflow日志
原因：超过2GB后，`int`类型无法完整表示文件大小