### PR TITLE
Print warning log when SRT push stream audio duration too large.

### DIFF
--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -639,6 +639,7 @@ tencentcloud_apm {
     # Overwrite by env SRS_TENCENTCLOUD_APM_TOKEN
     token xxxxxxxx;
     # The APM endpoint. See https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/otlp/otlptrace
+    # Please note that 4317 is for GRPC/HTTP2, while SRS only support HTTP and the port shoule be 55681.
     # Overwrite by env SRS_TENCENTCLOUD_APM_ENDPOINT
     endpoint ap-guangzhou.apm.tencentcs.com:55681;
     # The service.name of resource.

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -635,7 +635,12 @@ tencentcloud_apm {
     # Overwrite by env SRS_TENCENTCLOUD_APM_ENABLED
     # default: off
     enabled on;
-    # The APM token for authentication. See https://console.cloud.tencent.com/apm/monitor/access
+    # The APM team or business system ID, to which spans belongs to. For example, the team is apm-FsOsPOIMl (just an
+    # example, not available), please get your team from https://console.cloud.tencent.com/apm/monitor/team
+    # Overwrite by env SRS_TENCENTCLOUD_APM_TEAM
+    team apm-xxxxxxxxx;
+    # The APM token for authentication. For example, the token is xzddEaegsxGadEpGEDFx (just an example, not available),
+    # please get your token from https://console.cloud.tencent.com/apm/monitor/access
     # Overwrite by env SRS_TENCENTCLOUD_APM_TOKEN
     token xxxxxxxx;
     # The APM endpoint. See https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/otlp/otlptrace

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -3468,6 +3468,25 @@ bool SrsConfig::get_tencentcloud_apm_enabled()
     return SRS_CONF_PERFER_FALSE(conf->arg0());
 }
 
+string SrsConfig::get_tencentcloud_apm_team()
+{
+    SRS_OVERWRITE_BY_ENV_STRING("SRS_TENCENTCLOUD_APM_TEAM");
+
+    static string DEFAULT = "";
+
+    SrsConfDirective* conf = root->get("tencentcloud_apm");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("team");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    return conf->arg0();
+}
+
 string SrsConfig::get_tencentcloud_apm_token()
 {
     SRS_OVERWRITE_BY_ENV_STRING("SRS_TENCENTCLOUD_APM_TOKEN");

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -470,6 +470,7 @@ public:
     virtual std::string get_tencentcloud_cls_endpoint();
     virtual std::string get_tencentcloud_cls_topic_id();
     virtual bool get_tencentcloud_apm_enabled();
+    virtual std::string get_tencentcloud_apm_team();
     virtual std::string get_tencentcloud_apm_token();
     virtual std::string get_tencentcloud_apm_endpoint();
     virtual std::string get_tencentcloud_apm_service_name();

--- a/trunk/src/app/srs_app_mpegts_udp.cpp
+++ b/trunk/src/app/srs_app_mpegts_udp.cpp
@@ -417,7 +417,7 @@ srs_error_t SrsMpegtsOverUdp::write_h264_sps_pps(uint32_t dts, uint32_t pts)
     
     // h264 raw to h264 packet.
     std::string sh;
-    if ((err = avc->mux_sequence_header(h264_sps, h264_pps, dts, pts, sh)) != srs_success) {
+    if ((err = avc->mux_sequence_header(h264_sps, h264_pps, sh)) != srs_success) {
         return srs_error_wrap(err, "mux sequence header");
     }
     

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -35,6 +35,7 @@
 #endif
 
 #include <srs_protocol_kbps.hpp>
+#include <srs_protocol_raw_avc.hpp>
 
 // The NACK sent by us(SFU).
 SrsPps* _srs_pps_snack = NULL;
@@ -1480,30 +1481,30 @@ srs_error_t SrsRtmpFromRtcBridge::packet_video_key_frame(SrsRtpPacket* pkt)
         if (NULL == sps || NULL == pps) {
             return srs_error_new(ERROR_RTC_RTP_MUXER, "no sps or pps in stap-a rtp. sps: %p, pps:%p", sps, pps);
         } else {
-            //type_codec1 + avc_type + composition time + fix header + count of sps + len of sps + sps + count of pps + len of pps + pps
-            int nb_payload = 1 + 1 + 3 + 5 + 1 + 2 + sps->size + 1 + 2 + pps->size;
+            // h264 raw to h264 packet.
+            std::string sh;
+            SrsRawH264Stream* avc = new SrsRawH264Stream();
+            SrsAutoFree(SrsRawH264Stream, avc);
+
+            if ((err = avc->mux_sequence_header(string(sps->bytes, sps->size), string(pps->bytes, pps->size), sh)) != srs_success) {
+                return srs_error_wrap(err, "mux sequence header");
+            }
+
+            // h264 packet to flv packet.
+            char* flv = NULL;
+            int nb_flv = 0;
+            if ((err = avc->mux_avc2flv(sh, SrsVideoAvcFrameTypeKeyFrame, SrsVideoAvcFrameTraitSequenceHeader, pkt->get_avsync_time(),
+                    pkt->get_avsync_time(), &flv, &nb_flv)) != srs_success) {
+                return srs_error_wrap(err, "avc to flv");
+            }
+
+            SrsMessageHeader header;
+            header.initialize_video(nb_flv, pkt->get_avsync_time(), 1);
             SrsCommonMessage rtmp;
-            rtmp.header.initialize_video(nb_payload, pkt->get_avsync_time(), 1);
-            rtmp.create_payload(nb_payload);
-            rtmp.size = nb_payload;
-            SrsBuffer payload(rtmp.payload, rtmp.size);
-            //TODO: call api
-            payload.write_1bytes(0x17);// type(4 bits): key frame; code(4bits): avc
-            payload.write_1bytes(0x0); // avc_type: sequence header
-            payload.write_1bytes(0x0); // composition time
-            payload.write_1bytes(0x0);
-            payload.write_1bytes(0x0);
-            payload.write_1bytes(0x01); // version
-            payload.write_1bytes(sps->bytes[1]);
-            payload.write_1bytes(sps->bytes[2]);
-            payload.write_1bytes(sps->bytes[3]);
-            payload.write_1bytes(0xff);
-            payload.write_1bytes(0xe1);
-            payload.write_2bytes(sps->size);
-            payload.write_bytes(sps->bytes, sps->size);
-            payload.write_1bytes(0x01);
-            payload.write_2bytes(pps->size);
-            payload.write_bytes(pps->bytes, pps->size);
+            if ((err = rtmp.create(&header, flv, nb_flv)) != srs_success) {
+                return srs_error_wrap(err, "create rtmp");
+            }
+
             if ((err = source_->on_video(&rtmp)) != srs_success) {
                 return err;
             }

--- a/trunk/src/app/srs_app_srt_source.cpp
+++ b/trunk/src/app/srs_app_srt_source.cpp
@@ -18,6 +18,7 @@ using namespace std;
 #include <srs_protocol_rtmp_stack.hpp>
 #include <srs_app_source.hpp>
 #include <srs_app_statistic.hpp>
+#include <srs_app_pithy_print.hpp>
 
 SrsSrtPacket::SrsSrtPacket()
 {
@@ -250,14 +251,21 @@ SrsRtmpFromSrtBridge::SrsRtmpFromSrtBridge(SrsLiveSource* source) : ISrsSrtSourc
     sps_ = "";
     pps_ = "";
 
-    live_source_ = source;
     req_ = NULL;
+    live_source_ = source;
+
+    video_streamid_ = 1;
+    audio_streamid_ = 2;
+
+    pp_audio_duration_ = new SrsAlonePithyPrint();
 }
 
 SrsRtmpFromSrtBridge::~SrsRtmpFromSrtBridge()
 {
     srs_freep(ts_ctx_);
     srs_freep(req_);
+
+    srs_freep(pp_audio_duration_);
 }
 
 srs_error_t SrsRtmpFromSrtBridge::on_publish()
@@ -450,7 +458,7 @@ srs_error_t SrsRtmpFromSrtBridge::check_sps_pps_change(SrsTsMessage* msg)
     }
 
     SrsMessageHeader header;
-    header.initialize_video(nb_flv, dts, 1);
+    header.initialize_video(nb_flv, dts, video_streamid_);
     SrsCommonMessage rtmp;
     if ((err = rtmp.create(&header, flv, nb_flv)) != srs_success) {
         return srs_error_wrap(err, "create rtmp");
@@ -488,7 +496,7 @@ srs_error_t SrsRtmpFromSrtBridge::on_h264_frame(SrsTsMessage* msg, vector<pair<c
     }
 
     SrsCommonMessage rtmp;
-    rtmp.header.initialize_video(frame_size, dts, 1/*streamid*/);
+    rtmp.header.initialize_video(frame_size, dts, video_streamid_);
     rtmp.create_payload(frame_size);
     rtmp.size = frame_size;
     SrsBuffer payload(rtmp.payload, rtmp.size);
@@ -530,6 +538,7 @@ srs_error_t SrsRtmpFromSrtBridge::on_ts_audio(SrsTsMessage* msg, SrsBuffer* avs)
     uint32_t pts = (uint32_t)(msg->pts / 90);
 
     int frame_idx = 0;
+    int duration_ms = 0;
     
     // send each frame.
     while (!avs->empty()) {
@@ -567,6 +576,7 @@ srs_error_t SrsRtmpFromSrtBridge::on_ts_audio(SrsTsMessage* msg, SrsBuffer* avs)
             default: sample_rate = 44100; break;
         }
         uint32_t frame_pts = (double)pts + (frame_idx * (1024.0 * 1000.0 / sample_rate));
+        duration_ms += 1024.0 * 1000.0 / sample_rate;
         ++frame_idx;
 
         if ((err = check_audio_sh_change(msg, frame_pts)) != srs_success) {
@@ -576,6 +586,13 @@ srs_error_t SrsRtmpFromSrtBridge::on_ts_audio(SrsTsMessage* msg, SrsBuffer* avs)
         if ((err = on_aac_frame(msg, frame_pts, frame, frame_size)) != srs_success) {
             return srs_error_wrap(err, "audio frame");
         }
+    }
+
+    pp_audio_duration_->elapse();
+
+    if ((duration_ms >= 200) && pp_audio_duration_->can_print()) {
+        srs_warn("srt to rtmp, audio duration=%dms too large, audio frames=%d, may cause high latency and AV synchronization errors, "
+            "read https://ossrs.io/lts/en-us/docs/v5/doc/srt-codec#ffmpeg-push-srt-stream", duration_ms, frame_idx);
     }
     
     return err;
@@ -595,7 +612,7 @@ srs_error_t SrsRtmpFromSrtBridge::check_audio_sh_change(SrsTsMessage* msg, uint3
     int rtmp_len = audio_sh_.size() + 2;
 
     SrsCommonMessage rtmp;
-    rtmp.header.initialize_audio(rtmp_len, pts, 1);
+    rtmp.header.initialize_audio(rtmp_len, pts, audio_streamid_);
     rtmp.create_payload(rtmp_len);
     rtmp.size = rtmp_len;
 
@@ -619,7 +636,7 @@ srs_error_t SrsRtmpFromSrtBridge::on_aac_frame(SrsTsMessage* msg, uint32_t pts, 
     int rtmp_len = frame_size + 2/* 2 bytes of flv audio tag header*/;
 
     SrsCommonMessage rtmp;
-    rtmp.header.initialize_audio(rtmp_len, pts, 2/*streamid*/);
+    rtmp.header.initialize_audio(rtmp_len, pts, audio_streamid_);
     rtmp.create_payload(rtmp_len);
     rtmp.size = rtmp_len;
 

--- a/trunk/src/app/srs_app_srt_source.hpp
+++ b/trunk/src/app/srs_app_srt_source.hpp
@@ -20,6 +20,7 @@ class SrsSharedPtrMessage;
 class SrsRequest;
 class SrsLiveSource;
 class SrsSrtSource;
+class SrsAlonePithyPrint;
 
 // The SRT packet with shared message.
 class SrsSrtPacket
@@ -136,6 +137,13 @@ private:
 
     SrsRequest* req_;
     SrsLiveSource* live_source_;
+
+    // SRT to rtmp, video stream id.
+    int video_streamid_;
+    // SRT to rtmp, audio stream id.
+    int audio_streamid_;
+    // Cycle print when audio duration too large because mpegts may merge multi audio frame in one pes packet.
+    SrsAlonePithyPrint* pp_audio_duration_;
 };
 
 class SrsSrtSource

--- a/trunk/src/app/srs_app_tencentcloud.cpp
+++ b/trunk/src/app/srs_app_tencentcloud.cpp
@@ -2107,21 +2107,40 @@ srs_error_t SrsApmClient::initialize()
         return err;
     }
 
+    team_ = _srs_config->get_tencentcloud_apm_team();
     token_ = _srs_config->get_tencentcloud_apm_token();
     endpoint_ = _srs_config->get_tencentcloud_apm_endpoint();
     service_name_ = _srs_config->get_tencentcloud_apm_service_name();
     debug_logging_ = _srs_config->get_tencentcloud_apm_debug_logging();
-    srs_trace("Initialize TencentCloud APM, token=%dB, endpoint=%s, service_name=%s, debug_logging=%d", token_.length(), endpoint_.c_str(), service_name_.c_str(), debug_logging_);
+    srs_trace("Initialize TencentCloud APM, team=%s, token=%dB, endpoint=%s, service_name=%s, debug_logging=%d", team_.c_str(), token_.length(), endpoint_.c_str(), service_name_.c_str(), debug_logging_);
+
+    // Check authentication, the team or token.
+    if (team_.empty()) {
+        return srs_error_new(ERROR_APM_AUTH, "No authentication team for APM");
+    }
+    if (token_.empty()) {
+        return srs_error_new(ERROR_APM_AUTH, "No authentication token for APM");
+    }
 
     // Please note that 4317 is for GRPC/HTTP2, while SRS only support HTTP and the port shoule be 55681.
     if (srs_string_contains(endpoint_, ":4317")) {
-        return srs_error_new(ERROR_APM_INVALID_ENDPOINT, "Port 4317 is for GRPC or HTTP2");
+        return srs_error_new(ERROR_APM_ENDPOINT, "Port 4317 is for GRPC over HTTP2 for APM");
     }
 
     return err;
 }
 
 srs_error_t SrsApmClient::report()
+{
+    srs_error_t err = do_report();
+    if (err != srs_success) {
+        return srs_error_wrap(err, "team=%s, token=%dB", team_.c_str(), token_.length());
+    }
+
+    return err;
+}
+
+srs_error_t SrsApmClient::do_report()
 {
     srs_error_t err = srs_success;
 
@@ -2138,6 +2157,8 @@ srs_error_t SrsApmClient::report()
     rs->resource()->add_addr(SrsOtelAttribute::kv("service.name", service_name_));
     // For Tencent Cloud APM authentication, see https://console.cloud.tencent.com/apm/monitor/access
     rs->resource()->add_addr(SrsOtelAttribute::kv("token", token_));
+    // For Tencent Cloud APM debugging, see https://console.cloud.tencent.com/apm/monitor/team
+    rs->resource()->add_addr(SrsOtelAttribute::kv("tapm.team", team_));
 
     SrsOtelScopeSpans* spans = rs->append();
     spans->scope()->name_ = "srs";
@@ -2203,7 +2224,7 @@ srs_error_t SrsApmClient::report()
 
     if (debug_logging_) {
         string server_id = SrsStatistic::instance()->server_id();
-        srs_trace("APM write logs=%d, size=%dB, server_id=%s", spans->size(), body.length(), server_id.c_str());
+        srs_trace("APM write team=%s, token=%dB, logs=%d, size=%dB, server_id=%s", team_.c_str(), token_.length(), spans->size(), body.length(), server_id.c_str());
     }
 
     return err;

--- a/trunk/src/app/srs_app_tencentcloud.cpp
+++ b/trunk/src/app/srs_app_tencentcloud.cpp
@@ -2113,6 +2113,11 @@ srs_error_t SrsApmClient::initialize()
     debug_logging_ = _srs_config->get_tencentcloud_apm_debug_logging();
     srs_trace("Initialize TencentCloud APM, token=%dB, endpoint=%s, service_name=%s, debug_logging=%d", token_.length(), endpoint_.c_str(), service_name_.c_str(), debug_logging_);
 
+    // Please note that 4317 is for GRPC/HTTP2, while SRS only support HTTP and the port shoule be 55681.
+    if (srs_string_contains(endpoint_, ":4317")) {
+        return srs_error_new(ERROR_APM_INVALID_ENDPOINT, "Port 4317 is for GRPC or HTTP2");
+    }
+
     return err;
 }
 

--- a/trunk/src/app/srs_app_tencentcloud.hpp
+++ b/trunk/src/app/srs_app_tencentcloud.hpp
@@ -493,6 +493,7 @@ class SrsApmClient
 private:
     bool enabled_;
     uint64_t nn_spans_;
+    std::string team_;
     std::string token_;
     std::string endpoint_;
     std::string service_name_;
@@ -504,6 +505,9 @@ public:
 public:
     srs_error_t initialize();
     srs_error_t report();
+private:
+    srs_error_t do_report();
+public:
     bool enabled();
     uint64_t nn_spans();
 public:

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -98,7 +98,8 @@
     XX(ERROR_CLS_INVALID_CONFIG            , 1085, "ClsConfig", "Invalid configuration for TencentCloud CLS") \
     XX(ERROR_CLS_EXCEED_SIZE               , 1086, "ClsExceedSize", "CLS logs exceed max size 5MB") \
     XX(ERROR_APM_EXCEED_SIZE               , 1087, "ApmExceedSize", "APM logs exceed max size 5MB") \
-    XX(ERROR_APM_INVALID_ENDPOINT          , 1088, "ApmInvalidEndpoint", "APM endpoint is invalid") \
+    XX(ERROR_APM_ENDPOINT                  , 1088, "ApmEndpoint", "APM endpoint is invalid") \
+    XX(ERROR_APM_AUTH                      , 1089, "ApmAuth", "APM team or token is invalid") \
 
 /**************************************************/
 /* RTMP protocol error. */

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -97,7 +97,8 @@
     XX(ERROR_PB_NO_SPACE                   , 1084, "ProtobufNoSpace", "Failed to encode protobuf for no buffer space left") \
     XX(ERROR_CLS_INVALID_CONFIG            , 1085, "ClsConfig", "Invalid configuration for TencentCloud CLS") \
     XX(ERROR_CLS_EXCEED_SIZE               , 1086, "ClsExceedSize", "CLS logs exceed max size 5MB") \
-    XX(ERROR_APM_EXCEED_SIZE               , 1087, "ApmExceedSize", "APM logs exceed max size 5MB")
+    XX(ERROR_APM_EXCEED_SIZE               , 1087, "ApmExceedSize", "APM logs exceed max size 5MB") \
+    XX(ERROR_APM_INVALID_ENDPOINT          , 1088, "ApmInvalidEndpoint", "APM endpoint is invalid") \
 
 /**************************************************/
 /* RTMP protocol error. */

--- a/trunk/src/main/srs_main_ingest_hls.cpp
+++ b/trunk/src/main/srs_main_ingest_hls.cpp
@@ -1073,7 +1073,7 @@ int SrsIngestHlsOutput::write_h264_sps_pps(uint32_t dts, uint32_t pts)
     
     // h264 raw to h264 packet.
     std::string sh;
-    if ((err = avc->mux_sequence_header(h264_sps, h264_pps, dts, pts, sh)) != srs_success) {
+    if ((err = avc->mux_sequence_header(h264_sps, h264_pps, sh)) != srs_success) {
         // TODO: FIXME: Use error
         ret = srs_error_code(err);
         srs_freep(err);

--- a/trunk/src/protocol/srs_protocol_raw_avc.cpp
+++ b/trunk/src/protocol/srs_protocol_raw_avc.cpp
@@ -109,7 +109,7 @@ srs_error_t SrsRawH264Stream::pps_demux(char* frame, int nb_frame, string& pps)
     return err;
 }
 
-srs_error_t SrsRawH264Stream::mux_sequence_header(string sps, string pps, uint32_t dts, uint32_t pts, string& sh)
+srs_error_t SrsRawH264Stream::mux_sequence_header(string sps, string pps, string& sh)
 {
     srs_error_t err = srs_success;
     

--- a/trunk/src/protocol/srs_protocol_raw_avc.hpp
+++ b/trunk/src/protocol/srs_protocol_raw_avc.hpp
@@ -38,7 +38,7 @@ public:
     // The h264 raw data to h264 packet, without flv payload header.
     // Mux the sps/pps to flv sequence header packet.
     // @param sh output the sequence header.
-    virtual srs_error_t mux_sequence_header(std::string sps, std::string pps, uint32_t dts, uint32_t pts, std::string& sh);
+    virtual srs_error_t mux_sequence_header(std::string sps, std::string pps, std::string& sh);
     // The h264 raw data to h264 packet, without flv payload header.
     // Mux the ibp to flv ibp packet.
     // @param ibp output the packet.

--- a/trunk/src/utest/srs_utest_avc.cpp
+++ b/trunk/src/utest/srs_utest_avc.cpp
@@ -113,7 +113,7 @@ VOID TEST(SrsAVCTest, H264SequenceHeader)
     // For muxing sequence header.
     if (true) {
         SrsRawH264Stream h; string sh;
-        HELPER_ASSERT_SUCCESS(h.mux_sequence_header("Hello", "world", 0, 0, sh));
+        HELPER_ASSERT_SUCCESS(h.mux_sequence_header("Hello", "world", sh));
         EXPECT_EQ(11+5+5, (int)sh.length());
         EXPECT_STREQ("Hello", sh.substr(8, 5).c_str());
         EXPECT_STREQ("world", sh.substr(16).c_str());


### PR DESCRIPTION
Print warning log when SRT push stream audio duration too large.

@see https://ossrs.net/lts/en-us/docs/v5/doc/srt-codec#note