### PR TITLE
For #2899: Exporter: Add metrics cpu, memory and uname.

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-10-31, For [#2899](https://github.com/ossrs/srs/issues/2899): Exporter: Add metrics cpu, memory and uname. v5.0.86
 * v5.0, 2022-10-30, Config: Support startting with environment variable only. v5.0.85
 * v5.0, 2022-10-26, Fix [#3218](https://github.com/ossrs/srs/issues/3218): Log: Follow Java/log4j log level specs. v5.0.83
 * v5.0, 2022-10-25, Log: Refine the log interface. v5.0.82
@@ -23,7 +24,7 @@ The changelog for SRS.
 * v5.0, 2022-09-30, GB28181: Refine HTTP parser to support SIP. v5.0.70
 * v5.0, 2022-09-30, Kernel: Support lazy sweeping simple GC. v5.0.69
 * v5.0, 2022-09-30, HTTP: Support HTTP header in creating order. v5.0.68
-* v5.0, 2022-09-27, For [#2899](https://github.com/ossrs/srs/issues/2899): API: Support exporter for Prometheus. v5.0.67
+* v5.0, 2022-09-27, For [#2899](https://github.com/ossrs/srs/issues/2899): Exporter: Support exporter for Prometheus. v5.0.67
 * v5.0, 2022-09-27, For [#3167](https://github.com/ossrs/srs/issues/3167): WebRTC: Refine sequence jitter algorithm. v5.0.66
 * v5.0, 2022-09-22, Fix [#3164](https://github.com/ossrs/srs/issues/3164): SRT: Choppy when audio ts gap is too large. v5.0.65
 * v5.0, 2022-09-16, APM: Support distributed tracing by Tencent Cloud APM. v5.0.64

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1140,8 +1140,8 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
        << "\n";
 
     // The memory of proc used.(MBytes)
-    int memory = (int)(u->rss * 4 / 1024);
-    ss << "# HELP srs_memory SRS memory used(MB).\n"
+    int memory = (int)(u->rss * 4);
+    ss << "# HELP srs_memory SRS memory used.\n"
        << "# TYPE srs_memory gauge\n"
        << "srs_memory "
        << memory

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1085,6 +1085,7 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
 
     /*
      * build_info gauge
+     * cpu gauge
      * send_bytes_total counter
      * receive_bytes_total counter
      * streams gauge
@@ -1108,6 +1109,15 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     if (!label_.empty()) ss << ",label=\"" << label_ << "\"";
     if (!tag_.empty()) ss << ",tag=\"" << tag_ << "\"";
     ss << "} 1\n";
+
+    // Show ProcSelfStat
+    SrsProcSelfStat* u = srs_get_self_proc_stat();
+    // The cpu of proc used.
+    ss << "# HELP srs_cpu_stat SRS cpu used percent.\n"
+       << "# TYPE srs_cpu_stat gauge\n"
+       << "srs_cpu_stat "
+       << u->percent * 100
+       << "\n";
 
     // Dump metrics by statistic.
     int64_t send_bytes, recv_bytes, nstreams, nclients, total_nclients, nerrs;

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -31,6 +31,10 @@ using namespace std;
 #include <srs_protocol_utility.hpp>
 #include <srs_app_coworkers.hpp>
 
+#if defined(__linux__) || defined(SRS_OSX)
+#include <sys/utsname.h>
+#endif
+
 srs_error_t srs_api_response_jsonp(ISrsHttpResponseWriter* w, string callback, string data)
 {
     srs_error_t err = srs_success;
@@ -1099,11 +1103,19 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     SrsStatistic* stat = SrsStatistic::instance();
     std::stringstream ss;
 
-    // Get system info
-    ss << "# HELP srs_node_uname_info Labeled system information as provided by the uname system call.\n"
-       << "# TYPE srs_node_uname_info gauge\n"
-       << "srs_node_uname_info{" << srs_get_system_uname_info() << "\""
-    << "} 1\n";
+    #if defined(__linux__) || defined(SRS_OSX)
+        // Get system info
+        utsname* system_info = srs_get_system_uname_info();
+        ss << "# HELP srs_node_uname_info Labeled system information as provided by the uname system call.\n"
+            << "# TYPE srs_node_uname_info gauge\n"
+            << "srs_node_uname_info{"
+                << "sysname=\"" << system_info->sysname << "\","
+                << "nodename=\"" << system_info->nodename << "\","
+                << "release=\"" << system_info->release << "\","
+                << "version=\"" << system_info->version << "\","
+                << "machine=\"" << system_info->machine << "\""
+            << "} 1\n";
+    #endif
 
     // Build info from Config.
     ss << "# HELP srs_build_info A metric with a constant '1' value labeled by build_date, version from which SRS was built.\n"

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1095,8 +1095,12 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     */
 
     SrsStatistic* stat = SrsStatistic::instance();
-
     std::stringstream ss;
+
+    // Get system info
+    ss << "# HELP node_uname_info Labeled system information as provided by the uname system call.\n"
+       << "# TYPE node_uname_info gauge\n"
+       << "node_uname_info{" << srs_get_system_uname_info() << "} 1\n";
 
     // Build info from Config.
     ss << "# HELP srs_build_info A metric with a constant '1' value labeled by build_date, version from which SRS was built.\n"
@@ -1110,13 +1114,22 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     if (!tag_.empty()) ss << ",tag=\"" << tag_ << "\"";
     ss << "} 1\n";
 
-    // Show ProcSelfStat
+    // Get ProcSelfStat
     SrsProcSelfStat* u = srs_get_self_proc_stat();
+
     // The cpu of proc used.
-    ss << "# HELP srs_cpu_stat SRS cpu used percent.\n"
-       << "# TYPE srs_cpu_stat gauge\n"
-       << "srs_cpu_stat "
+    ss << "# HELP srs_cpu_percent SRS cpu used percent.\n"
+       << "# TYPE srs_cpu_percent gauge\n"
+       << "srs_cpu_percent "
        << u->percent * 100
+       << "\n";
+
+    // The memory of proc used.(MBytes)
+    int memory = (int)(u->rss * 4 / 1024);
+    ss << "# HELP srs_memory SRS memory used(MB).\n"
+       << "# TYPE srs_memory gauge\n"
+       << "srs_memory "
+       << memory
        << "\n";
 
     // Dump metrics by statistic.

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1084,8 +1084,10 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     }
 
     /*
+     * node_uname gauge
      * build_info gauge
      * cpu gauge
+     * memory gauge
      * send_bytes_total counter
      * receive_bytes_total counter
      * streams gauge
@@ -1098,9 +1100,10 @@ srs_error_t SrsGoApiMetrics::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     std::stringstream ss;
 
     // Get system info
-    ss << "# HELP node_uname_info Labeled system information as provided by the uname system call.\n"
-       << "# TYPE node_uname_info gauge\n"
-       << "node_uname_info{" << srs_get_system_uname_info() << "} 1\n";
+    ss << "# HELP srs_node_uname_info Labeled system information as provided by the uname system call.\n"
+       << "# TYPE srs_node_uname_info gauge\n"
+       << "srs_node_uname_info{" << srs_get_system_uname_info() << "\""
+    << "} 1\n";
 
     // Build info from Config.
     ss << "# HELP srs_build_info A metric with a constant '1' value labeled by build_date, version from which SRS was built.\n"

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    85
+#define VERSION_REVISION    86
 
 #endif

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -43,6 +43,10 @@ using namespace std;
 #include <srs_protocol_http_stack.hpp>
 #include <srs_core_autofree.hpp>
 
+#ifdef __linux__ || SRS_OSX
+#include <sys/utsname.h>
+#endif
+
 void srs_discovery_tc_url(string tcUrl, string& schema, string& host, string& vhost, string& app, string& stream, int& port, string& param)
 {
     // Standard URL is:
@@ -930,3 +934,30 @@ srs_error_t srs_ioutil_read_all(ISrsReader* in, std::string& content)
     return err;
 }
 
+string srs_get_system_uname_info()
+{
+    static string sys_uname = "";
+
+    if (!sys_uname.empty()) {
+        return sys_uname;
+    }
+
+    #if defined(__linux__) || defined(SRS_OSX)
+        // labeled system information as provided by the uname system call.
+        struct utsname buf;
+        if (uname(&buf) < 0) {
+            srs_warn("uname failed!");
+            return sys_uname;
+        }
+
+        std::stringstream ss;
+        ss << "sysname=\"" << buf.sysname << "\","
+        << "nodename=\"" << buf.nodename << "\","
+        << "release=\"" << buf.release << "\","
+        << "version=\"" << buf.version << "\","
+        << "machine=\"" << buf.machine;
+        sys_uname = ss.str();
+    #endif
+
+    return sys_uname;
+}

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -940,10 +940,9 @@ utsname* srs_get_system_uname_info()
     }
 
     system_info = new utsname();
+    memset(system_info, 0, sizeof(utsname));
     if (uname(system_info) < 0) {
-        srs_warn("uname failed!");
-        srs_freep(system_info);
-        return NULL;
+        srs_warn("uname failed");
     }
 
     return system_info;

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -43,7 +43,7 @@ using namespace std;
 #include <srs_protocol_http_stack.hpp>
 #include <srs_core_autofree.hpp>
 
-#ifdef __linux__ || SRS_OSX
+#if defined(__linux__) || defined(SRS_OSX)
 #include <sys/utsname.h>
 #endif
 

--- a/trunk/src/protocol/srs_protocol_utility.hpp
+++ b/trunk/src/protocol/srs_protocol_utility.hpp
@@ -26,6 +26,10 @@
 
 #include <srs_protocol_st.hpp>
 
+#if defined(__linux__) || defined(SRS_OSX)
+#include <sys/utsname.h>
+#endif
+
 class ISrsHttpMessage;
 
 class SrsMessageHeader;
@@ -187,8 +191,10 @@ extern std::string srs_get_system_hostname(void);
 // Read all content util EOF.
 extern srs_error_t srs_ioutil_read_all(ISrsReader* in, std::string& content);
 
+#if defined(__linux__) || defined(SRS_OSX)
 // Get system uname info.
-extern std::string srs_get_system_uname_info(void);
+extern utsname* srs_get_system_uname_info();
+#endif
 
 #endif
 

--- a/trunk/src/protocol/srs_protocol_utility.hpp
+++ b/trunk/src/protocol/srs_protocol_utility.hpp
@@ -187,5 +187,8 @@ extern std::string srs_get_system_hostname(void);
 // Read all content util EOF.
 extern srs_error_t srs_ioutil_read_all(ISrsReader* in, std::string& content);
 
+// Get system uname info.
+extern std::string srs_get_system_uname_info(void);
+
 #endif
 

--- a/trunk/src/utest/srs_utest_config.cpp
+++ b/trunk/src/utest/srs_utest_config.cpp
@@ -3644,6 +3644,15 @@ VOID TEST(ConfigMainTest, CheckVhostConfig5)
         EXPECT_EQ(0, (int)conf.get_stats_network());
         EXPECT_TRUE(conf.get_stats_disk_device() != NULL);
     }
+
+    if (true) {
+        MockSrsConfig conf;
+        HELPER_ASSERT_SUCCESS(conf.parse(_MIN_OK_CONF "exporter{enabled on;listen 9972;label cn-beijing;tag cn-edge;}"));
+        EXPECT_TRUE(conf.get_exporter_enabled());
+        EXPECT_STREQ("9972", conf.get_exporter_listen().c_str());
+        EXPECT_STREQ("cn-beijing", conf.get_exporter_label().c_str());
+        EXPECT_STREQ("cn-edge", conf.get_exporter_tag().c_str());
+    }
 }
 
 VOID TEST(ConfigMainTest, CheckIncludeConfig)


### PR DESCRIPTION
* Exporter: metrics support cpu gauge.
* Exporter: metrics support memory and uname..
* Exporter: Ignore error when uname fail.