### PR TITLE
SRT: Eliminate duplicate header file.(#2786)

### DIFF
--- a/trunk/src/srt/srt_to_rtmp.cpp
+++ b/trunk/src/srt/srt_to_rtmp.cpp
@@ -14,8 +14,6 @@
 #include <srs_app_rtmp_conn.hpp>
 #include <srs_app_config.hpp>
 #include <srs_kernel_stream.hpp>
-#include <list>
-#include <sstream>
 
 std::shared_ptr<srt2rtmp> srt2rtmp::s_srt2rtmp_ptr;
 


### PR DESCRIPTION
eliminate unused `#include < list >` and duplicate `#include <sstream>`, because srs_app_config.hpp have introduced.