### PR TITLE
RTC: fix play crash or no stream for rtmp2rtc tips.(#2728)

### DIFF
--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -187,9 +187,9 @@ srs_error_t SrsGoApiRtcPlay::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
     }
 
     // For RTMP to RTC, fail if disabled and RTMP is active, see https://github.com/ossrs/srs/issues/2728
-    if (!_srs_config->get_rtc_to_rtmp(ruc.req_->vhost)) {
+    if (!_srs_config->get_rtc_from_rtmp(ruc.req_->vhost)) {
         SrsLiveSource* rtmp = _srs_sources->fetch(ruc.req_);
-        if (!rtmp->inactive()) {
+        if (rtmp && rtmp->inactive()) {
             return srs_error_new(ERROR_RTC_DISABLED, "Disabled rtmp_to_rtc of %s, see #2728", ruc.req_->vhost.c_str());
         }
     }


### PR DESCRIPTION
If I don't publish stream, when I play RTC stream and SRS will crash. And if I publish RTC stream,  when I play RTC stream and SRS don't distribute RTC stream.Config as follows:
```
vhost __defaultVhost__ {
    rtc {
        enabled     on;
        # @see https://github.com/ossrs/srs/wiki/v4_CN_WebRTC#rtmp-to-rtc
        rtmp_to_rtc off;
        # @see https://github.com/ossrs/srs/wiki/v4_CN_WebRTC#rtc-to-rtmp
        rtc_to_rtmp off;
    }
}
```