### PR TITLE
SRS has crashed before first keyframe arriving on rtc2rtmp.

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -305,7 +305,7 @@ private:
     const static uint16_t s_cache_size = 512;
     RtcPacketCache cache_video_pkts_[s_cache_size];
     uint16_t header_sn_;
-    uint16_t lost_sn_;
+    int32_t lost_sn_;
     int64_t rtp_key_frame_ts_;
 public:
     SrsRtmpFromRtcBridger(SrsLiveSource *src);


### PR DESCRIPTION
https://github.com/ossrs/srs/issues/3034

1.从SrsRtmpFromRtcBridger::packet_video_rtmp (this=0x10ddc420, start=0, end=22704)可以看出是有故障的，一般情况下不可能有这么多的丢包(distance(0, 22704))；
2.继续看header_sn_=0,rtp_key_frame_ts_=-1，猜测没有收到过key_frame,从日志中可以证明这点，过滤条件ContextId=q38p5iuu）；
3.进而推出lost_sn_没有被初始化（随机值22705），巧合pkt->header.get_sequence也是22705，程序能走到srs_app_rtc_source.cpp:1451这行。
最终就crash了。
结论:lost_sn_没有被初始化引发的惨案。
webrtc的起始sequence是个随机值，只要首帧不是key_frame，在一个gop内sequence能够增长到lost_sn_都会引发crash。