### PR TITLE
Fix #3218: Log: Follow Java/log4j log level specs. v5.0.83

### DIFF
--- a/trunk/auto/auto_headers.sh
+++ b/trunk/auto/auto_headers.sh
@@ -163,6 +163,11 @@ if [ $SRS_LOG_TRACE = YES ]; then
 else
     srs_undefine_macro "SRS_TRACE" $SRS_AUTO_HEADERS_H
 fi
+if [ $SRS_LOG_LEVEL_V2 = YES ]; then
+    srs_define_macro "SRS_LOG_LEVEL_V2" $SRS_AUTO_HEADERS_H
+else
+    srs_undefine_macro "SRS_LOG_LEVEL_V2" $SRS_AUTO_HEADERS_H
+fi
 if [ $SRS_CROSS_BUILD = YES ]; then
     srs_define_macro "SRS_CROSSBUILD" $SRS_AUTO_HEADERS_H
 else

--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -57,6 +57,8 @@ SRS_GCOV=NO
 SRS_LOG_VERBOSE=NO
 SRS_LOG_INFO=NO
 SRS_LOG_TRACE=YES
+# Whether use new level definition, see https://stackoverflow.com/a/2031209/17679565
+SRS_LOG_LEVEL_V2=YES
 #
 ################################################################
 # Experts options.
@@ -143,6 +145,7 @@ Features:
   --log-verbose=on|off      Whether enable the log verbose level. Default: $(value2switch $SRS_LOG_VERBOSE)
   --log-info=on|off         Whether enable the log info level. Default: $(value2switch $SRS_LOG_INFO)
   --log-trace=on|off        Whether enable the log trace level. Default: $(value2switch $SRS_LOG_TRACE)
+  --log-level_v2=on|off     Whether use v2.0 log level definition, see log4j specs. Default: $(value2switch $SRS_LOG_LEVEL_V2)
 
 Performance:                @see https://blog.csdn.net/win_lin/article/details/53503869
   --valgrind=on|off         Whether build valgrind for memory check. Default: $(value2switch $SRS_VALGRIND)
@@ -353,6 +356,7 @@ function parse_user_option() {
         --log-verbose)                  SRS_LOG_VERBOSE=$(switch2value $value) ;;
         --log-info)                     SRS_LOG_INFO=$(switch2value $value) ;;
         --log-trace)                    SRS_LOG_TRACE=$(switch2value $value) ;;
+        --log-level_v2)                 SRS_LOG_LEVEL_V2=$(switch2value $value) ;;
         --debug)                        SRS_DEBUG=$(switch2value $value) ;;
         --debug-stats)                  SRS_DEBUG_STATS=$(switch2value $value) ;;
 
@@ -553,6 +557,7 @@ function regenerate_options() {
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --log-verbose=$(value2switch $SRS_LOG_VERBOSE)"
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --log-info=$(value2switch $SRS_LOG_INFO)"
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --log-trace=$(value2switch $SRS_LOG_TRACE)"
+    SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --log-level_v2=$(value2switch $SRS_LOG_LEVEL_V2)"
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --gcov=$(value2switch $SRS_GCOV)"
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --debug=$(value2switch $SRS_DEBUG)"
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --debug-stats=$(value2switch $SRS_DEBUG_STATS)"

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -39,12 +39,24 @@ ff_log_level info;
 # Overwrite by env SRS_SRS_LOG_TANK
 # default: file.
 srs_log_tank console;
-# the log level, for all log tanks.
-# can be: verbose, info, trace, warn, error
+# The log level for logging to console or file. It can be:
+#       verbose, info, trace, warn, error
+# If configure --log-level_v2=off, use SRS 4.0 level specs which is v1, the level text is:
+#       Verb, Info, Trace, Warn, Error
+# If configure --log-level_v2=on, use SRS 5.0 level specs which is v2, the level text is:
+#       TRACE, DEBUG, INFO, WARN, ERROR
 # Note: Do not support reloading, for SRS5+
 # Overwrite by env SRS_SRS_LOG_LEVEL
 # default: trace
 srs_log_level trace;
+# The log level v2, rewrite the config srs_log_level if not empty, it can be:
+#       trace, debug, info, warn, error
+# If configure --log-level_v2=off, use SRS 4.0 level specs which is v1, the level text is:
+#       Verb, Info, Trace, Warn, Error
+# If configure --log-level_v2=on, use SRS 5.0 level specs which is v2, the level text is:
+#       TRACE, DEBUG, INFO, WARN, ERROR
+# Overwrite by env SRS_SRS_LOG_LEVEL_V2
+srs_log_level_v2 info;
 # when srs_log_tank is file, specifies the log file.
 # Note: Do not support reloading, for SRS5+
 # Overwrite by env SRS_SRS_LOG_FILE

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-10-26, Fix [#3218](https://github.com/ossrs/srs/issues/3218): Log: Follow Java/log4j log level specs. v5.0.83
 * v5.0, 2022-10-25, Log: Refine the log interface. v5.0.82
 * v5.0, 2022-10-23, For [#3216](https://github.com/ossrs/srs/issues/3216): Support Google Address Sanitizer. v5.0.81
 * v5.0, 2022-10-21, Kernel: Support grab backtrace stack when assert fail. v5.0.80

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2280,7 +2280,7 @@ srs_error_t SrsConfig::check_normal_config()
         SrsConfDirective* conf = root->at(i);
         std::string n = conf->name;
         if (n != "listen" && n != "pid" && n != "chunk_size" && n != "ff_log_dir"
-            && n != "srs_log_tank" && n != "srs_log_level" && n != "srs_log_file"
+            && n != "srs_log_tank" && n != "srs_log_level" && n != "srs_log_level_v2" && n != "srs_log_file"
             && n != "max_connections" && n != "daemon" && n != "heartbeat" && n != "tencentcloud_apm"
             && n != "http_api" && n != "stats" && n != "vhost" && n != "pithy_print_ms"
             && n != "http_server" && n != "stream_caster" && n != "rtc_server" && n != "srt_server"
@@ -6342,12 +6342,26 @@ string SrsConfig::get_log_level()
     SRS_OVERWRITE_BY_ENV_STRING("srs.srs_log_level");
 
     static string DEFAULT = "trace";
-    
+
     SrsConfDirective* conf = root->get("srs_log_level");
     if (!conf || conf->arg0().empty()) {
         return DEFAULT;
     }
-    
+
+    return conf->arg0();
+}
+
+string SrsConfig::get_log_level_v2()
+{
+    SRS_OVERWRITE_BY_ENV_STRING("srs.srs_log_level_v2");
+
+    static string DEFAULT = "";
+
+    SrsConfDirective* conf = root->get("srs_log_level_v2");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
     return conf->arg0();
 }
 

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -869,6 +869,7 @@ public:
     virtual bool get_log_tank_file();
     // Get the log level.
     virtual std::string get_log_level();
+    virtual std::string get_log_level_v2();
     // Get the log file path.
     virtual std::string get_log_file();
     // Whether ffmpeg log enabled

--- a/trunk/src/app/srs_app_log.cpp
+++ b/trunk/src/app/srs_app_log.cpp
@@ -62,8 +62,11 @@ srs_error_t SrsFileLog::initialize()
         _srs_config->subscribe(this);
         
         log_to_file_tank = _srs_config->get_log_tank_file();
-        level_ = srs_get_log_level(_srs_config->get_log_level());
         utc = _srs_config->get_utc_time();
+
+        std::string level = _srs_config->get_log_level();
+        std::string level_v2 = _srs_config->get_log_level_v2();
+        level_ = level_v2.empty() ? srs_get_log_level(level) : srs_get_log_level_v2(level_v2);
     }
     
     return srs_success;

--- a/trunk/src/app/srs_app_utility.cpp
+++ b/trunk/src/app/srs_app_utility.cpp
@@ -53,6 +53,23 @@ SrsLogLevel srs_get_log_level(string level)
     }
 }
 
+SrsLogLevel srs_get_log_level_v2(string level)
+{
+    if ("trace" == level) {
+        return SrsLogLevelVerbose;
+    } else if ("debug" == level) {
+        return SrsLogLevelInfo;
+    } else if ("info" == level) {
+        return SrsLogLevelTrace;
+    } else if ("warn" == level) {
+        return SrsLogLevelWarn;
+    } else if ("error" == level) {
+        return SrsLogLevelError;
+    } else {
+        return SrsLogLevelDisabled;
+    }
+}
+
 string srs_path_build_stream(string template_path, string vhost, string app, string stream)
 {
     std::string path = template_path;

--- a/trunk/src/app/srs_app_utility.hpp
+++ b/trunk/src/app/srs_app_utility.hpp
@@ -28,6 +28,7 @@ class SrsJsonObject;
 // Convert level in string to log level in int.
 // @return the log level defined in SrsLogLevel.
 extern SrsLogLevel srs_get_log_level(std::string level);
+extern SrsLogLevel srs_get_log_level_v2(std::string level);
 
 // Build the path according to vhost/app/stream, where replace variables:
 //       [vhost], the vhost of stream.

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    82
+#define VERSION_REVISION    83
 
 #endif

--- a/trunk/src/kernel/srs_kernel_log.cpp
+++ b/trunk/src/kernel/srs_kernel_log.cpp
@@ -8,14 +8,25 @@
 
 #include <stdarg.h>
 
+// Go log level: Info, Warning, Error, Fatal, see https://github.com/golang/glog/blob/master/glog.go#L17
+// Java log level: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, see https://stackoverflow.com/a/2031209/17679565
+//      or https://github.com/apache/logging-log4j2/blob/release-2.x/log4j-api/src/main/java/org/apache/logging/log4j/Level.java#L29
 const char* srs_log_level_strings[] = {
-        "Forbidden",
-        "Verb",
-        "Debug", NULL,
-        "Trace", NULL, NULL, NULL,
-        "Warn", NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-        "Error", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-        "Disabled",
+#ifdef SRS_LOG_LEVEL_V2
+        // The v2 log level specs by log4j.
+        "FORB",     "TRACE",     "DEBUG",    NULL,   "INFO",    NULL, NULL, NULL,
+        "WARN",     NULL,       NULL,       NULL,   NULL,       NULL, NULL, NULL,
+        "ERROR",    NULL,       NULL,       NULL,   NULL,       NULL, NULL, NULL,
+        NULL,       NULL,       NULL,       NULL,   NULL,       NULL, NULL, NULL,
+        "OFF",
+#else
+        // SRS 4.0 level definition, to keep compatible.
+        "Forb",     "Verb",     "Debug",    NULL,   "Trace",    NULL, NULL, NULL,
+        "Warn",     NULL,       NULL,       NULL,   NULL,       NULL, NULL, NULL,
+        "Error",    NULL,       NULL,       NULL,   NULL,       NULL, NULL, NULL,
+        NULL,       NULL,       NULL,       NULL,   NULL,       NULL, NULL, NULL,
+        "Off",
+#endif
 };
 
 ISrsLog::ISrsLog()

--- a/trunk/src/kernel/srs_kernel_log.hpp
+++ b/trunk/src/kernel/srs_kernel_log.hpp
@@ -18,12 +18,12 @@
 
 #include <srs_kernel_consts.hpp>
 
-// The log level, for example:
-//      if specified Debug level, all level messages will be logged.
-//      if specified Warn level, only Warn/Error/Fatal level messages will be logged.
+// The log level, see https://github.com/apache/logging-log4j2/blob/release-2.x/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
+// Please note that the enum name might not be the string, to keep compatible with previous definition.
 enum SrsLogLevel
 {
     SrsLogLevelForbidden = 0x00,
+
     // Only used for very verbose debug, generally,
     // we compile without this level for high performance.
     SrsLogLevelVerbose = 0x01,
@@ -31,6 +31,7 @@ enum SrsLogLevel
     SrsLogLevelTrace = 0x04,
     SrsLogLevelWarn = 0x08,
     SrsLogLevelError = 0x10,
+
     SrsLogLevelDisabled = 0x20,
 };
 

--- a/trunk/src/utest/srs_utest_config.cpp
+++ b/trunk/src/utest/srs_utest_config.cpp
@@ -16,6 +16,7 @@ using namespace std;
 #include <srs_protocol_st.hpp>
 #include <srs_protocol_rtmp_stack.hpp>
 #include <srs_utest_kernel.hpp>
+#include <srs_app_utility.hpp>
 
 MockSrsConfigBuffer::MockSrsConfigBuffer(string buf)
 {
@@ -3830,5 +3831,28 @@ VOID TEST(ConfigMainTest, CheckIncludeConfig)
         MockSrsConfig conf;
 
         HELPER_ASSERT_FAILED(conf.parse("include ./conf/include_test/include.conf;"));
+    }
+}
+
+VOID TEST(ConfigMainTest, LogLevelV2)
+{
+    srs_error_t err;
+
+    if (true) {
+        MockSrsConfig conf;
+        HELPER_ASSERT_SUCCESS(conf.parse(_MIN_OK_CONF));
+        EXPECT_EQ(SrsLogLevelTrace, srs_get_log_level(conf.get_log_level()));
+    }
+
+    if (true) {
+        MockSrsConfig conf;
+        HELPER_ASSERT_SUCCESS(conf.parse(_MIN_OK_CONF "srs_log_level warn;"));
+        EXPECT_EQ(SrsLogLevelWarn, srs_get_log_level(conf.get_log_level()));
+    }
+
+    if (true) {
+        MockSrsConfig conf;
+        HELPER_ASSERT_SUCCESS(conf.parse(_MIN_OK_CONF "srs_log_level_v2 warn;"));
+        EXPECT_EQ(SrsLogLevelWarn, srs_get_log_level(conf.get_log_level_v2()));
     }
 }

--- a/trunk/src/utest/srs_utest_kernel2.cpp
+++ b/trunk/src/utest/srs_utest_kernel2.cpp
@@ -10,6 +10,7 @@
 #include <srs_kernel_buffer.hpp>
 #include <srs_kernel_rtc_rtcp.hpp>
 #include <srs_app_gb28181.hpp>
+#include <srs_app_utility.hpp>
 
 VOID TEST(KernelPSTest, PsPacketDecodeNormal)
 {
@@ -315,12 +316,39 @@ VOID TEST(KernelPSTest, PsPacketHeaderClockDecode)
 
 VOID TEST(KernelLogTest, LogLevelString)
 {
-    EXPECT_STREQ("Forbidden",        srs_log_level_strings[SrsLogLevelForbidden]);
-    EXPECT_STREQ("Verb",        srs_log_level_strings[SrsLogLevelVerbose]);
-    EXPECT_STREQ("Debug",       srs_log_level_strings[SrsLogLevelInfo]);
-    EXPECT_STREQ("Trace",       srs_log_level_strings[SrsLogLevelTrace]);
-    EXPECT_STREQ("Warn",        srs_log_level_strings[SrsLogLevelWarn]);
-    EXPECT_STREQ("Error",       srs_log_level_strings[SrsLogLevelError]);
-    EXPECT_STREQ("Disabled",    srs_log_level_strings[SrsLogLevelDisabled]);
+#ifdef SRS_LOG_LEVEL_V2
+    EXPECT_STREQ("FORB",    srs_log_level_strings[SrsLogLevelForbidden]);
+    EXPECT_STREQ("TRACE",   srs_log_level_strings[SrsLogLevelVerbose]);
+    EXPECT_STREQ("DEBUG",   srs_log_level_strings[SrsLogLevelInfo]);
+    EXPECT_STREQ("INFO",    srs_log_level_strings[SrsLogLevelTrace]);
+    EXPECT_STREQ("WARN",    srs_log_level_strings[SrsLogLevelWarn]);
+    EXPECT_STREQ("ERROR",   srs_log_level_strings[SrsLogLevelError]);
+    EXPECT_STREQ("OFF",     srs_log_level_strings[SrsLogLevelDisabled]);
+#else
+    EXPECT_STREQ("Forb",    srs_log_level_strings[SrsLogLevelForbidden]);
+    EXPECT_STREQ("Verb",    srs_log_level_strings[SrsLogLevelVerbose]);
+    EXPECT_STREQ("Debug",   srs_log_level_strings[SrsLogLevelInfo]);
+    EXPECT_STREQ("Trace",   srs_log_level_strings[SrsLogLevelTrace]);
+    EXPECT_STREQ("Warn",    srs_log_level_strings[SrsLogLevelWarn]);
+    EXPECT_STREQ("Error",   srs_log_level_strings[SrsLogLevelError]);
+    EXPECT_STREQ("Off",     srs_log_level_strings[SrsLogLevelDisabled]);
+#endif
+}
+
+VOID TEST(KernelLogTest, LogLevelStringV2)
+{
+    EXPECT_EQ(srs_get_log_level("verbose"),      SrsLogLevelVerbose);
+    EXPECT_EQ(srs_get_log_level("info"),      SrsLogLevelInfo);
+    EXPECT_EQ(srs_get_log_level("trace"),       SrsLogLevelTrace);
+    EXPECT_EQ(srs_get_log_level("warn"),       SrsLogLevelWarn);
+    EXPECT_EQ(srs_get_log_level("error"),      SrsLogLevelError);
+    EXPECT_EQ(srs_get_log_level("off"),        SrsLogLevelDisabled);
+
+    EXPECT_EQ(srs_get_log_level_v2("trace"),   SrsLogLevelVerbose);
+    EXPECT_EQ(srs_get_log_level_v2("debug"),   SrsLogLevelInfo);
+    EXPECT_EQ(srs_get_log_level_v2("info"),    SrsLogLevelTrace);
+    EXPECT_EQ(srs_get_log_level_v2("warn"),    SrsLogLevelWarn);
+    EXPECT_EQ(srs_get_log_level_v2("error"),   SrsLogLevelError);
+    EXPECT_EQ(srs_get_log_level_v2("off"),     SrsLogLevelDisabled);
 }
 


### PR DESCRIPTION
1. Support Java/log4j log level text.
2. Support configuring by `--log-new-level=on` which is enabled by default.
3. Support `--log-new-level=off` to use SRS 4.0 log level for compatibility.
