### PR TITLE
Fix bug when the value of http header is empty

### DIFF
--- a/trunk/src/protocol/srs_service_http_conn.cpp
+++ b/trunk/src/protocol/srs_service_http_conn.cpp
@@ -263,12 +263,12 @@ int SrsHttpParser::on_header_value(http_parser* parser, const char* at, size_t l
     
     if (length > 0) {
         obj->field_value.append(at, (int)length);
-    }
 
-    // When header parsed, we must save the position of start for body,
-    // because we have to consume the header in buffer.
-    // @see https://github.com/ossrs/srs/issues/1508
-    obj->p_header_tail = at;
+        // When header parsed, we must save the position of start for body,
+        // because we have to consume the header in buffer.
+        // @see https://github.com/ossrs/srs/issues/1508
+        obj->p_header_tail = at;
+    }
     
     srs_info("Header value(%d bytes): %.*s", (int)length, (int)length, at);
     return 0;

--- a/trunk/src/utest/srs_utest_http.cpp
+++ b/trunk/src/utest/srs_utest_http.cpp
@@ -143,6 +143,16 @@ string mock_http_response2(int status, string content)
     return ss.str();
 }
 
+string mock_http_response3(int status, string content)
+{
+    stringstream ss;
+    ss << "HTTP/1.1 " << status << " " << srs_generate_http_status_text(status) << "\r\n"
+        << "Server:" << "\r\n"
+        << "\r\n"
+        << content;
+    return ss.str();
+}
+
 bool is_string_contain(string substr, string str)
 {
     return (string::npos != str.find(substr));
@@ -521,6 +531,17 @@ VOID TEST(ProtocolHTTPTest, ClientRequest)
     // Normal case, with specified content-length.
     if (true) {
         MockBufferIO io; io.append(mock_http_response(200, "Hello, world!"));
+        SrsHttpParser hp; HELPER_ASSERT_SUCCESS(hp.initialize(HTTP_RESPONSE));
+        ISrsHttpMessage* msg = NULL; HELPER_ASSERT_SUCCESS(hp.parse_message(&io, &msg));
+        string res; HELPER_ASSERT_SUCCESS(msg->body_read_all(res));
+        EXPECT_EQ(200, msg->status_code());
+        EXPECT_STREQ("Hello, world!", res.c_str());
+        srs_freep(msg);
+    }
+    
+    // Normal case, with empty server.
+    if(true) {
+        MockBufferIO io; io.append(mock_http_response3(200, "Hello, world!"));
         SrsHttpParser hp; HELPER_ASSERT_SUCCESS(hp.initialize(HTTP_RESPONSE));
         ISrsHttpMessage* msg = NULL; HELPER_ASSERT_SUCCESS(hp.parse_message(&io, &msg));
         string res; HELPER_ASSERT_SUCCESS(msg->body_read_all(res));


### PR DESCRIPTION
## Summary

场景：开启HTTP HOOK
配置文件：
```
rtc_server {
    enabled on;
    listen 8000; # UDP port
    # @see https://github.com/ossrs/srs/wiki/v4_CN_WebRTC#config-candidate
    candidate $CANDIDATE;
}

vhost __defaultVhost__ {
    rtc {
        enabled     on;
        # @see https://github.com/ossrs/srs/wiki/v4_CN_WebRTC#rtmp-to-rtc
        rtmp_to_rtc on;
        # @see https://github.com/ossrs/srs/wiki/v4_CN_WebRTC#rtc-to-rtmp
        rtc_to_rtmp off;
    }
    http_remux {
        enabled     on;
        mount       [vhost]/[app]/[stream].flv;
    }
    http_hooks {
        enabled         on;
        on_play         http://192.168.1.10:8888/;
    }
}

```

重现步骤：
使用@mingyang0921 提供的代码搭建一个http server，即可重现。链接在此： https://github.com/ossrs/srs/pull/2851#issuecomment-1006280683

原因分析：
http response header最后一个字段的value为空，如下示例里面的`Server`：
```
Date: Fri, 31 Dec 2021 08:47:59 GMT\r\nServer: \r\n\r\n{\"code\": 0, \"data\": \"\"}
```
就会导致找不到body，以至于最终超时，错误日志如下：
```
[2022-01-23 15:40:26.982][Warn][41098][78k9o875][62] RTC error code=1011 : RTC: http_hooks_on_play : on_play http://192.168.1.10:8888/ : http: on_play failed, client_id=78k9o875, url=http://192.168.1.10:8888/, request={"server_id":"vid-300d7a8","action":"on_play","client_id":"78k9o875","ip":"192.168.1.6","vhost":"__defaultVhost__","app":"live","stream":"livestream","param":"","pageUrl":""}, response=, status=200 : http: body read : read body : grow buffer : read bytes : timeout 30000 ms
thread [41098][78k9o875]: do_serve_http() [src/app/srs_app_rtc_api.cpp:134][errno=62]
thread [41098][78k9o875]: http_hooks_on_play() [src/app/srs_app_rtc_api.cpp:290][errno=62]
thread [41098][78k9o875]: on_play() [src/app/srs_app_http_hooks.cpp:224][errno=62]
thread [41098][78k9o875]: do_post() [src/app/srs_app_http_hooks.cpp:511][errno=62]
thread [41098][78k9o875]: body_read_all() [src/protocol/srs_service_http_conn.cpp:589][errno=62]
thread [41098][78k9o875]: read_specified() [src/protocol/srs_service_http_conn.cpp:1107][errno=62]
thread [41098][78k9o875]: grow() [src/protocol/srs_protocol_stream.cpp:162][errno=62]
thread [41098][78k9o875]: read() [src/protocol/srs_service_st.cpp:522][errno=62]
```

## Details

相关链接：https://github.com/ossrs/srs/pull/2851

## Others

http parser 升级到`v2.9.4`仍然有同样的问题，https://github.com/nodejs/http-parser/releases/tag/v2.9.4
