### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/trunk/3rdparty/signaling/www/demos/index.html
+++ b/trunk/3rdparty/signaling/www/demos/index.html
@@ -15,7 +15,7 @@
     点击进入<a class="srs_demo" href="room.html?autostart=true">SRS多人通话演示</a>
 </p>
 <script>
-    let roomName = Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).substr(0, 7);
+    let roomName = Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).slice(0, 7);
     let elems = document.getElementsByClassName('srs_demo');
     for (var i = 0; i < elems.length; i++) {
         let elem = elems.item(i);

--- a/trunk/3rdparty/signaling/www/demos/js/srs.sdk.js
+++ b/trunk/3rdparty/signaling/www/demos/js/srs.sdk.js
@@ -154,7 +154,7 @@ function SrsRtcPublisherAsync() {
 
             return {
                 apiUrl: apiUrl, streamUrl: streamUrl, schema: schema, urlObject: urlObject, port: port,
-                tid: Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).substr(0, 7)
+                tid: Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).slice(0, 7)
             };
         },
         parse: function (url) {
@@ -165,19 +165,19 @@ function SrsRtcPublisherAsync() {
                 .replace("rtc://", "http://");
 
             var vhost = a.hostname;
-            var app = a.pathname.substr(1, a.pathname.lastIndexOf("/") - 1);
-            var stream = a.pathname.substr(a.pathname.lastIndexOf("/") + 1);
+            var app = a.pathname.substring(1, a.pathname.lastIndexOf("/"));
+            var stream = a.pathname.slice(a.pathname.lastIndexOf("/") + 1);
 
             // parse the vhost in the params of app, that srs supports.
             app = app.replace("...vhost...", "?vhost=");
             if (app.indexOf("?") >= 0) {
-                var params = app.substr(app.indexOf("?"));
-                app = app.substr(0, app.indexOf("?"));
+                var params = app.slice(app.indexOf("?"));
+                app = app.slice(0, app.indexOf("?"));
 
                 if (params.indexOf("vhost=") > 0) {
-                    vhost = params.substr(params.indexOf("vhost=") + "vhost=".length);
+                    vhost = params.slice(params.indexOf("vhost=") + "vhost=".length);
                     if (vhost.indexOf("&") > 0) {
-                        vhost = vhost.substr(0, vhost.indexOf("&"));
+                        vhost = vhost.slice(0, vhost.indexOf("&"));
                     }
                 }
             }
@@ -194,7 +194,7 @@ function SrsRtcPublisherAsync() {
             // parse the schema
             var schema = "rtmp";
             if (url.indexOf("://") > 0) {
-                schema = url.substr(0, url.indexOf("://"));
+                schema = url.slice(0, url.indexOf("://"));
             }
 
             var port = a.port;
@@ -381,7 +381,7 @@ function SrsRtcPlayerAsync() {
 
             return {
                 apiUrl: apiUrl, streamUrl: streamUrl, schema: schema, urlObject: urlObject, port: port,
-                tid: Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).substr(0, 7)
+                tid: Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).slice(0, 7)
             };
         },
         parse: function (url) {
@@ -392,19 +392,19 @@ function SrsRtcPlayerAsync() {
                 .replace("rtc://", "http://");
 
             var vhost = a.hostname;
-            var app = a.pathname.substr(1, a.pathname.lastIndexOf("/") - 1);
-            var stream = a.pathname.substr(a.pathname.lastIndexOf("/") + 1);
+            var app = a.pathname.substring(1, a.pathname.lastIndexOf("/"));
+            var stream = a.pathname.slice(a.pathname.lastIndexOf("/") + 1);
 
             // parse the vhost in the params of app, that srs supports.
             app = app.replace("...vhost...", "?vhost=");
             if (app.indexOf("?") >= 0) {
-                var params = app.substr(app.indexOf("?"));
-                app = app.substr(0, app.indexOf("?"));
+                var params = app.slice(app.indexOf("?"));
+                app = app.slice(0, app.indexOf("?"));
 
                 if (params.indexOf("vhost=") > 0) {
-                    vhost = params.substr(params.indexOf("vhost=") + "vhost=".length);
+                    vhost = params.slice(params.indexOf("vhost=") + "vhost=".length);
                     if (vhost.indexOf("&") > 0) {
-                        vhost = vhost.substr(0, vhost.indexOf("&"));
+                        vhost = vhost.slice(0, vhost.indexOf("&"));
                     }
                 }
             }
@@ -421,7 +421,7 @@ function SrsRtcPlayerAsync() {
             // parse the schema
             var schema = "rtmp";
             if (url.indexOf("://") > 0) {
-                schema = url.substr(0, url.indexOf("://"));
+                schema = url.slice(0, url.indexOf("://"));
             }
 
             var port = a.port;

--- a/trunk/3rdparty/signaling/www/demos/js/srs.sig.js
+++ b/trunk/3rdparty/signaling/www/demos/js/srs.sig.js
@@ -59,7 +59,7 @@ function SrsRtcSignalingAsync() {
     // The message is a json object.
     self.send = async function (message) {
         return new Promise(function (resolve, reject) {
-            var r = {tid: Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).substr(0, 7), msg: message};
+            var r = {tid: Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).slice(0, 7), msg: message};
             self._internals.msgs[r.tid] = {resolve: resolve, reject: reject};
             self.ws.send(JSON.stringify(r));
         });
@@ -108,7 +108,7 @@ function SrsRtcSignalingParse(location) {
     room = room? room.split('&')[0] : null;
 
     let display = location.href.split('display=')[1];
-    display = display? display.split('&')[0] : Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).toString(16).substr(0, 7);
+    display = display? display.split('&')[0] : Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).toString(16).slice(0, 7);
 
     let autostart = location.href.split('autostart=')[1];
     autostart = autostart && autostart.split('&')[0] === 'true';
@@ -131,10 +131,10 @@ function SrsRtcSignalingParse(location) {
         }
         query = query.replace('?&', '?');
         if (query.lastIndexOf('?') === query.length - 1) {
-            query = query.substr(0, query.length - 1);
+            query = query.slice(0, query.length - 1);
         }
         if (query.lastIndexOf('&') === query.length - 1) {
-            query = query.substr(0, query.length - 1);
+            query = query.slice(0, query.length - 1);
         }
     }
 

--- a/trunk/research/console/js/srs.console.js
+++ b/trunk/research/console/js/srs.console.js
@@ -558,7 +558,7 @@ scApp.filter("sc_filter_number", function(){
 
 scApp.filter("sc_filter_less", function(){
     return function(v) {
-        return v? (v.length > 15? v.substr(0, 15) + "...":v):v;
+        return v? (v.length > 15? v.slice(0, 15) + "...":v):v;
     };
 });
 
@@ -636,7 +636,7 @@ scApp.provider("$sc_server", [function(){
                 var $location = self.$location;
                 var url = $location.absUrl();
                 if (url.indexOf('?') > 0) {
-                    url = url.substr(0, url.indexOf('?'));
+                    url = url.slice(0, url.indexOf('?'));
                 }
                 url += '?';
 

--- a/trunk/research/console/js/winlin.utility.js
+++ b/trunk/research/console/js/winlin.utility.js
@@ -158,11 +158,11 @@ function system_string_trim(str, flag) {
     }
 
     while (system_string_startswith(str, flag)) {
-        str = str.substr(flag.length);
+        str = str.slice(flag.length);
     }
 
     while (system_string_endswith(str, flag)) {
-        str = str.substr(0, str.length - flag.length);
+        str = str.slice(0, str.length - flag.length);
     }
 
     return str;
@@ -227,8 +227,8 @@ function parse_query_string(){
         obj.dir = "/";
         obj.filename = "";
     } else {
-        obj.dir = obj.pathname.substr(0, obj.pathname.lastIndexOf("/"));
-        obj.filename = obj.pathname.substr(obj.pathname.lastIndexOf("/"));
+        obj.dir = obj.pathname.slice(0, obj.pathname.lastIndexOf("/"));
+        obj.filename = obj.pathname.slice(obj.pathname.lastIndexOf("/"));
     }
 
     // pure user query object.
@@ -298,19 +298,19 @@ function parse_rtmp_url(rtmp_url) {
         .replace("rtc://", "http://");
 
     var vhost = a.hostname;
-    var app = a.pathname.substr(1, a.pathname.lastIndexOf("/") - 1);
-    var stream = a.pathname.substr(a.pathname.lastIndexOf("/") + 1);
+    var app = a.pathname.substring(1, a.pathname.lastIndexOf("/"));
+    var stream = a.pathname.slice(a.pathname.lastIndexOf("/") + 1);
 
     // parse the vhost in the params of app, that srs supports.
     app = app.replace("...vhost...", "?vhost=");
     if (app.indexOf("?") >= 0) {
-        var params = app.substr(app.indexOf("?"));
-        app = app.substr(0, app.indexOf("?"));
+        var params = app.slice(app.indexOf("?"));
+        app = app.slice(0, app.indexOf("?"));
 
         if (params.indexOf("vhost=") > 0) {
-            vhost = params.substr(params.indexOf("vhost=") + "vhost=".length);
+            vhost = params.slice(params.indexOf("vhost=") + "vhost=".length);
             if (vhost.indexOf("&") > 0) {
-                vhost = vhost.substr(0, vhost.indexOf("&"));
+                vhost = vhost.slice(0, vhost.indexOf("&"));
             }
         }
     }
@@ -327,7 +327,7 @@ function parse_rtmp_url(rtmp_url) {
     // parse the schema
     var schema = "rtmp";
     if (rtmp_url.indexOf("://") > 0) {
-        schema = rtmp_url.substr(0, rtmp_url.indexOf("://"));
+        schema = rtmp_url.slice(0, rtmp_url.indexOf("://"));
     }
 
     var port = a.port;

--- a/trunk/research/players/js/srs.page.js
+++ b/trunk/research/players/js/srs.page.js
@@ -81,7 +81,7 @@ function build_default_flv_url() {
     }
     uri += "/" + app + "/" + stream + "?" + queries.join('&');
     while (uri.indexOf("?") === uri.length - 1) {
-        uri = uri.substr(0, uri.length - 1);
+        uri = uri.slice(0, uri.length - 1);
     }
 
     return uri;
@@ -110,7 +110,7 @@ function build_default_rtc_url(query) {
 
     var uri = "webrtc://" + server + api + "/" + app + "/" + stream + "?" + queries.join('&');
     while (uri.lastIndexOf("?") === uri.length - 1) {
-        uri = uri.substr(0, uri.length - 1);
+        uri = uri.slice(0, uri.length - 1);
     }
 
     return uri;

--- a/trunk/research/players/js/srs.sdk.js
+++ b/trunk/research/players/js/srs.sdk.js
@@ -148,7 +148,7 @@ function SrsRtcPublisherAsync() {
 
             return {
                 apiUrl: apiUrl, streamUrl: streamUrl, schema: schema, urlObject: urlObject, port: port,
-                tid: Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).substr(0, 7)
+                tid: Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).slice(0, 7)
             };
         },
         parse: function (url) {
@@ -159,19 +159,19 @@ function SrsRtcPublisherAsync() {
                 .replace("rtc://", "http://");
 
             var vhost = a.hostname;
-            var app = a.pathname.substr(1, a.pathname.lastIndexOf("/") - 1);
-            var stream = a.pathname.substr(a.pathname.lastIndexOf("/") + 1);
+            var app = a.pathname.substring(1, a.pathname.lastIndexOf("/"));
+            var stream = a.pathname.slice(a.pathname.lastIndexOf("/") + 1);
 
             // parse the vhost in the params of app, that srs supports.
             app = app.replace("...vhost...", "?vhost=");
             if (app.indexOf("?") >= 0) {
-                var params = app.substr(app.indexOf("?"));
-                app = app.substr(0, app.indexOf("?"));
+                var params = app.slice(app.indexOf("?"));
+                app = app.slice(0, app.indexOf("?"));
 
                 if (params.indexOf("vhost=") > 0) {
-                    vhost = params.substr(params.indexOf("vhost=") + "vhost=".length);
+                    vhost = params.slice(params.indexOf("vhost=") + "vhost=".length);
                     if (vhost.indexOf("&") > 0) {
-                        vhost = vhost.substr(0, vhost.indexOf("&"));
+                        vhost = vhost.slice(0, vhost.indexOf("&"));
                     }
                 }
             }
@@ -188,7 +188,7 @@ function SrsRtcPublisherAsync() {
             // parse the schema
             var schema = "rtmp";
             if (url.indexOf("://") > 0) {
-                schema = url.substr(0, url.indexOf("://"));
+                schema = url.slice(0, url.indexOf("://"));
             }
 
             var port = a.port;
@@ -383,7 +383,7 @@ function SrsRtcPlayerAsync() {
 
             return {
                 apiUrl: apiUrl, streamUrl: streamUrl, schema: schema, urlObject: urlObject, port: port,
-                tid: Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).substr(0, 7)
+                tid: Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).slice(0, 7)
             };
         },
         parse: function (url) {
@@ -394,19 +394,19 @@ function SrsRtcPlayerAsync() {
                 .replace("rtc://", "http://");
 
             var vhost = a.hostname;
-            var app = a.pathname.substr(1, a.pathname.lastIndexOf("/") - 1);
-            var stream = a.pathname.substr(a.pathname.lastIndexOf("/") + 1);
+            var app = a.pathname.substring(1, a.pathname.lastIndexOf("/"));
+            var stream = a.pathname.slice(a.pathname.lastIndexOf("/") + 1);
 
             // parse the vhost in the params of app, that srs supports.
             app = app.replace("...vhost...", "?vhost=");
             if (app.indexOf("?") >= 0) {
-                var params = app.substr(app.indexOf("?"));
-                app = app.substr(0, app.indexOf("?"));
+                var params = app.slice(app.indexOf("?"));
+                app = app.slice(0, app.indexOf("?"));
 
                 if (params.indexOf("vhost=") > 0) {
-                    vhost = params.substr(params.indexOf("vhost=") + "vhost=".length);
+                    vhost = params.slice(params.indexOf("vhost=") + "vhost=".length);
                     if (vhost.indexOf("&") > 0) {
-                        vhost = vhost.substr(0, vhost.indexOf("&"));
+                        vhost = vhost.slice(0, vhost.indexOf("&"));
                     }
                 }
             }
@@ -423,7 +423,7 @@ function SrsRtcPlayerAsync() {
             // parse the schema
             var schema = "rtmp";
             if (url.indexOf("://") > 0) {
-                schema = url.substr(0, url.indexOf("://"));
+                schema = url.slice(0, url.indexOf("://"));
             }
 
             var port = a.port;

--- a/trunk/research/players/js/winlin.utility.js
+++ b/trunk/research/players/js/winlin.utility.js
@@ -158,11 +158,11 @@ function system_string_trim(str, flag) {
     }
 
     while (system_string_startswith(str, flag)) {
-        str = str.substr(flag.length);
+        str = str.slice(flag.length);
     }
 
     while (system_string_endswith(str, flag)) {
-        str = str.substr(0, str.length - flag.length);
+        str = str.slice(0, str.length - flag.length);
     }
 
     return str;
@@ -227,8 +227,8 @@ function parse_query_string(){
         obj.dir = "/";
         obj.filename = "";
     } else {
-        obj.dir = obj.pathname.substr(0, obj.pathname.lastIndexOf("/"));
-        obj.filename = obj.pathname.substr(obj.pathname.lastIndexOf("/"));
+        obj.dir = obj.pathname.slice(0, obj.pathname.lastIndexOf("/"));
+        obj.filename = obj.pathname.slice(obj.pathname.lastIndexOf("/"));
     }
 
     // pure user query object.
@@ -298,19 +298,19 @@ function parse_rtmp_url(rtmp_url) {
         .replace("rtc://", "http://");
 
     var vhost = a.hostname;
-    var app = a.pathname.substr(1, a.pathname.lastIndexOf("/") - 1);
-    var stream = a.pathname.substr(a.pathname.lastIndexOf("/") + 1);
+    var app = a.pathname.substring(1, a.pathname.lastIndexOf("/"));
+    var stream = a.pathname.slice(a.pathname.lastIndexOf("/") + 1);
 
     // parse the vhost in the params of app, that srs supports.
     app = app.replace("...vhost...", "?vhost=");
     if (app.indexOf("?") >= 0) {
-        var params = app.substr(app.indexOf("?"));
-        app = app.substr(0, app.indexOf("?"));
+        var params = app.slice(app.indexOf("?"));
+        app = app.slice(0, app.indexOf("?"));
 
         if (params.indexOf("vhost=") > 0) {
-            vhost = params.substr(params.indexOf("vhost=") + "vhost=".length);
+            vhost = params.slice(params.indexOf("vhost=") + "vhost=".length);
             if (vhost.indexOf("&") > 0) {
-                vhost = vhost.substr(0, vhost.indexOf("&"));
+                vhost = vhost.slice(0, vhost.indexOf("&"));
             }
         }
     }
@@ -327,7 +327,7 @@ function parse_rtmp_url(rtmp_url) {
     // parse the schema
     var schema = "rtmp";
     if (rtmp_url.indexOf("://") > 0) {
-        schema = rtmp_url.substr(0, rtmp_url.indexOf("://"));
+        schema = rtmp_url.slice(0, rtmp_url.indexOf("://"));
     }
 
     var port = a.port;

--- a/trunk/research/players/srs_gb28181.html
+++ b/trunk/research/players/srs_gb28181.html
@@ -556,19 +556,19 @@
                     .replace("rtc://", "http://");
 
                 var vhost = a.hostname;
-                var app = a.pathname.substr(1, a.pathname.lastIndexOf("/") - 1);
-                var stream = a.pathname.substr(a.pathname.lastIndexOf("/") + 1);
+                var app = a.pathname.substring(1, a.pathname.lastIndexOf("/"));
+                var stream = a.pathname.slice(a.pathname.lastIndexOf("/") + 1);
 
                 // parse the vhost in the params of app, that srs supports.
                 app = app.replace("...vhost...", "?vhost=");
                 if (app.indexOf("?") >= 0) {
-                    var params = app.substr(app.indexOf("?"));
-                    app = app.substr(0, app.indexOf("?"));
+                    var params = app.slice(app.indexOf("?"));
+                    app = app.slice(0, app.indexOf("?"));
 
                     if (params.indexOf("vhost=") > 0) {
-                        vhost = params.substr(params.indexOf("vhost=") + "vhost=".length);
+                        vhost = params.slice(params.indexOf("vhost=") + "vhost=".length);
                         if (vhost.indexOf("&") > 0) {
-                            vhost = vhost.substr(0, vhost.indexOf("&"));
+                            vhost = vhost.slice(0, vhost.indexOf("&"));
                         }
                     }
                 }
@@ -585,7 +585,7 @@
                 // parse the schema
                 var schema = "rtmp";
                 if (url.indexOf("://") > 0) {
-                    schema = url.substr(0, url.indexOf("://"));
+                    schema = url.slice(0, url.indexOf("://"));
                 }
 
                 var port = a.port;

--- a/trunk/research/players/srs_publisher.html
+++ b/trunk/research/players/srs_publisher.html
@@ -56,7 +56,7 @@
             url = window.location.href.replace('http:', 'https:');
         }
 
-        url = url.substr(0, url.lastIndexOf('/')) + '/srs_publisher_flash.html';
+        url = url.substring(0, url.lastIndexOf('/')) + '/srs_publisher_flash.html';
         $('#https_publisher').attr('href', url);
     });
 </script>

--- a/trunk/research/players/srs_publisher_flash.html
+++ b/trunk/research/players/srs_publisher_flash.html
@@ -335,7 +335,7 @@
         $("#btn_publish").click(on_user_publish);
 
         // for publish, we use randome stream name.
-        $("#txt_url").val($("#txt_url").val() + "." + Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).substr(0, 7));
+        $("#txt_url").val($("#txt_url").val() + "." + Number(parseInt(new Date().getTime()*Math.random()*100)).toString(16).slice(0, 7));
 
         // start the publisher.
         srs_publisher = new SrsPublisher("local_publisher", 430, 185);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.