### PR TITLE
RTC: fix play rtc judge for config rtc2rtmp on.(#2863)

### DIFF
--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -186,8 +186,15 @@ srs_error_t SrsGoApiRtcPlay::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
             server_enabled, rtc_enabled, ruc.req_->vhost.c_str());
     }
 
+    // Whether RTC stream is active.
+    bool is_rtc_stream_active = false;
+    if (true) {
+        SrsRtcSource* source = _srs_rtc_sources->fetch(ruc.req_);
+        is_rtc_stream_active = (source && !source->can_publish());
+    }
+
     // For RTMP to RTC, fail if disabled and RTMP is active, see https://github.com/ossrs/srs/issues/2728
-    if (!_srs_config->get_rtc_from_rtmp(ruc.req_->vhost)) {
+    if (!is_rtc_stream_active && !_srs_config->get_rtc_from_rtmp(ruc.req_->vhost)) {
         SrsLiveSource* rtmp = _srs_sources->fetch(ruc.req_);
         if (rtmp && !rtmp->inactive()) {
             return srs_error_new(ERROR_RTC_DISABLED, "Disabled rtmp_to_rtc of %s, see #2728", ruc.req_->vhost.c_str());

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -112,7 +112,7 @@ public:
     // @param r the client request.
     // @param pps the matched source, if success never be NULL.
     virtual srs_error_t fetch_or_create(SrsRequest* r, SrsRtcSource** pps);
-private:
+public:
     // Get the exists source, NULL when not exists.
     virtual SrsRtcSource* fetch(SrsRequest* r);
 };


### PR DESCRIPTION
### Configuration1
```
vhost __defaultVhost__ {
    rtc {
        enabled     on;
        rtmp_to_rtc off;
        rtc_to_rtmp off;
    }
}
```
>Step1: Rtmp Publish: `ffmpeg -re -i 264_aac.flv -c copy -f flv rtmp://127.0.0.1/live/livestream`
Step2: Rtmp stream can play: `ffplay rtmp://localhost/live/livestream`
Step3: Rtc stream can't play(**reject tips**): `./objs/srs_bench -sr webrtc://localhost/live/livestream`

>Step1: RTC Publish: `./objs/srs_bench -pr webrtc://localhost/live/livestream -sa avatar.ogg -sv avatar.h264 -fps 25`
Step2: Rtmp stream can't play: `ffplay rtmp://localhost/live/livestream`
Step3: Rtc stream  can play: `./objs/srs_bench -sr webrtc://localhost/live/livestream`
### Configuration2
```
vhost __defaultVhost__ {
    rtc {
        enabled     on;
        rtmp_to_rtc off;
        rtc_to_rtmp on;
    }
}
```
>Step1: Rtmp Publish: `ffmpeg -re -i 264_aac.flv -c copy -f flv rtmp://127.0.0.1/live/livestream`
Step2: Rtmp stream can play: `ffplay rtmp://localhost/live/livestream`
Step3: Rtc stream can't play(**reject tips**): `./objs/srs_bench -sr webrtc://localhost/live/livestream`

>Step1: RTC Publish: `./objs/srs_bench -pr webrtc://localhost/live/livestream -sa avatar.ogg -sv avatar.h264 -fps 25`
Step2: Rtmp stream can play: `ffplay rtmp://localhost/live/livestream`
Step3: Rtc stream  can play: `./objs/srs_bench -sr webrtc://localhost/live/livestream`
### Configuration3
```
vhost __defaultVhost__ {
    rtc {
        enabled     on;
        rtmp_to_rtc on;
        rtc_to_rtmp off;
    }
}
```
>Step1: Rtmp Publish: `ffmpeg -re -i 264_aac.flv -c copy -f flv rtmp://127.0.0.1/live/livestream`
Step2: Rtmp stream can play: `ffplay rtmp://localhost/live/livestream`
Step3: Rtc stream can play: `./objs/srs_bench -sr webrtc://localhost/live/livestream`

>Step1: RTC Publish: `./objs/srs_bench -pr webrtc://localhost/live/livestream -sa avatar.ogg -sv avatar.h264 -fps 25`
Step2: Rtmp stream can't play: `ffplay rtmp://localhost/live/livestream`
Step3: Rtc stream  can play: `./objs/srs_bench -sr webrtc://localhost/live/livestream`

### Configuration4
```
vhost __defaultVhost__ {
    rtc {
        enabled     on;
        rtmp_to_rtc on;
        rtc_to_rtmp on;
    }
}
```
>Step1: Rtmp Publish: `ffmpeg -re -i 264_aac.flv -c copy -f flv rtmp://127.0.0.1/live/livestream`
Step2: Rtmp stream can play: `ffplay rtmp://localhost/live/livestream`
Step3: Rtc stream can play: `./objs/srs_bench -sr webrtc://localhost/live/livestream`

>Step1: RTC Publish: `./objs/srs_bench -pr webrtc://localhost/live/livestream -sa avatar.ogg -sv avatar.h264 -fps 25`
Step2: Rtmp stream can play: `ffplay rtmp://localhost/live/livestream`
Step3: Rtc stream  can play: `./objs/srs_bench -sr webrtc://localhost/live/livestream`
