### PR TITLE
bugfix: hls ts segment does not start with key frame for a stream with audio and video

### DIFF
--- a/trunk/src/app/srs_app_hls.cpp
+++ b/trunk/src/app/srs_app_hls.cpp
@@ -977,7 +977,7 @@ srs_error_t SrsHlsController::write_audio(SrsAudioFrame* frame, int64_t pts)
     // @see https://github.com/ossrs/srs/issues/151
     // we use absolutely overflow of segment to make jwplayer/ffplay happy
     // @see https://github.com/ossrs/srs/issues/151#issuecomment-71155184
-    if (tsmc->audio && muxer->is_segment_absolutely_overflow()) {
+    if (muxer->pure_audio() && tsmc->audio && muxer->is_segment_absolutely_overflow()) {
         if ((err = reap_segment()) != srs_success) {
             return srs_error_wrap(err, "hls: reap segment");
         }


### PR DESCRIPTION
bugfix: hls ts segment does not start with key frame for a stream with audio and video.

- my hls config as below:
```
vhost __defaultVhost__ {
    hls {
        enabled         on;
        hls_fragment    6;
        hls_td_ratio    1.0;
        hls_aof_ratio   1.0;
        hls_window      30;
        hls_path        ./objs/nginx/html;
        hls_m3u8_file   [app]/[stream]/[stream].m3u8;
        hls_ts_file     [app]/[stream]/[stream]-[2006][01][02][15][04]-[seq].ts;
        hls_ts_floor    off;
    }
}
```
- bug description as below:
For a stream with audio and video, some ts segment not start with key frame. 

- root cause is as below: 
`reap_segment` is triggered both in `write_audio` and `write_video`. 
`is_segment_absolutely_overflow` true when write audio. it is early then `is_segment_overflow` when write video.

- bug fix solution as below:
`is_segment_absolutely_overflow` should only check for  a stream with pure audio.


