### PR TITLE
fix coverity scan

### DIFF
--- a/trunk/src/app/srs_app_listener.cpp
+++ b/trunk/src/app/srs_app_listener.cpp
@@ -130,6 +130,7 @@ int SrsUdpListener::listen()
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = inet_addr(ip.c_str());
+    bzero(&(addr.sin_zero),8);
     if (bind(_fd, (const sockaddr*)&addr, sizeof(sockaddr_in)) == -1) {
         ret = ERROR_SOCKET_BIND;
         srs_error("bind socket error. ep=%s:%d, ret=%d", ip.c_str(), port, ret);
@@ -239,6 +240,7 @@ int SrsTcpListener::listen()
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = inet_addr(ip.c_str());
+    bzero(&(addr.sin_zero),8);
     if (bind(_fd, (const sockaddr*)&addr, sizeof(sockaddr_in)) == -1) {
         ret = ERROR_SOCKET_BIND;
         srs_error("bind socket error. ep=%s:%d, ret=%d", ip.c_str(), port, ret);


### PR DESCRIPTION
CID 42517 (#2 of 2): Uninitialized scalar variable (UNINIT)
4. uninit_use_in_call: Using uninitialized value addr. Field addr.sin_zero is uninitialized when calling bind.

## Summary

Please describe the summary for this PR.

## Details

Add more details about this PR.