### PR TITLE
Limit max frames in gop cache by gop_cache_max_frames

### DIFF
--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -1096,6 +1096,13 @@ vhost play.srs.com {
         # Overwrite by env SRS_VHOST_PLAY_GOP_CACHE for all vhosts.
         # default: on
         gop_cache off;
+
+        # to limit the max gop cache frames
+        # without this limit, if ingest stream always has no IDR frame,
+        # it may cause srs run out of memory
+        # default: 250
+        gop_cache_max_frames 250;
+
         # the max live queue length in seconds.
         # if the messages in the queue exceed the max length,
         # drop the old whole gop.

--- a/trunk/conf/srs.conf
+++ b/trunk/conf/srs.conf
@@ -37,7 +37,7 @@ vhost __defaultVhost__ {
         rtc_to_rtmp off;
     }
 
-	play{
-		gop_cache_max_frames 100;
+    play{
+        gop_cache_max_frames 100;
 	}
 }

--- a/trunk/conf/srs.conf
+++ b/trunk/conf/srs.conf
@@ -36,4 +36,8 @@ vhost __defaultVhost__ {
         # @see https://ossrs.net/lts/zh-cn/docs/v4/doc/webrtc#rtc-to-rtmp
         rtc_to_rtmp off;
     }
+
+	play{
+		gop_cache_max_frames 100;
+	}
 }

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -517,7 +517,8 @@ srs_error_t srs_config_transform_vhost(SrsConfDirective* root)
             //  SRS3+:
             //      vhost { play { shadow; } }
             if (n == "time_jitter" || n == "mix_correct" || n == "atc" || n == "atc_auto"
-                || n == "mw_latency" || n == "gop_cache" || n == "queue_length" || n == "send_min_interval"
+                || n == "mw_latency" || n == "gop_cache" || n == "gop_cache_max_frames" 
+                || n == "queue_length" || n == "send_min_interval"
                 || n == "reduce_sequence_header") {
                 it = dir->directives.erase(it);
                 
@@ -2548,7 +2549,7 @@ srs_error_t SrsConfig::check_normal_config()
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
                     if (m != "time_jitter" && m != "mix_correct" && m != "atc" && m != "atc_auto" && m != "mw_latency"
-                        && m != "gop_cache" && m != "queue_length" && m != "send_min_interval" && m != "reduce_sequence_header"
+                        && m != "gop_cache" && m != "gop_cache_max_frames" && m != "queue_length" && m != "send_min_interval" && m != "reduce_sequence_header"
                         && m != "mw_msgs") {
                         return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal vhost.play.%s of %s", m.c_str(), vhost->arg0().c_str());
                     }
@@ -4656,6 +4657,32 @@ bool SrsConfig::get_gop_cache(string vhost)
     
     return SRS_CONF_PERFER_TRUE(conf->arg0());
 }
+
+
+int SrsConfig::get_gop_cache_max_frames(string vhost)
+{
+    SRS_OVERWRITE_BY_ENV_INT("srs.vhost.play.gop_cache_max_frames");
+
+    static int DEFAULT = 250;
+
+    SrsConfDirective* conf = get_vhost(vhost);
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("play");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("gop_cache_max_frames");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+    
+    return ::atoi(conf->arg0().c_str());
+}
+
 
 bool SrsConfig::get_debug_srs_upnode(string vhost)
 {

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -553,6 +553,10 @@ public:
     // @return true when gop_cache is ok; otherwise, false.
     // @remark, default true.
     virtual bool get_gop_cache(std::string vhost);
+    // to set the max frames limit for gop cache
+    // @return gop cache frames limit
+    // @remark, default 250 (10s for 25fps)
+    virtual int get_gop_cache_max_frames(std::string vhost);
     // Whether debug_srs_upnode is enabled of vhost.
     // debug_srs_upnode is very important feature for tracable log,
     // but some server, for instance, flussonic donot support it.

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -560,6 +560,7 @@ srs_error_t SrsRtmpConn::stream_service_cycle()
     srs_trace("source url=%s, ip=%s, cache=%d, is_edge=%d, source_id=%s/%s",
         req->get_stream_url().c_str(), ip.c_str(), enabled_cache, info->edge, source->source_id().c_str(), source->pre_source_id().c_str());
     source->set_cache(enabled_cache);
+    source->set_cache_max_frames(_srs_config->get_gop_cache_max_frames(req->vhost));
     
     switch (info->type) {
         case SrsRtmpConnPlay: {

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -575,7 +575,7 @@ SrsGopCache::SrsGopCache()
     cached_video_count = 0;
     enable_gop_cache = true;
     audio_after_last_video_count = 0;
-    gop_cache_max_frames = 250;
+    gop_cache_max_frames_ = 250;
 }
 
 SrsGopCache::~SrsGopCache()
@@ -599,11 +599,11 @@ void SrsGopCache::set(bool v)
 }
 
 
-void SrsGopCache::set_max_frames(int m)
+void SrsGopCache::set_max_frames(int v)
 {
-    gop_cache_max_frames = m;
+    gop_cache_max_frames_ = v;
 
-    if (cached_video_count > gop_cache_max_frames){
+    if (cached_video_count > gop_cache_max_frames_){
         srs_warn("too much frames in the gop cache");
         clear();
     }
@@ -653,7 +653,7 @@ srs_error_t SrsGopCache::cache(SrsSharedPtrMessage* shared_msg)
         return err;
     }
     
-    if (cached_video_count > gop_cache_max_frames){
+    if (cached_video_count > gop_cache_max_frames_){
         srs_warn("too much frames in the gop cache");
         clear();
     }
@@ -2744,9 +2744,9 @@ void SrsLiveSource::set_cache(bool enabled)
     gop_cache->set(enabled);
 }
 
-void SrsLiveSource::set_cache_max_frames(int max)
+void SrsLiveSource::set_cache_max_frames(int v)
 {
-    gop_cache->set_max_frames(max);
+    gop_cache->set_max_frames(v);
 }
 
 

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -231,7 +231,7 @@ private:
     // to limit the max gop cache frames
     // without this limit, if ingest stream always has no IDR frame
     // it will cause srs run out of memory
-    int gop_cache_max_frames;
+    int gop_cache_max_frames_;
     // The video frame count, avoid cache for pure audio stream.
     int cached_video_count;
     // when user disabled video when publishing, and gop cache enalbed,
@@ -256,7 +256,7 @@ public:
     // To enable or disable the gop cache.
     virtual void set(bool v);
     // max gop frames
-    virtual void set_max_frames(int m);
+    virtual void set_max_frames(int v);
     virtual bool enabled();
     // only for h264 codec
     // 1. cache the gop when got h264 video packet.
@@ -595,7 +595,7 @@ public:
     virtual srs_error_t consumer_dumps(SrsLiveConsumer* consumer, bool ds = true, bool dm = true, bool dg = true);
     virtual void on_consumer_destroy(SrsLiveConsumer* consumer);
     virtual void set_cache(bool enabled);
-    virtual void set_cache_max_frames(int max);
+    virtual void set_cache_max_frames(int v);
     virtual SrsRtmpJitterAlgorithm jitter();
 public:
     // For edge, when publish edge stream, check the state

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -228,6 +228,10 @@ private:
     // The client will wait for the next keyframe for h264,
     // and will be black-screen.
     bool enable_gop_cache;
+    // to limit the max gop cache frames
+    // without this limit, if ingest stream always has no IDR frame
+    // it will cause srs run out of memory
+    int gop_cache_max_frames;
     // The video frame count, avoid cache for pure audio stream.
     int cached_video_count;
     // when user disabled video when publishing, and gop cache enalbed,
@@ -251,6 +255,8 @@ public:
     virtual void dispose();
     // To enable or disable the gop cache.
     virtual void set(bool v);
+    // max gop frames
+    virtual void set_max_frames(int m);
     virtual bool enabled();
     // only for h264 codec
     // 1. cache the gop when got h264 video packet.
@@ -589,6 +595,7 @@ public:
     virtual srs_error_t consumer_dumps(SrsLiveConsumer* consumer, bool ds = true, bool dm = true, bool dg = true);
     virtual void on_consumer_destroy(SrsLiveConsumer* consumer);
     virtual void set_cache(bool enabled);
+    virtual void set_cache_max_frames(int max);
     virtual SrsRtmpJitterAlgorithm jitter();
 public:
     // For edge, when publish edge stream, check the state


### PR DESCRIPTION
set limits for gop cahe max frames, to keep srs from run out of memory while stream pusher pushes no video key frames for a long time.