### PR TITLE
Update srs_core_performance.hpp to stop recursively including.

### DIFF
--- a/trunk/src/core/srs_core_performance.hpp
+++ b/trunk/src/core/srs_core_performance.hpp
@@ -7,8 +7,6 @@
 #ifndef SRS_CORE_PERFORMANCE_HPP
 #define SRS_CORE_PERFORMANCE_HPP
 
-#include <srs_core.hpp>
-
 /**
  * this file defines the perfromance options.
  */


### PR DESCRIPTION
Please describe the summary for this PR.

1. In included file: main file cannot be included recursively when building a preamble
    clang(pp_including_mainfile_in_preamble)
    srs_core.hpp(43, 10): Error occurred here
    Circular reference of header files

---------

`TRANS_BY_GPT3`