### PR TITLE
CI: Support build and test for CentOS 6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # Build for CentOS7
+      # Build for CentOS 7
       - name: Build on CentOS7, baseline
         run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target centos7-baseline .
       - name: Build on CentOS7, with SRT
@@ -23,7 +23,10 @@ jobs:
         run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target centos7-no-asm .
       - name: Build on CentOS7, C++98, no FFmpeg
         run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target centos7-ansi-no-ffmpeg .
-      # Build for CentOS8
+      # Build for CentOS 6
+      - name: Build on CentOS6, baseline
+        run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target centos6-baseline .
+      # Build for CentOS 8
       - name: Build on CentOS8, baseline
         run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target centos8-baseline .
       - name: Build on CentOS8, with SRT

--- a/trunk/Dockerfile.builds
+++ b/trunk/Dockerfile.builds
@@ -20,6 +20,11 @@ COPY . /srs
 RUN cd /srs/trunk && ./configure --jobs=2 --cxx11=off --cxx14=off --ffmpeg-fit=off && make -j2
 
 ########################################################
+FROM ossrs/srs:dev6 AS centos6-baseline
+COPY . /srs
+RUN cd /srs/trunk && ./configure --jobs=2 && make -j2
+
+########################################################
 FROM ossrs/srs:dev8 AS centos8-baseline
 COPY . /srs
 RUN cd /srs/trunk && ./configure --jobs=2 && make -j2


### PR DESCRIPTION
## Summary

Enable CentOS 6.0 CI

## Details

Support baseline build and utest.