### PR TITLE
WebRTC: Fix missing type in track desc when backup H.264 payload type is chosen.

### DIFF
--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -3015,6 +3015,7 @@ srs_error_t SrsRtcConnection::negotiate_publish_capability(SrsRtcUserConfig* ruc
                     }
                 }
 
+                track_desc->type_ = "video";
                 track_desc->set_codec_payload((SrsCodecPayload*)video_payload);
                 srs_warn("choose backup H.264 payload type=%d", payload.payload_type_);
             }


### PR DESCRIPTION
When the backup H.264 payload type is selected, the track desc type is not set.
