### PR TITLE
SRT: Fix the cache and update for SequenceHeader.

### DIFF
--- a/trunk/src/srt/srt_to_rtmp.cpp
+++ b/trunk/src/srt/srt_to_rtmp.cpp
@@ -308,7 +308,7 @@ void rtmp_client::close() {
     _rtmp_conn_ptr->close();
     _rtmp_conn_ptr = nullptr;
     
-    //关闭时重置音频和视频解码信息
+    //when close connection, reset audio and video dec parameters
     _aac_specific_config = "";
     _h264_sps = "";
     _h264_pps = "";
@@ -339,7 +339,7 @@ srs_error_t rtmp_client::connect() {
 
     _rtmp_conn_ptr = std::make_shared<SrsSimpleRtmpClient>(_url, cto, sto);
 
-     //增加清除发送缓存
+     //clear send queue
      srs_trace("clear send queue url:%s", _url.c_str());
      _rtmp_queue.clear_queue();
 
@@ -782,7 +782,7 @@ bool rtmp_packet_queue::get_rtmp_data(rtmp_packet_info_s& packet_info) {
     return true;
 }
 
-//清除发送缓存
+//clear send queue
 void rtmp_packet_queue::clear_queue() {
     _send_map.clear();
 }

--- a/trunk/src/srt/srt_to_rtmp.cpp
+++ b/trunk/src/srt/srt_to_rtmp.cpp
@@ -308,6 +308,10 @@ void rtmp_client::close() {
     _rtmp_conn_ptr->close();
     _rtmp_conn_ptr = nullptr;
     
+    //关闭时重置音频和视频解码信息
+    _aac_specific_config = "";
+    _h264_sps = "";
+    _h264_pps = "";
 }
 
 int64_t rtmp_client::get_last_live_ts() {
@@ -334,6 +338,10 @@ srs_error_t rtmp_client::connect() {
     }
 
     _rtmp_conn_ptr = std::make_shared<SrsSimpleRtmpClient>(_url, cto, sto);
+
+     //增加清除发送缓存
+     srs_trace("clear send queue url:%s", _url.c_str());
+     _rtmp_queue.clear_queue();
 
     if ((err = _rtmp_conn_ptr->connect()) != srs_success) {
         close();
@@ -772,4 +780,9 @@ bool rtmp_packet_queue::get_rtmp_data(rtmp_packet_info_s& packet_info) {
     _send_map.erase(iter);
 
     return true;
+}
+
+//清除发送缓存
+void rtmp_packet_queue::clear_queue() {
+    _send_map.clear();
 }

--- a/trunk/src/srt/srt_to_rtmp.hpp
+++ b/trunk/src/srt/srt_to_rtmp.hpp
@@ -55,7 +55,7 @@ public:
     void insert_rtmp_data(unsigned char* data, int len, int64_t dts, char media_type);
     bool get_rtmp_data(rtmp_packet_info_s& packet_info);
 
-    //清除发送缓存
+    //clear send queue
     void clear_queue();
 
 private:

--- a/trunk/src/srt/srt_to_rtmp.hpp
+++ b/trunk/src/srt/srt_to_rtmp.hpp
@@ -55,6 +55,9 @@ public:
     void insert_rtmp_data(unsigned char* data, int len, int64_t dts, char media_type);
     bool get_rtmp_data(rtmp_packet_info_s& packet_info);
 
+    //清除发送缓存
+    void clear_queue();
+
 private:
     bool is_ready();
 


### PR DESCRIPTION
## Summary

1. Problem Reproduction:

The camera pushes the audio and video streams through SRT to SRS. During the testing process, it was found that the browser playback end cannot last for a night and will be interrupted. Only by restarting SRS or the camera can it be restored.

2. Problem cause:

The cause is due to SequenceHeader updates and caching issues.

## Details

![Audio Flow](https://user-images.githubusercontent.com/62530869/157189999-b42cc36b-a991-4770-a0f4-347525bb2967.jpg)

![Video Flow](https://user-images.githubusercontent.com/62530869/157188760-3c20ed84-229a-473b-9a57-0922d799f8ed.jpg)



---------

`TRANS_BY_GPT3`