### PR TITLE
SRT: do not ignore AUD nalus

### DIFF
--- a/trunk/src/app/srs_app_srt_source.cpp
+++ b/trunk/src/app/srs_app_srt_source.cpp
@@ -383,11 +383,6 @@ srs_error_t SrsRtmpFromSrtBridge::on_ts_video(SrsTsMessage* msg, SrsBuffer* avs)
         //  7: SPS, 8: PPS, 5: I Frame, 1: P Frame
         SrsAvcNaluType nal_unit_type = (SrsAvcNaluType)(frame[0] & 0x1f);
         
-        // ignore the nalu type sps(7), pps(8), aud(9)
-        if (nal_unit_type == SrsAvcNaluTypeAccessUnitDelimiter) {
-            continue;
-        }
-        
         // for sps
         if (avc->is_sps(frame, frame_size)) {
             std::string sps;


### PR DESCRIPTION
When converting SRT to RTMP, AUD nalus should not be filtered out.

I consulted with Commissioner Zhao, and he said, "In the ts format, AUD is generally mandatory. If the encoder does not include AUD, the ffmpeg ts muxer will automatically insert it." 
"It is used to separate frames. When iOS parses ts, it requires AUD to ensure convenient determination of complete frames.

Please provide more context or specify which part of the FFmpeg code you would like me to translate.
libavformat/mpegtsenc.c
`Function mpegts_write_packet_internal`

![Screenshot of Enterprise WeChat](https://user-images.githubusercontent.com/8449258/191892649-e5094c4d-a43c-47d8-bfc7-f864349820c6.png)

Here, the `aud` is indeed inserted.

Additionally, from the nal structure of the OBS streaming, taking the I frame as an example, the received I frame nalu sequence is aud/sps/pps/idr.

After converting to RTMP, multiple mainstream players were tested, and all of them played FLV/RTMP/SRT/HLS formats correctly.

---------

`TRANS_BY_GPT3`