### PR TITLE
Fix the recursively included issue for srs_core_time.hpp

### DIFF
--- a/trunk/src/core/srs_core_time.hpp
+++ b/trunk/src/core/srs_core_time.hpp
@@ -7,8 +7,15 @@
 #ifndef SRS_CORE_TIME_HPP
 #define SRS_CORE_TIME_HPP
 
+#if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600) && !defined(__WINE__)
+#include <BaseTsd.h>
+typedef __int64 int64_t;
+#else
+#include <stdint.h>
+#endif
+
 // Time and duration unit, in us.
-typedef signed long int srs_utime_t;
+typedef int64_t srs_utime_t;
 
 // The time unit in ms, for example 100 * SRS_UTIME_MILLISECONDS means 100ms.
 #define SRS_UTIME_MILLISECONDS 1000

--- a/trunk/src/core/srs_core_time.hpp
+++ b/trunk/src/core/srs_core_time.hpp
@@ -7,10 +7,8 @@
 #ifndef SRS_CORE_TIME_HPP
 #define SRS_CORE_TIME_HPP
 
-#include <srs_core.hpp>
-
 // Time and duration unit, in us.
-typedef int64_t srs_utime_t;
+typedef signed long int srs_utime_t;
 
 // The time unit in ms, for example 100 * SRS_UTIME_MILLISECONDS means 100ms.
 #define SRS_UTIME_MILLISECONDS 1000


### PR DESCRIPTION
Please describe the summary for this PR.

1. In included file: main file cannot be included recursively when building a preamble
    clang(pp_including_mainfile_in_preamble)
    srs_core.hpp(43, 10): Error occurred here
    Circular reference to header files

---------

`TRANS_BY_GPT3`