### PR TITLE
fix fd leak

### DIFF
--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -1374,12 +1374,12 @@ srs_error_t SrsServer::accept_client(SrsListenerType type, srs_netfd_t stfd)
     ISrsStartableConneciton* conn = NULL;
     
     if ((err = fd_to_resource(type, stfd, &conn)) != srs_success) {
-        if (srs_error_code(err) == ERROR_SOCKET_GET_PEER_IP && _srs_config->empty_ip_ok()) {
-            srs_close_stfd(stfd); srs_error_reset(err);
-            return srs_success;
-        }
         //close fd on conn error, otherwise will lead to fd leak -gs
         srs_close_stfd(stfd);
+        if (srs_error_code(err) == ERROR_SOCKET_GET_PEER_IP && _srs_config->empty_ip_ok()) {
+            srs_error_reset(err);
+            return srs_success;
+        }
         return srs_error_wrap(err, "fd to resource");
     }
     srs_assert(conn);

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -1378,6 +1378,8 @@ srs_error_t SrsServer::accept_client(SrsListenerType type, srs_netfd_t stfd)
             srs_close_stfd(stfd); srs_error_reset(err);
             return srs_success;
         }
+        //close fd on conn error, otherwise will lead to fd leak -gs
+        srs_close_stfd(stfd);
         return srs_error_wrap(err, "fd to resource");
     }
     srs_assert(conn);


### PR DESCRIPTION
when tcp connection exceed max_connection, that connection will leak because of not closing the fd

## Summary

when a incoming tcp connection exceed max_connection, it will lead to fd leaking, if too many leaking happened, then http server may not respond, because of "too many open files”

## Details

same to the summary