### PR TITLE
API: support metrics for prometheus.(#2899)

### DIFF
--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -657,6 +657,21 @@ tencentcloud_apm {
     debug_logging off;
 }
 
+# Promethous exporter config.
+# See https://prometheus.io/docs/instrumenting/exporters
+exporter {
+    # Whether exporter is enabled.
+    # Overwrite by env SRS_EXPORTER_ENABLED
+    # default: off
+    enabled         off;
+    # The logging label to category the cluster servers.
+    # Overwrite by env SRS_EXPORTER_LABEL
+    label cn-beijing;
+    # The logging tag to category the cluster servers.
+    # Overwrite by env SRS_EXPORTER_TAG
+    tag cn-edge;
+}
+
 #############################################################################################
 # heartbeat/stats sections
 #############################################################################################

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -657,12 +657,12 @@ tencentcloud_apm {
     debug_logging off;
 }
 
-# Promethous exporter config.
+# Prometheus exporter config.
 # See https://prometheus.io/docs/instrumenting/exporters
 exporter {
     # Whether exporter is enabled.
     # Overwrite by env SRS_EXPORTER_ENABLED
-    # default: off
+    # Default: off
     enabled         off;
     # The logging label to category the cluster servers.
     # Overwrite by env SRS_EXPORTER_LABEL

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-09-27, For [#2899](https://github.com/ossrs/srs/issues/2899): API: Support exporter for Prometheus. v5.0.67
 * v5.0, 2022-09-27, For [#3167](https://github.com/ossrs/srs/issues/3167): WebRTC: Refine sequence jitter algorithm. v5.0.66
 * v5.0, 2022-09-22, Fix [#3164](https://github.com/ossrs/srs/issues/3164): SRT: Choppy when audio ts gap is too large. v5.0.65
 * v5.0, 2022-09-16, APM: Support distributed tracing by Tencent Cloud APM. v5.0.64

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -20,9 +20,6 @@
 #include <linux/version.h>
 #include <sys/utsname.h>
 #endif
-#ifdef SRS_OSX
-#include <sys/utsname.h>
-#endif
 
 #include <vector>
 #include <algorithm>

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -297,6 +297,9 @@ protected:
 private:
     // The reload subscribers, when reload, callback all handlers.
     std::vector<ISrsReloadHandler*> subscribes;
+private:
+    // uname info
+    std::string sys_uname_;
 public:
     SrsConfig();
     virtual ~SrsConfig();
@@ -1086,6 +1089,9 @@ public:
     // The device name configed in args of directive.
     // @return the disk device name to stat. NULL if not configed.
     virtual SrsConfDirective* get_stats_disk_device();
+public:
+    // Get sys uname info.
+    virtual std::string get_uname_info();
 };
 
 #endif

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -297,9 +297,6 @@ protected:
 private:
     // The reload subscribers, when reload, callback all handlers.
     std::vector<ISrsReloadHandler*> subscribes;
-private:
-    // uname info
-    std::string sys_uname_;
 public:
     SrsConfig();
     virtual ~SrsConfig();
@@ -1090,8 +1087,10 @@ public:
     // @return the disk device name to stat. NULL if not configed.
     virtual SrsConfDirective* get_stats_disk_device();
 public:
-    // Get sys uname info.
-    virtual std::string get_uname_info();
+    // Get Prometheus exporter info.
+    virtual bool get_exporter_enabled();
+    virtual std::string get_exporter_label();
+    virtual std::string get_exporter_tag();
 };
 
 #endif

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -1087,7 +1087,7 @@ public:
     // @return the disk device name to stat. NULL if not configed.
     virtual SrsConfDirective* get_stats_disk_device();
 public:
-    // Get Prometheus exporter info.
+    // Get Prometheus exporter config.
     virtual bool get_exporter_enabled();
     virtual std::string get_exporter_label();
     virtual std::string get_exporter_tag();

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1078,7 +1078,7 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
 {
     // whether enabled the HTTP Metrics API.
     if (!enabled_) {
-        return srs_api_response_code(w, r, ERROR_SYSTEM_CONFIG_EXPORTER_DISABLED);
+        return srs_api_response_code(w, r, ERROR_EXPORTER_DISABLED);
     }
 
     /*
@@ -1096,58 +1096,58 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     std::stringstream ss;
 
     // Build info from Config.
-    ss << "# HELP srs_build_info A metric with a constant '1' value labeled by build_date, version from which srs was built.\n"
-       << "# TYPE srs_build_info gauge\n"
-       << "srs_build_info{"
-       << "build_date=\"" << SRS_BUILD_DATE << "\","
-       << "major=\"" << VERSION_MAJOR << "\","
-       << "version=\"" << RTMP_SIG_SRS_VERSION << "\","
-       << "code=\"" << RTMP_SIG_SRS_CODE<< "\","
-       << "label=\"" << label_<< "\","
-       << "tag=\"" << tag_
-       << "\"} 1\n";
+    ss << "# HELP srs_build_info A metric with a constant '1' value labeled by build_date, version from which SRS was built.\n"
+        << "# TYPE srs_build_info gauge\n"
+        << "srs_build_info{"
+            << "build_date=\"" << SRS_BUILD_DATE << "\","
+            << "major=\"" << VERSION_MAJOR << "\","
+            << "version=\"" << RTMP_SIG_SRS_VERSION << "\","
+            << "code=\"" << RTMP_SIG_SRS_CODE<< "\"";
+    if (!label_.empty()) ss << ",label=\"" << label_ << "\"";
+    if (!tag_.empty()) ss << ",tag=\"" << tag_ << "\"";
+    ss << "} 1\n";
 
     // Dump metrics by statistic.
     int64_t send_bytes, recv_bytes, nstreams, nclients, total_nclients, nerrs;
     stat->dumps_metrics(send_bytes, recv_bytes, nstreams, nclients, total_nclients, nerrs);
 
     // The total of bytes sent.
-    ss << "# HELP srs_send_bytes_total SRS server send bytes.\n"
+    ss << "# HELP srs_send_bytes_total SRS total sent bytes.\n"
        << "# TYPE srs_send_bytes_total counter\n"
        << "srs_send_bytes_total "
        << send_bytes
        << "\n";
 
     // The total of bytes received.
-    ss << "# HELP srs_receive_bytes_total SRS server receive bytes.\n"
+    ss << "# HELP srs_receive_bytes_total SRS total received bytes.\n"
        << "# TYPE srs_receive_bytes_total counter\n"
        << "srs_receive_bytes_total "
        << recv_bytes
        << "\n";
 
     // Current number of online streams.
-    ss << "# HELP srs_streams SRS server concurrent stream counts.\n"
+    ss << "# HELP srs_streams The number of SRS concurrent streams.\n"
        << "# TYPE srs_streams gauge\n"
        << "srs_streams "
        << nstreams
        << "\n";
 
     // Current number of online clients.
-    ss << "# HELP srs_clients SRS server concurrent client counts.\n"
+    ss << "# HELP srs_clients The number of SRS concurrent clients.\n"
        << "# TYPE srs_clients gauge\n"
        << "srs_clients "
        << nclients
        << "\n";
 
     // The total of clients connections.
-    ss << "# HELP srs_clients_total SRS server client total counts.\n"
+    ss << "# HELP srs_clients_total The total counts of SRS clients.\n"
        << "# TYPE srs_clients_total counter\n"
        << "srs_clients_total "
        << total_nclients
        << "\n";
 
     // The total of clients errors.
-    ss << "# HELP srs_clients_errs_total SRS server clients total errors.\n"
+    ss << "# HELP srs_clients_errs_total The total errors of SRS clients.\n"
        << "# TYPE srs_clients_errs_total counter\n"
        << "srs_clients_errs_total "
        << nerrs

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1095,7 +1095,7 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
 
     std::stringstream ss;
 
-    // srs_build_info gauge
+    // Build info from Config.
     ss << "# HELP srs_build_info A metric with a constant '1' value labeled by build_date, version from which srs was built.\n"
        << "# TYPE srs_build_info gauge\n"
        << "srs_build_info{"
@@ -1107,46 +1107,46 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
        << "tag=\"" << tag_
        << "\"} 1\n";
 
-    // dump_metrics
+    // Dump metrics by statistic.
     int64_t send_bytes, recv_bytes, nstreams, nclients, total_nclients, nerrs;
     stat->dumps_metrics(send_bytes, recv_bytes, nstreams, nclients, total_nclients, nerrs);
 
-    // server send total bytes counter.
+    // The total of bytes sent.
     ss << "# HELP srs_send_bytes_total SRS server send bytes.\n"
        << "# TYPE srs_send_bytes_total counter\n"
        << "srs_send_bytes_total "
        << send_bytes
        << "\n";
 
-    // servers receive total bytes counter.
+    // The total of bytes received.
     ss << "# HELP srs_receive_bytes_total SRS server receive bytes.\n"
        << "# TYPE srs_receive_bytes_total counter\n"
        << "srs_receive_bytes_total "
        << recv_bytes
        << "\n";
 
-    // servers srs_server_streams gauge
+    // Current number of online streams.
     ss << "# HELP srs_streams SRS server concurrent stream counts.\n"
        << "# TYPE srs_streams gauge\n"
        << "srs_streams "
        << nstreams
        << "\n";
 
-    // servers srs_clients counter
+    // Current number of online clients.
     ss << "# HELP srs_clients SRS server concurrent client counts.\n"
        << "# TYPE srs_clients gauge\n"
        << "srs_clients "
        << nclients
        << "\n";
 
-    // servers srs_clients_total counter
+    // The total of clients connections.
     ss << "# HELP srs_clients_total SRS server client total counts.\n"
        << "# TYPE srs_clients_total counter\n"
        << "srs_clients_total "
        << total_nclients
        << "\n";
 
-    // errors
+    // The total of clients errors.
     ss << "# HELP srs_clients_errs_total SRS server clients total errors.\n"
        << "# TYPE srs_clients_errs_total counter\n"
        << "srs_clients_errs_total "

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1100,6 +1100,7 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
        << "# TYPE srs_build_info gauge\n"
        << "srs_build_info{"
        << "build_date=\"" << SRS_BUILD_DATE << "\","
+       << "major=\"" << VERSION_MAJOR << "\","
        << "version=\"" << RTMP_SIG_SRS_VERSION << "\","
        << "code=\"" << RTMP_SIG_SRS_CODE<< "\","
        << "label=\"" << label_<< "\","

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1125,9 +1125,9 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
        << "\n";
 
     // servers srs_server_streams gauge
-    ss << "# HELP srs_streams_total SRS server concurrent stream counts.\n"
-       << "# TYPE srs_streams_total gauge\n"
-       << "srs_streams_total "
+    ss << "# HELP srs_streams SRS server concurrent stream counts.\n"
+       << "# TYPE srs_streams gauge\n"
+       << "srs_streams "
        << nstreams
        << "\n";
 

--- a/trunk/src/app/srs_app_http_api.hpp
+++ b/trunk/src/app/srs_app_http_api.hpp
@@ -218,6 +218,10 @@ public:
 
 class SrsGoApiMetrics : public ISrsHttpHandler
 {
+private:
+    bool enabled_;
+    std::string label_;
+    std::string tag_;
 public:
     SrsGoApiMetrics();
     virtual ~SrsGoApiMetrics();

--- a/trunk/src/app/srs_app_http_api.hpp
+++ b/trunk/src/app/srs_app_http_api.hpp
@@ -216,5 +216,14 @@ public:
 };
 #endif
 
+class SrsGoApiMetrics : public ISrsHttpHandler
+{
+public:
+    SrsGoApiMetrics();
+    virtual ~SrsGoApiMetrics();
+public:
+    virtual srs_error_t serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r);
+};
+
 #endif
 

--- a/trunk/src/app/srs_app_http_conn.cpp
+++ b/trunk/src/app/srs_app_http_conn.cpp
@@ -406,7 +406,7 @@ srs_error_t SrsHttpxConn::on_conn_done(srs_error_t r0)
 {
     // Only stat the HTTP streaming clients, ignore all API clients.
     if (enable_stat_) {
-        SrsStatistic::instance()->on_disconnect(get_id().c_str());
+        SrsStatistic::instance()->on_disconnect(get_id().c_str(), r0);
         SrsStatistic::instance()->kbps_add_delta(get_id().c_str(), conn->delta());
     }
 

--- a/trunk/src/app/srs_app_http_static.cpp
+++ b/trunk/src/app/srs_app_http_static.cpp
@@ -331,7 +331,7 @@ srs_error_t SrsHlsStream::on_timer(srs_utime_t interval)
             http_hooks_on_stop(info->req);
 
             SrsStatistic* stat = SrsStatistic::instance();
-            stat->on_disconnect(ctx);
+            stat->on_disconnect(ctx, srs_success);
 
             map_ctx_info_.erase(it);
             srs_freep(info);

--- a/trunk/src/app/srs_app_http_static.cpp
+++ b/trunk/src/app/srs_app_http_static.cpp
@@ -331,6 +331,7 @@ srs_error_t SrsHlsStream::on_timer(srs_utime_t interval)
             http_hooks_on_stop(info->req);
 
             SrsStatistic* stat = SrsStatistic::instance();
+            // TODO: FIXME: Should finger out the err.
             stat->on_disconnect(ctx, srs_success);
 
             map_ctx_info_.erase(it);

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -458,6 +458,7 @@ SrsRtcPlayStream::~SrsRtcPlayStream()
 	
     // update the statistic when client coveried.
     SrsStatistic* stat = SrsStatistic::instance();
+    // TODO: FIXME: Should finger out the err.
     stat->on_disconnect(cid_.c_str(), srs_success);
 }
 
@@ -1108,6 +1109,7 @@ SrsRtcPublishStream::~SrsRtcPublishStream()
 	
     // update the statistic when client coveried.
     SrsStatistic* stat = SrsStatistic::instance();
+    // TODO: FIXME: Should finger out the err.
     stat->on_disconnect(cid_.c_str(), srs_success);
 }
 

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -458,7 +458,7 @@ SrsRtcPlayStream::~SrsRtcPlayStream()
 	
     // update the statistic when client coveried.
     SrsStatistic* stat = SrsStatistic::instance();
-    stat->on_disconnect(cid_.c_str());
+    stat->on_disconnect(cid_.c_str(), srs_success);
 }
 
 srs_error_t SrsRtcPlayStream::initialize(SrsRequest* req, std::map<uint32_t, SrsRtcTrackDescription*> sub_relations)
@@ -1108,7 +1108,7 @@ SrsRtcPublishStream::~SrsRtcPublishStream()
 	
     // update the statistic when client coveried.
     SrsStatistic* stat = SrsStatistic::instance();
-    stat->on_disconnect(cid_.c_str());
+    stat->on_disconnect(cid_.c_str(), srs_success);
 }
 
 srs_error_t SrsRtcPublishStream::initialize(SrsRequest* r, SrsRtcSourceDescription* stream_desc)

--- a/trunk/src/app/srs_app_rtc_network.cpp
+++ b/trunk/src/app/srs_app_rtc_network.cpp
@@ -749,7 +749,7 @@ srs_error_t SrsRtcTcpConn::cycle()
     srs_error_t err = do_cycle();
 
     // Only stat the HTTP streaming clients, ignore all API clients.
-    SrsStatistic::instance()->on_disconnect(get_id().c_str());
+    SrsStatistic::instance()->on_disconnect(get_id().c_str(), err);
     SrsStatistic::instance()->kbps_add_delta(get_id().c_str(), delta_);
 
     // Because we use manager to manage this object, not the http connection object, so we must remove it here.

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -1551,7 +1551,7 @@ srs_error_t SrsRtmpConn::cycle()
     // Update statistic when done.
     SrsStatistic* stat = SrsStatistic::instance();
     stat->kbps_add_delta(get_id().c_str(), delta_);
-    stat->on_disconnect(get_id().c_str());
+    stat->on_disconnect(get_id().c_str(), err);
 
     // Notify manager to remove it.
     // Note that we create this object, so we use manager to remove it.

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -887,6 +887,10 @@ srs_error_t SrsServer::http_handle()
         return srs_error_wrap(err, "handle tests errors");
     }
 #endif
+    // metrics by prometheus
+    if ((err = http_api_mux->handle("/metrics", new SrsGoApiMetrics())) != srs_success) {
+        return srs_error_wrap(err, "handle tests errors");
+    }
     
     // TODO: FIXME: for console.
     // TODO: FIXME: support reload.

--- a/trunk/src/app/srs_app_srt_conn.cpp
+++ b/trunk/src/app/srs_app_srt_conn.cpp
@@ -228,7 +228,7 @@ srs_error_t SrsMpegtsSrtConn::cycle()
     // Update statistic when done.
     SrsStatistic* stat = SrsStatistic::instance();
     stat->kbps_add_delta(get_id().c_str(), delta_);
-    stat->on_disconnect(get_id().c_str());
+    stat->on_disconnect(get_id().c_str(), err);
 
     // Notify manager to remove it.
     // Note that we create this object, so we use manager to remove it.

--- a/trunk/src/app/srs_app_statistic.cpp
+++ b/trunk/src/app/srs_app_statistic.cpp
@@ -241,6 +241,9 @@ SrsStatistic* SrsStatistic::_instance = NULL;
 SrsStatistic::SrsStatistic()
 {
     kbps = new SrsKbps();
+
+    nb_clients_ = 0;
+    nb_errs_ = 0;
 }
 
 SrsStatistic::~SrsStatistic()
@@ -421,11 +424,13 @@ srs_error_t SrsStatistic::on_client(std::string id, SrsRequest* req, ISrsExpire*
     // @see https://github.com/ossrs/srs/issues/2311
     srs_freep(client->req);
     client->req = req->copy();
+
+    nb_clients_++;
     
     return err;
 }
 
-void SrsStatistic::on_disconnect(std::string id)
+void SrsStatistic::on_disconnect(std::string id, srs_error_t err)
 {
     std::map<std::string, SrsStatisticClient*>::iterator it = clients.find(id);
     if (it == clients.end()) return;
@@ -439,6 +444,10 @@ void SrsStatistic::on_disconnect(std::string id)
     
     stream->nb_clients--;
     vhost->nb_clients--;
+
+    if (srs_error_code(err) != ERROR_SUCCESS) {
+        nb_errs_++;
+    }
 
     cleanup_stream(stream);
 }
@@ -721,96 +730,19 @@ SrsStatisticStream* SrsStatistic::create_stream(SrsStatisticVhost* vhost, SrsReq
     return stream;
 }
 
-void SrsStatistic::dumps_metric_vhosts(std::stringstream & send_bytes, std::stringstream & recv_bytes)
+srs_error_t SrsStatistic::dumps_metrics(int64_t& send_bytes, int64_t& recv_bytes, int64_t& nstreams, int64_t& nclients, int64_t& total_nclients, int64_t& nerrs)
 {
-    std::map<std::string, SrsStatisticVhost*>::iterator it;
-    for (it = vhosts.begin(); it != vhosts.end(); it++) {
-        SrsStatisticVhost* vhost = it->second;
+    srs_error_t err = srs_success;
 
-        // srs_server_send_bytes_total{protocol=\"rtmp\", vhost=\"__defaultVhost__\"} 66271966\n
-        send_bytes << "srs_server_send_bytes_total{"
-                    << "vhost=\""
-                    << vhost->vhost
-                    << "\"} "
-                    << vhost->kbps->get_send_bytes()
-                    << "\n";
+    send_bytes = kbps->get_send_bytes();
+    recv_bytes = kbps->get_recv_bytes();
 
-        // srs_server_receive_bytes_total{protocol=\"rtmp\", vhost=\"__defaultVhost__\"} 38070789710\n
-        recv_bytes << "srs_server_receive_bytes_total{"
-                    << "vhost=\""
-                    << vhost->vhost
-                    << "\"} "
-                    << vhost->kbps->get_recv_bytes()
-                    << "\n";
-    }
+    nstreams = streams.size();
+    nclients = clients.size();
+
+    total_nclients = nb_clients_;
+    nerrs = nb_errs_;
+
+    return err;
 }
 
-void SrsStatistic::dumps_metric_streams(std::stringstream & ss)
-{
-    std::map<std::string, SrsStatisticStream*>::iterator it = streams.begin();
-    for (; it != streams.end(); it++) {
-        SrsStatisticStream* stream = it->second;
-
-        std::string protocol = "unknown";
-        size_t pos = string::npos;
-        if ((pos = stream->tcUrl.find("://")) != string::npos) {
-            protocol = stream->tcUrl.substr(0, pos);
-        }
-
-        // "srs_server_streams_total{protocol=\"rtmp\", stream=\"/live/livestream\"} 1\n"
-        ss << "srs_server_streams_total{"
-            << "protocol=\""
-            << protocol
-            << "\","
-            << "stream=\""
-            << stream->vhost->vhost << "/" << stream->app << "/" << stream->stream
-            << "\"} 1"
-            << "\n";
-    }
-}
-
-void SrsStatistic::dumps_metric_clients(std::stringstream & ss)
-{
-    std::map<std::string, int64_t> consumers;
-
-    std::map<std::string, SrsStatisticClient*>::iterator it = clients.begin();
-    for (; it != clients.end(); it++) {
-        SrsStatisticClient* client = it->second;
-
-        if (srs_client_type_is_publish(client->type)) {
-            continue;
-        }
-
-        std::string protocol = "unknown";
-        size_t pos = string::npos;
-        if ((pos = client->req->tcUrl.find("://")) != string::npos) {
-            protocol = client->req->tcUrl.substr(0, pos);
-        }
-
-        string key = protocol + ":::" + client->req->get_stream_url();
-        consumers[key]++;
-    }
-
-    std::map<std::string, int64_t>::iterator iter = consumers.begin();
-    for (; iter != consumers.end(); iter++) {
-        string key = iter->first;
-        string protocol = "unknown";
-        string stream = "";
-        size_t pos = string::npos;
-        if ((pos = key.find(":::")) != string::npos) {
-            protocol = key.substr(0, pos);
-            stream = key.substr(pos + 3);
-        }
-
-        // "srs_server_clients_total{protocol=\"rtmp\", stream=\"/live/livestream\"} 10\n"
-        ss << "srs_server_clients_total{"
-            << "protocol=\""
-            << protocol
-            << "\","
-            << "stream=\""
-            << stream
-            << "\"} "
-            << iter->second
-            << "\n";
-    }
-}

--- a/trunk/src/app/srs_app_statistic.hpp
+++ b/trunk/src/app/srs_app_statistic.hpp
@@ -210,6 +210,10 @@ public:
 private:
     virtual SrsStatisticVhost* create_vhost(SrsRequest* req);
     virtual SrsStatisticStream* create_stream(SrsStatisticVhost* vhost, SrsRequest* req);
+public:
+    virtual void dumps_metric_vhosts(std::stringstream & send_bytes, std::stringstream & recv_bytes);
+    virtual void dumps_metric_streams(std::stringstream & ss);
+    virtual void dumps_metric_clients(std::stringstream & ss);
 };
 
 // Generate a random string id, with constant prefix.

--- a/trunk/src/app/srs_app_statistic.hpp
+++ b/trunk/src/app/srs_app_statistic.hpp
@@ -140,9 +140,9 @@ private:
     // The server total kbps.
     SrsKbps* kbps;
 private:
-    // The nb clients.
+    // The total of clients connections.
     int64_t nb_clients_;
-    // The nb errors.
+    // The total of clients errors.
     int64_t nb_errs_;
 private:
     SrsStatistic();

--- a/trunk/src/app/srs_app_statistic.hpp
+++ b/trunk/src/app/srs_app_statistic.hpp
@@ -140,6 +140,11 @@ private:
     // The server total kbps.
     SrsKbps* kbps;
 private:
+    // The nb clients.
+    int64_t nb_clients_;
+    // The nb errors.
+    int64_t nb_errs_;
+private:
     SrsStatistic();
     virtual ~SrsStatistic();
 public:
@@ -177,7 +182,7 @@ public:
     // @remark the on_disconnect always call, while the on_client is call when
     //      only got the request object, so the client specified by id maybe not
     //      exists in stat.
-    virtual void on_disconnect(std::string id);
+    virtual void on_disconnect(std::string id, srs_error_t err);
 private:
     // Cleanup the stream if stream is not active and for the last client.
     void cleanup_stream(SrsStatisticStream* stream);
@@ -211,9 +216,8 @@ private:
     virtual SrsStatisticVhost* create_vhost(SrsRequest* req);
     virtual SrsStatisticStream* create_stream(SrsStatisticVhost* vhost, SrsRequest* req);
 public:
-    virtual void dumps_metric_vhosts(std::stringstream & send_bytes, std::stringstream & recv_bytes);
-    virtual void dumps_metric_streams(std::stringstream & ss);
-    virtual void dumps_metric_clients(std::stringstream & ss);
+    // Dumps exporter metrics.
+    virtual srs_error_t dumps_metrics(int64_t& send_bytes, int64_t& recv_bytes, int64_t& nstreams, int64_t& nclients, int64_t& total_nclients, int64_t& nerrs);
 };
 
 // Generate a random string id, with constant prefix.

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    66
+#define VERSION_REVISION    67
 
 #endif

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -100,6 +100,7 @@
     XX(ERROR_APM_EXCEED_SIZE               , 1087, "ApmExceedSize", "APM logs exceed max size 5MB") \
     XX(ERROR_APM_ENDPOINT                  , 1088, "ApmEndpoint", "APM endpoint is invalid") \
     XX(ERROR_APM_AUTH                      , 1089, "ApmAuth", "APM team or token is invalid") \
+    XX(ERROR_SYSTEM_CONFIG_EXPORTER_DISABLED, 1090, "ConfigMetricsDisable", "Metrics API is disabled") \
 
 /**************************************************/
 /* RTMP protocol error. */

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -100,7 +100,7 @@
     XX(ERROR_APM_EXCEED_SIZE               , 1087, "ApmExceedSize", "APM logs exceed max size 5MB") \
     XX(ERROR_APM_ENDPOINT                  , 1088, "ApmEndpoint", "APM endpoint is invalid") \
     XX(ERROR_APM_AUTH                      , 1089, "ApmAuth", "APM team or token is invalid") \
-    XX(ERROR_SYSTEM_CONFIG_EXPORTER_DISABLED, 1090, "ConfigMetricsDisable", "Metrics API is disabled") \
+    XX(ERROR_EXPORTER_DISABLED             , 1090, "ExporterDisable", "Prometheus exporter is disabled") \
 
 /**************************************************/
 /* RTMP protocol error. */


### PR DESCRIPTION
Support metrics for Prometheus, Prometheus can call metrics, likely:
```
http://127.0.0.1:1985/metrics
```
Prometheus config:
```config
scrape_configs:
    static_configs:
      - targets: ['127.0.0.1:1985']
        labels:
          group: '127.0.0.1:1985'
```
SRS config:
```config

listen              1935;
max_connections     1000;
daemon              off;
srs_log_tank        console;

exporter {
    # Whether exporter is enabled.
    # Overwrite by env SRS_EXPORTER_ENABLED
    # default: off
    enabled         on;
    # The logging label to category the cluster servers.
    # Overwrite by env SRS_EXPORTER_LABEL
    label cn-beijing;
    # The logging tag to category the cluster servers.
    # Overwrite by env SRS_EXPORTER_TAG
    tag cn-edge;
}

http_api {
    enabled         on;
    listen          1985;
}
vhost __defaultVhost__ {
}
```
