### PR TITLE
Fix parse_file function did not handle err

### DIFF
--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2040,14 +2040,14 @@ srs_error_t SrsConfig::parse_options(int argc, char** argv)
         // we check it when user requires check config file.
         if (err == srs_success && (err = srs_config_transform_vhost(root)) == srs_success) {
             if ((err = check_config()) == srs_success) {
-                srs_trace("the configuration file %s syntax is ok", config_file.c_str());
-                srs_trace("configuration file %s test is successful", config_file.c_str());
+                srs_trace("the config file %s syntax is ok", config_file.c_str());
+                srs_trace("config file %s test is successful", config_file.c_str());
                 exit(0);
             }
         }
 
-        srs_trace("invalid configuration: %s in %s", srs_error_summary(err).c_str(), config_file.c_str());
-        srs_trace("configuration file %s test is failed", config_file.c_str());
+        srs_trace("invalid config%s in %s", srs_error_summary(err).c_str(), config_file.c_str());
+        srs_trace("config file %s test is failed", config_file.c_str());
         exit(srs_error_code(err));
     }
 

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2033,25 +2033,29 @@ srs_error_t SrsConfig::parse_options(int argc, char** argv)
     }
 
     // Parse the matched config file.
-    if ((err = parse_file(config_file.c_str())) != srs_success) {
+    err = parse_file(config_file.c_str());
+
+    if (test_conf) {
+        // the parse_file never check the config,
+        // we check it when user requires check config file.
+        if (err == srs_success && (err = srs_config_transform_vhost(root)) == srs_success) {
+            if ((err = check_config()) == srs_success) {
+                srs_trace("config file is ok");
+                exit(0);
+            }
+        }
+
+        srs_error("config file, %s", srs_error_desc(err).c_str());
+        exit(srs_error_code(err));
+    }
+
+    if (err != srs_success) {
         return srs_error_wrap(err, "invalid config");
     }
 
     // transform config to compatible with previous style of config.
     if ((err = srs_config_transform_vhost(root)) != srs_success) {
         return srs_error_wrap(err, "transform");
-    }
-
-    if (test_conf) {
-        // the parse_file never check the config,
-        // we check it when user requires check config file.
-        if ((err = check_config()) == srs_success) {
-            srs_trace("config file is ok");
-            exit(0);
-        }
-
-        srs_error("config file, %s", srs_error_desc(err).c_str());
-        exit(srs_error_code(err));
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -984,10 +984,10 @@ srs_error_t SrsConfDirective::parse_conf(SrsConfigBuffer* buffer, SrsDirectiveCo
         }
 
         if (state == SrsDirectiveStateBlockEnd) {
-            return ctx == SrsDirectiveContextBlock ? srs_success : srs_error_wrap(err, "line %d: unexpected \"}\"", buffer->line);
+            return ctx == SrsDirectiveContextBlock ? srs_success : srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "line %d: unexpected \"}\"", buffer->line);
         }
         if (state == SrsDirectiveStateEOF) {
-            return ctx != SrsDirectiveContextBlock ? srs_success : srs_error_wrap(err, "line %d: unexpected end of file, expecting \"}\"", conf_line);
+            return ctx != SrsDirectiveContextBlock ? srs_success : srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "line %d: unexpected end of file, expecting \"}\"", conf_line);
         }
         if (args.empty()) {
             return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "line %d: empty directive", conf_line);
@@ -2040,12 +2040,14 @@ srs_error_t SrsConfig::parse_options(int argc, char** argv)
         // we check it when user requires check config file.
         if (err == srs_success && (err = srs_config_transform_vhost(root)) == srs_success) {
             if ((err = check_config()) == srs_success) {
-                srs_trace("config file is ok");
+                srs_trace("the configuration file %s syntax is ok", config_file.c_str());
+                srs_trace("configuration file %s test is successful", config_file.c_str());
                 exit(0);
             }
         }
 
-        srs_error("config file, %s", srs_error_desc(err).c_str());
+        srs_trace("invalid configuration: %s in %s", srs_error_summary(err).c_str(), config_file.c_str());
+        srs_trace("configuration file %s test is failed", config_file.c_str());
         exit(srs_error_code(err));
     }
 

--- a/trunk/src/kernel/srs_kernel_error.cpp
+++ b/trunk/src/kernel/srs_kernel_error.cpp
@@ -85,7 +85,9 @@ std::string SrsCplxError::summary() {
 
         SrsCplxError* next = this;
         while (next) {
-            ss << " : " << next->msg;
+            if (!next->wrapped) {
+                ss << next->msg;
+            }
             next = next->wrapped;
         }
 

--- a/trunk/src/kernel/srs_kernel_error.cpp
+++ b/trunk/src/kernel/srs_kernel_error.cpp
@@ -85,9 +85,7 @@ std::string SrsCplxError::summary() {
 
         SrsCplxError* next = this;
         while (next) {
-            if (!next->wrapped) {
-                ss << next->msg;
-            }
+            ss << " : " << next->msg;
             next = next->wrapped;
         }
 


### PR DESCRIPTION
## Summary

Fix parse_file function did not handle err

## Details

配置文件 live.conf
```
listen              1935;
max_connections     1000;
srs_log_tank        console;
daemon              off;

http_api {
    enabled         on;
    listen          1985;
}

http_server {
    enabled         on;
    listen          8080;
    dir             ./objs/nginx/html;
}

vhost __defaultVhost__ {
    hls {
        enabled         on;
    }
    http_remux {
        enabled     on;
        mount       [vhost]/[app]/[stream].flv;
    }
#} ----------------------------假定此花括号缺失

```
运行加载配置
```
./objs/srs -c ./conf/live.conf
```
运行并不会报错，提示配置文件异常。