### PR TITLE
GB28181: fixed crash when deleting gb28181 channel

### DIFF
--- a/trunk/src/app/srs_app_gb28181.cpp
+++ b/trunk/src/app/srs_app_gb28181.cpp
@@ -1122,6 +1122,7 @@ void SrsGb28181RtmpMuxer::stop()
 {
     if (trd){
         trd->interrupt();
+	return;
     }
     //stop rtmp publish
     close();


### PR DESCRIPTION
## Summary

修复 #2839 

## Details

删除通道致使 SrsGb28181RtmpMuxer::close 被重复调用。
原因：删除通道时 SrsGb28181RtmpMuxer::stop 方法会修改线程状态并调用 close 方法，由于线程状态的改变，SrsGb28181RtmpMuxer::cycle 会从 do_cycle 返回，然后通过 gb28181_manger->remove 方法释放 SrsGb28181RtmpMuxer，在其析构函数中会再次调用 SrsGb28181RtmpMuxer::close，致使二次释放，程序 crash。
