### PR TITLE
WebRTC: Fix no audio and video issue for Firefox.

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -261,7 +261,7 @@ private:
     uint16_t video_sequence;
     uint32_t audio_ssrc;
     uint32_t video_ssrc;
-
+    uint8_t audio_payload_type_;
     uint8_t video_payload_type_;
 public:
     SrsRtcFromRtmpBridge(SrsRtcSource* source);


### PR DESCRIPTION
#3041 

After the RTC starts streaming, the video payload type corresponding to the RTC source will change due to the SDP negotiation result.

If rtmp to rtc or srt to rtc occurs afterwards, the bridge constructs the video payload type of the rtp packet as the default value 102. This mismatch with the previous situation causes the webrtc receiver to not correctly obtain the video track.

Solution: Set the value of the video payload type for constructing the rtp packet in the bridge to match the video payload type of the rtc source.


---------

`TRANS_BY_GPT3`