### PR TITLE
RTC: fix play rtc judge for rtmp inactive.(#2863)

### DIFF
--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -189,7 +189,7 @@ srs_error_t SrsGoApiRtcPlay::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
     // For RTMP to RTC, fail if disabled and RTMP is active, see https://github.com/ossrs/srs/issues/2728
     if (!_srs_config->get_rtc_from_rtmp(ruc.req_->vhost)) {
         SrsLiveSource* rtmp = _srs_sources->fetch(ruc.req_);
-        if (rtmp && rtmp->inactive()) {
+        if (rtmp && !rtmp->inactive()) {
             return srs_error_new(ERROR_RTC_DISABLED, "Disabled rtmp_to_rtc of %s, see #2728", ruc.req_->vhost.c_str());
         }
     }


### PR DESCRIPTION
After the RTMP publishing is disconnected, then I publish RTC stream and the RTC playing will be rejected.Likely:
My config as follows,
```
vhost __defaultVhost__ {
    rtc {
        enabled     on;
        # @see https://github.com/ossrs/srs/wiki/v4_CN_WebRTC#rtmp-to-rtc
        rtmp_to_rtc off;
        # @see https://github.com/ossrs/srs/wiki/v4_CN_WebRTC#rtc-to-rtmp
        rtc_to_rtmp off;
    }
}
```
Firstly, publish rtmp stream, then disconnect.
`ffmpeg -re -i 264_aac.flv -c copy -f flv rtmp://127.0.0.1/live/livestream`
Secondly, publish rtc stream.
`./objs/srs_bench -pr webrtc://localhost/live/livestream -sa avatar.ogg -sv avatar.h264 -fps 25`
Thirdly, play is rejected.
`./objs/srs_bench -sr webrtc://localhost/live/livestream`