### PR TITLE
HTTP-FLV:播放无流的流，没有超时或404

### DIFF
--- a/trunk/conf/clion-edge.conf
+++ b/trunk/conf/clion-edge.conf
@@ -1,0 +1,24 @@
+
+listen              19350;
+pid                 ./objs/srs-edge.pid;
+max_connections     1000;
+daemon              off;
+srs_log_tank        console;
+
+http_server {
+    enabled         on;
+    listen          80;
+    dir             ./objs/nginx/html;
+}
+
+vhost __defaultVhost__ {
+    cluster {
+        mode            remote;
+        origin          127.0.0.1:1935;
+    }
+
+    http_remux {
+        enabled     on;
+        mount       [vhost]/[app]/[stream].flv;
+    }
+}

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -794,6 +794,10 @@ vhost play.srs.com {
         # while the sequence header is not changed yet.
         # default: off
         reduce_sequence_header  on;
+
+        # set origin play timeout
+        # default: 15
+        timeout 15;
     }
 }
 

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -626,6 +626,10 @@ vhost cluster.srs.com {
         # @remark The FLV might use different signature(in query string) to RTMP.
         # Default: off
         follow_client off;
+
+        # For edge(mode remote),when edge connect origin cluster retry times
+        # Default: 0
+        retry_times 0;
     }
 }
 

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -4586,6 +4586,27 @@ srs_utime_t SrsConfig::get_publish_normal_timeout(string vhost)
     return (srs_utime_t)(::atoi(conf->arg0().c_str()) * SRS_UTIME_MILLISECONDS);
 }
 
+srs_utime_t SrsConfig::get_play_timeout(std::string vhost){
+    static srs_utime_t DEFAULT = 15 * SRS_UTIME_SECONDS;
+
+    SrsConfDirective* conf = get_vhost(vhost);
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("play");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("timeout");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
+    return (srs_utime_t)(::atoi(conf->arg0().c_str()) * SRS_UTIME_SECONDS);
+}
+
 int SrsConfig::get_global_chunk_size()
 {
     SrsConfDirective* conf = root->get("chunk_size");

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -4935,6 +4935,25 @@ SrsConfDirective* SrsConfig::get_vhost_edge_origin(string vhost)
     return conf->get("origin");
 }
 
+int SrsConfig::get_vhost_edge_retry_times(string vhost)
+{
+    static int DEFAULT = 0;
+    SrsConfDirective* conf = get_vhost(vhost);
+    if (!conf) {
+        return NULL;
+    }
+
+    conf = conf->get("cluster");
+    if (!conf) {
+        return NULL;
+    }
+    conf = conf->get("retry_times");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+    return ::atoi(conf->arg0().c_str());
+}
+
 string SrsConfig::get_vhost_edge_protocol(string vhost)
 {
     static string DEFAULT = "rtmp";

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -614,7 +614,8 @@ public:
     virtual srs_utime_t get_publish_1stpkt_timeout(std::string vhost);
     // The normal packet timeout in srs_utime_t for encoder.
     virtual srs_utime_t get_publish_normal_timeout(std::string vhost);
-    // play timeout
+    // Get the http play timeout (second)
+    // @param vhost, the vhost to get the play timeout second
     virtual srs_utime_t get_play_timeout(std::string vhost);
 private:
     // Get the global chunk size.
@@ -727,6 +728,8 @@ public:
     // Get the origin config of edge,
     // specifies the origin ip address, port.
     virtual SrsConfDirective* get_vhost_edge_origin(std::string vhost);
+    // Get the edge connect to origin retry limit times
+    virtual int get_vhost_edge_retry_times(std::string vhost);
     // Get the procotol to connect to origin server.
     virtual std::string get_vhost_edge_protocol(std::string vhost);
     // Whether follow client protocol to connect to origin.

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -614,6 +614,8 @@ public:
     virtual srs_utime_t get_publish_1stpkt_timeout(std::string vhost);
     // The normal packet timeout in srs_utime_t for encoder.
     virtual srs_utime_t get_publish_normal_timeout(std::string vhost);
+    // play timeout
+    virtual srs_utime_t get_play_timeout(std::string vhost);
 private:
     // Get the global chunk size.
     virtual int get_global_chunk_size();

--- a/trunk/src/app/srs_app_edge.cpp
+++ b/trunk/src/app/srs_app_edge.cpp
@@ -454,10 +454,10 @@ srs_error_t SrsEdgeIngester::cycle()
     int retry_limit = _srs_config->get_vhost_edge_retry_times(req->vhost);
     SrsConfDirective* conf = _srs_config->get_vhost_edge_origin(req->vhost);
     int origin_count = 1;
-    if (conf != nullptr && !conf->args.empty()) {
+    if (conf != NULL && !conf->args.empty()) {
         origin_count = (int) conf->args.size();
     }
-    u_int32_t retry_times = 0;
+    int retry_times = 0;
     while (true) {
         // We always check status first.
         // @see https://github.com/ossrs/srs/issues/1634#issuecomment-597571561

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -157,6 +157,9 @@
 #define ERROR_RTMP_MESSAGE_CREATE           2053
 #define ERROR_RTMP_PROXY_EXCEED             2054
 #define ERROR_RTMP_CREATE_STREAM_DEPTH      2055
+#define ERROR_RTMP_INGEST_FAIL              2056
+#define ERROR_RTMP_STREAM_EOF               2057
+#define ERROR_RTMP_PLAY_TIMEOUT             2058
 //
 // The system control message,
 // It's not an error, but special control logic.


### PR DESCRIPTION
[HTTP-FLV: 播放无流的流，没有超时或404](https://github.com/ossrs/srs/issues/1134)

1.如果origin找不到流时，直接404处理
2.如果origin可以找到流，但消费者15秒没有消费到数据时，http-flv返回流结束
3.对于edge，由于找不到流后会回源到origin，这里添加回源重试次数限制（默认不限制），由于origin支持多个备份源站，因此重试次数限制是指将所有源站都重试一轮的次数
4.修改了备份源间重试的等待时间改为0，每一轮重试间隔用原来的3s，保证备份源快速查找