### PR TITLE
Exporter: Listen at port 9972 for Prometheus exporter.

### DIFF
--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -664,6 +664,11 @@ exporter {
     # Overwrite by env SRS_EXPORTER_ENABLED
     # Default: off
     enabled off;
+    # The http api listen port for exporter metrics.
+    # Overwrite by env SRS_EXPORTER_LISTEN
+    # Default: 9972
+    # See https://github.com/prometheus/prometheus/wiki/Default-port-allocations
+    listen 9972;
     # The logging label to category the cluster servers.
     # Overwrite by env SRS_EXPORTER_LABEL
     label cn-beijing;

--- a/trunk/conf/prometheus.conf
+++ b/trunk/conf/prometheus.conf
@@ -1,0 +1,44 @@
+# no-daemon and write log to console config for srs.
+# @see full.conf for detail config.
+
+listen              1935;
+max_connections     1000;
+daemon              off;
+srs_log_tank        console;
+http_api {
+    enabled         on;
+    listen          1985;
+}
+http_server {
+    enabled         on;
+    listen          8080;
+}
+rtc_server {
+    enabled on;
+    listen 8000; # UDP port
+    # @see https://ossrs.net/lts/zh-cn/docs/v4/doc/webrtc#config-candidate
+    candidate $CANDIDATE;
+}
+# Prometheus exporter config.
+exporter {
+    enabled         on;
+    listen          9972;
+    label           cn-beijing;
+    tag             cn-edge;
+}
+vhost __defaultVhost__ {
+    hls {
+        enabled         on;
+    }
+    http_remux {
+        enabled     on;
+        mount       [vhost]/[app]/[stream].flv;
+    }
+    rtc {
+        enabled     on;
+        # @see https://ossrs.net/lts/zh-cn/docs/v4/doc/webrtc#rtmp-to-rtc
+        rtmp_to_rtc on;
+        # @see https://ossrs.net/lts/zh-cn/docs/v4/doc/webrtc#rtc-to-rtmp
+        rtc_to_rtmp on;
+    }
+}

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2305,7 +2305,16 @@ srs_error_t SrsConfig::check_normal_config()
             }
         }
     }
-    
+    if (true) {
+        SrsConfDirective* conf = root->get("exporter");
+        for (int i = 0; conf && i < (int)conf->directives.size(); i++) {
+            string n = conf->at(i)->name;
+            if (n != "enabled" && n != "listen" && n != "label" && n != "tag") {
+                return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal exporter.%s", n.c_str());
+            }
+        }
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // check listen for rtmp.
     ////////////////////////////////////////////////////////////////////////
@@ -3581,6 +3590,25 @@ bool SrsConfig::get_exporter_enabled()
     }
 
     return SRS_CONF_PERFER_FALSE(conf->arg0());
+}
+
+string SrsConfig::get_exporter_listen()
+{
+    SRS_OVERWRITE_BY_ENV_STRING("SRS_EXPORTER_LISTEN");
+
+    static string DEFAULT = "9972";
+
+    SrsConfDirective* conf = root->get("exporter");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("listen");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    return conf->arg0();
 }
 
 string SrsConfig::get_exporter_label()

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -1089,6 +1089,7 @@ public:
 public:
     // Get Prometheus exporter config.
     virtual bool get_exporter_enabled();
+    virtual std::string get_exporter_listen();
     virtual std::string get_exporter_label();
     virtual std::string get_exporter_tag();
 };

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -87,7 +87,9 @@ srs_error_t srs_api_response_json(ISrsHttpResponseWriter* w, string data)
     SrsHttpHeader* h = w->header();
     
     h->set_content_length(data.length());
-    h->set_content_type("application/json");
+    if (h->content_type().empty()) {
+        h->set_content_type("application/json");
+    }
     
     if ((err = w->write((char*)data.data(), (int)data.length())) != srs_success) {
         return srs_error_wrap(err, "write json");
@@ -1152,6 +1154,8 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
        << "srs_clients_errs_total "
        << nerrs
        << "\n";
+
+    w->header()->set_content_type("text/plain; charset=utf-8");
 
     return srs_api_response(w, r, ss.str());
 }

--- a/trunk/src/app/srs_app_server.hpp
+++ b/trunk/src/app/srs_app_server.hpp
@@ -133,6 +133,9 @@ private:
     SrsHttpFlvListener* stream_caster_flv_listener_;
     // Stream Caster for push over MPEGTS-UDP
     SrsUdpCasterListener* stream_caster_mpegts_;
+    // Exporter server listener, over TCP. Please note that metrics request of HTTP is served by this
+    // listener, and it might be reused by HTTP API.
+    SrsTcpListener* exporter_listener_;
 private:
     // Signal manager which convert gignal to io message.
     SrsSignalManager* signal_manager;


### PR DESCRIPTION
Exporter add default port listen for Prometheus. SRS organization applies for the default port(9972) at the official Prometheus address([Default port allocations](https://github.com/prometheus/prometheus/wiki/Default-port-allocations)).You can see prometheus.conf,

```config
listen              1935;
max_connections     1000;
daemon              off;
srs_log_tank        console;
http_api {
    enabled         on;
    listen          1985;
}
http_server {
    enabled         on;
    listen          8080;
}
rtc_server {
    enabled on;
    listen 8000; # UDP port
    # @see https://ossrs.net/lts/zh-cn/docs/v4/doc/webrtc#config-candidate
    candidate $CANDIDATE;
}
# Prometheus exporter config.
exporter {
    enabled         on;
    listen          9972;
    label           cn-beijing;
    tag             cn-edge;
}
vhost __defaultVhost__ {
    hls {
        enabled         on;
    }
    http_remux {
        enabled     on;
        mount       [vhost]/[app]/[stream].flv;
    }
    rtc {
        enabled     on;
        # @see https://ossrs.net/lts/zh-cn/docs/v4/doc/webrtc#rtmp-to-rtc
        rtmp_to_rtc on;
        # @see https://ossrs.net/lts/zh-cn/docs/v4/doc/webrtc#rtc-to-rtmp
        rtc_to_rtmp on;
    }
}
```
