### PR TITLE
Support address sanitizer for utest and fix some leaks.

### DIFF
--- a/trunk/src/app/srs_app_conn.cpp
+++ b/trunk/src/app/srs_app_conn.cpp
@@ -59,6 +59,13 @@ SrsResourceManager::~SrsResourceManager()
 
     clear();
 
+    // Free all objects not in zombies.
+    std::vector<ISrsResource*>::iterator it;
+    for (it = conns_.begin(); it != conns_.end(); ++it) {
+        ISrsResource* resource = *it;
+        srs_freep(resource);
+    }
+
     srs_freepa(conns_level0_cache_);
 }
 

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -68,6 +68,61 @@ string srs_audio_codec_id2str(SrsAudioCodecId codec)
     }
 }
 
+SrsAudioSampleRate srs_audio_sample_rate_from_number(uint32_t v)
+{
+    if (v == 5512) return SrsAudioSampleRate5512;
+    if (v == 11025) return SrsAudioSampleRate11025;
+    if (v == 22050) return SrsAudioSampleRate22050;
+    if (v == 44100) return SrsAudioSampleRate44100;
+
+    if (v == 12000) return SrsAudioSampleRate12000;
+    if (v == 24000) return SrsAudioSampleRate24000;
+    if (v == 48000) return SrsAudioSampleRate48000;
+
+    if (v == 8000) return SrsAudioSampleRateNB8kHz;
+    if (v == 12000) return SrsAudioSampleRateMB12kHz;
+    if (v == 16000) return SrsAudioSampleRateWB16kHz;
+    if (v == 24000) return SrsAudioSampleRateSWB24kHz;
+    if (v == 48000) return SrsAudioSampleRateFB48kHz;
+
+    return SrsAudioSampleRateForbidden;
+}
+
+SrsAudioSampleRate srs_audio_sample_rate_guess_number(uint32_t v)
+{
+    if (v >= 48000) return SrsAudioSampleRate48000;
+    if (v >= 44100) return SrsAudioSampleRate44100;
+    if (v >= 24000) return SrsAudioSampleRate24000;
+    if (v >= 24000) return SrsAudioSampleRate24000;
+    if (v >= 22050) return SrsAudioSampleRate22050;
+    if (v >= 16000) return SrsAudioSampleRateWB16kHz;
+    if (v >= 12000) return SrsAudioSampleRate12000;
+    if (v >= 8000) return SrsAudioSampleRateNB8kHz;
+    if (v >= 5512) return SrsAudioSampleRate5512;
+
+    return SrsAudioSampleRateForbidden;
+}
+
+uint32_t srs_audio_sample_rate2number(SrsAudioSampleRate v)
+{
+    if (v == SrsAudioSampleRate5512) return 5512;
+    if (v == SrsAudioSampleRate11025) return 11025;
+    if (v == SrsAudioSampleRate22050) return 22050;
+    if (v == SrsAudioSampleRate44100) return 44100;
+
+    if (v == SrsAudioSampleRate12000) return 12000;
+    if (v == SrsAudioSampleRate24000) return 24000;
+    if (v == SrsAudioSampleRate48000) return 48000;
+
+    if (v == SrsAudioSampleRateNB8kHz) return 8000;
+    if (v == SrsAudioSampleRateMB12kHz) return 12000;
+    if (v == SrsAudioSampleRateWB16kHz) return 16000;
+    if (v == SrsAudioSampleRateSWB24kHz) return 24000;
+    if (v == SrsAudioSampleRateFB48kHz) return 48000;
+
+    return 0;
+}
+
 string srs_audio_sample_rate2str(SrsAudioSampleRate v)
 {
     switch (v) {

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -196,6 +196,11 @@ enum SrsAudioSampleRate
     SrsAudioSampleRate11025 = 1,
     SrsAudioSampleRate22050 = 2,
     SrsAudioSampleRate44100 = 3,
+
+    // For MP4, extra sampling rate to FLV.
+    SrsAudioSampleRate12000 = 12,
+    SrsAudioSampleRate24000 = 24,
+    SrsAudioSampleRate48000 = 48,
     
     // For Opus, support 8, 12, 16, 24, 48KHz
     // We will write a UINT8 sampling rate after FLV audio tag header.
@@ -206,6 +211,9 @@ enum SrsAudioSampleRate
     SrsAudioSampleRateSWB24kHz = 24, // SWB (super-wideband)
     SrsAudioSampleRateFB48kHz  = 48, // FB (fullband)
 };
+SrsAudioSampleRate srs_audio_sample_rate_from_number(uint32_t v);
+SrsAudioSampleRate srs_audio_sample_rate_guess_number(uint32_t v);
+uint32_t srs_audio_sample_rate2number(SrsAudioSampleRate v);
 std::string srs_audio_sample_rate2str(SrsAudioSampleRate v);
 
 /**

--- a/trunk/src/protocol/srs_protocol_http_stack.cpp
+++ b/trunk/src/protocol/srs_protocol_http_stack.cpp
@@ -689,12 +689,14 @@ srs_error_t SrsHttpServeMux::handle(std::string pattern, ISrsHttpHandler* handle
     srs_assert(handler);
     
     if (pattern.empty()) {
+        srs_freep(handler);
         return srs_error_new(ERROR_HTTP_PATTERN_EMPTY, "empty pattern");
     }
     
     if (entries.find(pattern) != entries.end()) {
         SrsHttpMuxEntry* exists = entries[pattern];
         if (exists->explicit_match) {
+            srs_freep(handler);
             return srs_error_new(ERROR_HTTP_PATTERN_DUPLICATED, "pattern=%s exists", pattern.c_str());
         }
     }

--- a/trunk/src/protocol/srs_protocol_rtmp_stack.cpp
+++ b/trunk/src/protocol/srs_protocol_rtmp_stack.cpp
@@ -3331,6 +3331,12 @@ SrsCreateStreamPacket::~SrsCreateStreamPacket()
     srs_freep(command_object);
 }
 
+void SrsCreateStreamPacket::set_command_object(SrsAmf0Any* v)
+{
+    srs_freep(command_object);
+    command_object = v;
+}
+
 srs_error_t SrsCreateStreamPacket::decode(SrsBuffer* stream)
 {
     srs_error_t err = srs_success;
@@ -3509,6 +3515,12 @@ SrsFMLEStartPacket::~SrsFMLEStartPacket()
     srs_freep(command_object);
 }
 
+void SrsFMLEStartPacket::set_command_object(SrsAmf0Any* v)
+{
+    srs_freep(command_object);
+    command_object = v;
+}
+
 srs_error_t SrsFMLEStartPacket::decode(SrsBuffer* stream)
 {
     srs_error_t err = srs_success;
@@ -3613,6 +3625,18 @@ SrsFMLEStartResPacket::~SrsFMLEStartResPacket()
     srs_freep(args);
 }
 
+void SrsFMLEStartResPacket::set_args(SrsAmf0Any* v)
+{
+    srs_freep(args);
+    args = v;
+}
+
+void SrsFMLEStartResPacket::set_command_object(SrsAmf0Any* v)
+{
+    srs_freep(command_object);
+    command_object = v;
+}
+
 srs_error_t SrsFMLEStartResPacket::decode(SrsBuffer* stream)
 {
     srs_error_t err = srs_success;
@@ -3689,6 +3713,12 @@ SrsPublishPacket::SrsPublishPacket()
 SrsPublishPacket::~SrsPublishPacket()
 {
     srs_freep(command_object);
+}
+
+void SrsPublishPacket::set_command_object(SrsAmf0Any* v)
+{
+    srs_freep(command_object);
+    command_object = v;
 }
 
 srs_error_t SrsPublishPacket::decode(SrsBuffer* stream)
@@ -3961,6 +3991,18 @@ SrsPlayResPacket::~SrsPlayResPacket()
     srs_freep(desc);
 }
 
+void SrsPlayResPacket::set_command_object(SrsAmf0Any* v)
+{
+    srs_freep(command_object);
+    command_object = v;
+}
+
+void SrsPlayResPacket::set_desc(SrsAmf0Object* v)
+{
+    srs_freep(desc);
+    desc = v;
+}
+
 int SrsPlayResPacket::get_prefer_cid()
 {
     return RTMP_CID_OverStream;
@@ -4012,6 +4054,12 @@ SrsOnBWDonePacket::~SrsOnBWDonePacket()
     srs_freep(args);
 }
 
+void SrsOnBWDonePacket::set_args(SrsAmf0Any* v)
+{
+    srs_freep(args);
+    args = v;
+}
+
 int SrsOnBWDonePacket::get_prefer_cid()
 {
     return RTMP_CID_OverConnection;
@@ -4059,6 +4107,18 @@ SrsOnStatusCallPacket::~SrsOnStatusCallPacket()
 {
     srs_freep(args);
     srs_freep(data);
+}
+
+void SrsOnStatusCallPacket::set_args(SrsAmf0Any* v)
+{
+    srs_freep(args);
+    args = v;
+}
+
+void SrsOnStatusCallPacket::set_data(SrsAmf0Object* v)
+{
+    srs_freep(data);
+    data = v;
 }
 
 int SrsOnStatusCallPacket::get_prefer_cid()
@@ -4109,6 +4169,12 @@ SrsOnStatusDataPacket::SrsOnStatusDataPacket()
 SrsOnStatusDataPacket::~SrsOnStatusDataPacket()
 {
     srs_freep(data);
+}
+
+void SrsOnStatusDataPacket::set_data(SrsAmf0Object* v)
+{
+    srs_freep(data);
+    data = v;
 }
 
 int SrsOnStatusDataPacket::get_prefer_cid()
@@ -4196,6 +4262,12 @@ SrsOnMetaDataPacket::SrsOnMetaDataPacket()
 SrsOnMetaDataPacket::~SrsOnMetaDataPacket()
 {
     srs_freep(metadata);
+}
+
+void SrsOnMetaDataPacket::set_metadata(SrsAmf0Object* v)
+{
+    srs_freep(metadata);
+    metadata = v;
 }
 
 srs_error_t SrsOnMetaDataPacket::decode(SrsBuffer* stream)

--- a/trunk/src/protocol/srs_protocol_rtmp_stack.hpp
+++ b/trunk/src/protocol/srs_protocol_rtmp_stack.hpp
@@ -908,6 +908,8 @@ public:
 public:
     SrsCreateStreamPacket();
     virtual ~SrsCreateStreamPacket();
+public:
+    void set_command_object(SrsAmf0Any* v);
 // Decode functions for concrete packet to override.
 public:
     virtual srs_error_t decode(SrsBuffer* stream);
@@ -982,6 +984,8 @@ public:
 public:
     SrsFMLEStartPacket();
     virtual ~SrsFMLEStartPacket();
+public:
+    void set_command_object(SrsAmf0Any* v);
 // Decode functions for concrete packet to override.
 public:
     virtual srs_error_t decode(SrsBuffer* stream);
@@ -1014,6 +1018,9 @@ public:
 public:
     SrsFMLEStartResPacket(double _transaction_id);
     virtual ~SrsFMLEStartResPacket();
+public:
+    void set_args(SrsAmf0Any* v);
+    void set_command_object(SrsAmf0Any* v);
 // Decode functions for concrete packet to override.
 public:
     virtual srs_error_t decode(SrsBuffer* stream);
@@ -1057,6 +1064,8 @@ public:
 public:
     SrsPublishPacket();
     virtual ~SrsPublishPacket();
+public:
+    void set_command_object(SrsAmf0Any* v);
 // Decode functions for concrete packet to override.
 public:
     virtual srs_error_t decode(SrsBuffer* stream);
@@ -1181,6 +1190,9 @@ public:
 public:
     SrsPlayResPacket();
     virtual ~SrsPlayResPacket();
+public:
+    void set_command_object(SrsAmf0Any* v);
+    void set_desc(SrsAmf0Object* v);
 // Encode functions for concrete packet to override.
 public:
     virtual int get_prefer_cid();
@@ -1204,6 +1216,8 @@ public:
 public:
     SrsOnBWDonePacket();
     virtual ~SrsOnBWDonePacket();
+public:
+    void set_args(SrsAmf0Any* v);
 // Encode functions for concrete packet to override.
 public:
     virtual int get_prefer_cid();
@@ -1232,6 +1246,9 @@ public:
 public:
     SrsOnStatusCallPacket();
     virtual ~SrsOnStatusCallPacket();
+public:
+    void set_args(SrsAmf0Any* v);
+    void set_data(SrsAmf0Object* v);
 // Encode functions for concrete packet to override.
 public:
     virtual int get_prefer_cid();
@@ -1255,6 +1272,9 @@ public:
 public:
     SrsOnStatusDataPacket();
     virtual ~SrsOnStatusDataPacket();
+public:
+    void set_data(SrsAmf0Object* v);
+    SrsAmf0Object* get_data();
 // Encode functions for concrete packet to override.
 public:
     virtual int get_prefer_cid();
@@ -1303,6 +1323,8 @@ public:
 public:
     SrsOnMetaDataPacket();
     virtual ~SrsOnMetaDataPacket();
+public:
+    void set_metadata(SrsAmf0Object* v);
 // Decode functions for concrete packet to override.
 public:
     virtual srs_error_t decode(SrsBuffer* stream);

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -665,6 +665,17 @@ bool srs_net_device_is_internet(const sockaddr* addr)
 }
 
 vector<SrsIPAddress*> _srs_system_ips;
+void srs_free_global_system_ips()
+{
+    vector<SrsIPAddress*>& ips = _srs_system_ips;
+
+    // Release previous IPs.
+    for (int i = 0; i < (int)ips.size(); i++) {
+        SrsIPAddress* ip = ips[i];
+        srs_freep(ip);
+    }
+    ips.clear();
+}
 
 void discover_network_iface(ifaddrs* cur, vector<SrsIPAddress*>& ips, stringstream& ss0, stringstream& ss1, bool ipv6, bool loopback)
 {
@@ -702,14 +713,10 @@ void discover_network_iface(ifaddrs* cur, vector<SrsIPAddress*>& ips, stringstre
 
 void retrieve_local_ips()
 {
-    vector<SrsIPAddress*>& ips = _srs_system_ips;
-
     // Release previous IPs.
-    for (int i = 0; i < (int)ips.size(); i++) {
-        SrsIPAddress* ip = ips[i];
-        srs_freep(ip);
-    }
-    ips.clear();
+    srs_free_global_system_ips();
+
+    vector<SrsIPAddress*>& ips = _srs_system_ips;
 
     // Get the addresses.
     ifaddrs* ifap;

--- a/trunk/src/utest/srs_utest.cpp
+++ b/trunk/src/utest/srs_utest.cpp
@@ -81,6 +81,9 @@ srs_error_t prepare_main() {
     return err;
 }
 
+// Free global data, for address sanitizer.
+extern void srs_free_global_system_ips();
+
 // We could do something in the main of utest.
 // Copy from gtest-1.6.0/src/gtest_main.cc
 GTEST_API_ int main(int argc, char **argv) {
@@ -97,7 +100,11 @@ GTEST_API_ int main(int argc, char **argv) {
     }
 
     testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+    int r0 = RUN_ALL_TESTS();
+
+    srs_free_global_system_ips();
+
+    return r0;
 }
 
 MockEmptyLog::MockEmptyLog(SrsLogLevel l)

--- a/trunk/src/utest/srs_utest_amf0.cpp
+++ b/trunk/src/utest/srs_utest_amf0.cpp
@@ -75,7 +75,7 @@ VOID TEST(ProtocolAMF0Test, ScenarioMain)
         EXPECT_EQ(0x03, bytes[0]);
         EXPECT_EQ(0x09, bytes[nb_bytes - 1]);
     }
-    SrsAutoFree(char, bytes);
+    SrsAutoFreeA(char, bytes);
     
     // decoding amf0 object from bytes
     // when user know the schema
@@ -1301,7 +1301,7 @@ VOID TEST(ProtocolAMF0Test, InterfacesString)
         EXPECT_TRUE(string("hello") == pp->to_str());
 
         // For copy.
-        SrsAmf0Any* cp = p->copy();
+        SrsAmf0Any* cp = p->copy(); SrsAutoFree(SrsAmf0Any, cp);
         EXPECT_TRUE(string("hello") == cp->to_str());
     }
 
@@ -1430,7 +1430,7 @@ VOID TEST(ProtocolAMF0Test, InterfacesBoolean)
         EXPECT_FALSE(p->to_boolean());
 
         // For copy.
-        SrsAmf0Any* cp = p->copy();
+        SrsAmf0Any* cp = p->copy(); SrsAutoFree(SrsAmf0Any, cp);
         EXPECT_FALSE(cp->to_boolean());
     }
 
@@ -1527,7 +1527,7 @@ VOID TEST(ProtocolAMF0Test, InterfacesNumber)
         EXPECT_TRUE(100.1 == p->to_number());
 
         // For copy.
-        SrsAmf0Any* cp = p->copy();
+        SrsAmf0Any* cp = p->copy(); SrsAutoFree(SrsAmf0Any, cp);
         EXPECT_TRUE(100.1 == cp->to_number());
     }
 
@@ -1790,6 +1790,7 @@ VOID TEST(ProtocolAMF0Test, InterfacesObject)
 
         // For copy.
         SrsAmf0Any* cp = p->copy();
+        SrsAutoFree(SrsAmf0Any, cp);
         EXPECT_TRUE(NULL != cp->to_object());
     }
 
@@ -1992,7 +1993,7 @@ VOID TEST(ProtocolAMF0Test, InterfacesObjectEOF)
         HELPER_EXPECT_SUCCESS(pp->read(&b));
 
         // For copy.
-        SrsAmf0Any* cp = p->copy();
+        SrsAmf0Any* cp = p->copy(); SrsAutoFree(SrsAmf0Any, cp);
         EXPECT_TRUE(cp->is_object_eof());
     }
 
@@ -2084,7 +2085,7 @@ VOID TEST(ProtocolAMF0Test, InterfacesEcmaArray)
         EXPECT_TRUE(NULL != pp->to_ecma_array());
 
         // For copy.
-        SrsAmf0Any* cp = p->copy();
+        SrsAmf0Any* cp = p->copy(); SrsAutoFree(SrsAmf0Any, cp);
         EXPECT_TRUE(NULL != cp->to_ecma_array());
     }
 
@@ -2211,7 +2212,7 @@ VOID TEST(ProtocolAMF0Test, InterfacesStrictArray)
         EXPECT_TRUE(NULL != pp->to_strict_array());
 
         // For copy.
-        SrsAmf0Any* cp = p->copy();
+        SrsAmf0Any* cp = p->copy(); SrsAutoFree(SrsAmf0Any, cp);
         EXPECT_TRUE(NULL != cp->to_strict_array());
     }
 

--- a/trunk/src/utest/srs_utest_avc.cpp
+++ b/trunk/src/utest/srs_utest_avc.cpp
@@ -222,7 +222,7 @@ VOID TEST(SrsAVCTest, H264IPBFrame)
         EXPECT_EQ(SrsVideoAvcFrameTraitSequenceHeader, uint8_t(flv[1]));
         EXPECT_EQ(01, flv[2]); EXPECT_EQ(02, flv[3]); EXPECT_EQ(03, flv[4]);
         EXPECT_STREQ("Hello", HELPER_ARR2STR(flv+5, 5).c_str());
-        srs_freep(flv);
+        srs_freepa(flv);
     }
 
     // For muxing I/P/B frame.
@@ -493,7 +493,7 @@ VOID TEST(SrsAVCTest, AACMuxToFLV)
         EXPECT_EQ(6, nb_flv);
         EXPECT_EQ(0x23, (uint8_t)flv[0]);
         EXPECT_STREQ("Hello", HELPER_ARR2STR(flv+1,5).c_str());
-        srs_freep(flv);
+        srs_freepa(flv);
     }
 
     // For Opus frame.
@@ -508,7 +508,7 @@ VOID TEST(SrsAVCTest, AACMuxToFLV)
         EXPECT_EQ(6, nb_flv);
         EXPECT_EQ(0xd3, (uint8_t)flv[0]);
         EXPECT_STREQ("Hello", HELPER_ARR2STR(flv+1,5).c_str());
-        srs_freep(flv);
+        srs_freepa(flv);
     }
 
     // For Speex frame.
@@ -523,7 +523,7 @@ VOID TEST(SrsAVCTest, AACMuxToFLV)
         EXPECT_EQ(6, nb_flv);
         EXPECT_EQ(0xb3, (uint8_t)flv[0]);
         EXPECT_STREQ("Hello", HELPER_ARR2STR(flv+1,5).c_str());
-        srs_freep(flv);
+        srs_freepa(flv);
     }
 
     // For AAC frame.
@@ -539,7 +539,7 @@ VOID TEST(SrsAVCTest, AACMuxToFLV)
         EXPECT_EQ(0xa3, (uint8_t)flv[0]);
         EXPECT_EQ(0x04, (uint8_t)flv[1]);
         EXPECT_STREQ("Hello", HELPER_ARR2STR(flv+2,5).c_str());
-        srs_freep(flv);
+        srs_freepa(flv);
     }
     if (true) {
         SrsRawAacStream h;
@@ -553,7 +553,7 @@ VOID TEST(SrsAVCTest, AACMuxToFLV)
         EXPECT_EQ(0xa6, (uint8_t)flv[0]);
         EXPECT_EQ(0x04, (uint8_t)flv[1]);
         EXPECT_STREQ("Hello", HELPER_ARR2STR(flv+2,5).c_str());
-        srs_freep(flv);
+        srs_freepa(flv);
     }
     if (true) {
         SrsRawAacStream h;
@@ -567,7 +567,7 @@ VOID TEST(SrsAVCTest, AACMuxToFLV)
         EXPECT_EQ(0xa5, (uint8_t)flv[0]);
         EXPECT_EQ(0x04, (uint8_t)flv[1]);
         EXPECT_STREQ("Hello", HELPER_ARR2STR(flv+2,5).c_str());
-        srs_freep(flv);
+        srs_freepa(flv);
     }
     if (true) {
         SrsRawAacStream h;
@@ -581,7 +581,7 @@ VOID TEST(SrsAVCTest, AACMuxToFLV)
         EXPECT_EQ(0xa7, (uint8_t)flv[0]);
         EXPECT_EQ(0x04, (uint8_t)flv[1]);
         EXPECT_STREQ("Hello", HELPER_ARR2STR(flv+2,5).c_str());
-        srs_freep(flv);
+        srs_freepa(flv);
     }
     if (true) {
         SrsRawAacStream h;
@@ -595,7 +595,7 @@ VOID TEST(SrsAVCTest, AACMuxToFLV)
         EXPECT_EQ(0xaf, (uint8_t)flv[0]);
         EXPECT_EQ(0x04, (uint8_t)flv[1]);
         EXPECT_STREQ("Hello", HELPER_ARR2STR(flv+2,5).c_str());
-        srs_freep(flv);
+        srs_freepa(flv);
     }
 }
 

--- a/trunk/src/utest/srs_utest_http.cpp
+++ b/trunk/src/utest/srs_utest_http.cpp
@@ -2081,6 +2081,7 @@ VOID TEST(ProtocolHTTPTest, QueryEscape)
             } else {
                 HELPER_ASSERT_FAILED(SrsHttpUri::query_unescape(d.in, value));
             }
+            srs_freep(d.err);
         }
     }
 

--- a/trunk/src/utest/srs_utest_kernel.cpp
+++ b/trunk/src/utest/srs_utest_kernel.cpp
@@ -227,8 +227,11 @@ MockSrsFileReader::MockSrsFileReader(const char* src, int nb_src)
     seekable = true;
     uf = new MockSrsFile();
 
-    uf->write((void*)src, nb_src, NULL);
-    uf->lseek(0, SEEK_SET, NULL);
+    srs_error_t err = uf->write((void*)src, nb_src, NULL);
+    srs_freep(err);
+
+    err = uf->lseek(0, SEEK_SET, NULL);
+    srs_freep(err);
 }
 
 MockSrsFileReader::~MockSrsFileReader()
@@ -255,20 +258,25 @@ bool MockSrsFileReader::is_open()
 int64_t MockSrsFileReader::tellg()
 {
     off_t offset = 0;
-    lseek(0, SEEK_CUR, &offset);
+    srs_error_t err = lseek(0, SEEK_CUR, &offset);
+    srs_freep(err);
+
     return offset;
 }
 
 void MockSrsFileReader::skip(int64_t _size)
 {
     int64_t offset = tellg() + _size;
-    lseek(offset, SEEK_SET, NULL);
+    srs_error_t err = lseek(offset, SEEK_SET, NULL);
+    srs_freep(err);
 }
 
 int64_t MockSrsFileReader::seek2(int64_t _offset)
 {
     off_t offset = 0;
-    lseek(_offset, SEEK_SET, &offset);
+    srs_error_t err = lseek(_offset, SEEK_SET, &offset);
+    srs_freep(err);
+
     return offset;
 }
 
@@ -277,7 +285,8 @@ int64_t MockSrsFileReader::filesize()
     int64_t cur = tellg();
 
     off_t offset = 0;
-    lseek(0, SEEK_END, &offset);
+    srs_error_t err = lseek(0, SEEK_END, &offset);
+    srs_freep(err);
 
     seek2(cur);
     return offset;
@@ -298,7 +307,8 @@ srs_error_t MockSrsFileReader::lseek(off_t offset, int whence, off_t* seeked)
 
 void MockSrsFileReader::mock_append_data(const char* data, int size)
 {
-    uf->write((void*)data, size, NULL);
+    srs_error_t err = uf->write((void*)data, size, NULL);
+    srs_freep(err);
 }
 
 void MockSrsFileReader::mock_reset_offset()
@@ -1127,6 +1137,11 @@ VOID TEST(KernelFLVTest, CoverVodStreamErrorCase)
 
 		HELPER_EXPECT_FAILED(d.seek2(1));
 	}
+}
+
+VOID TEST(KernelFLVTest, CoverVodStreamErrorCase2)
+{
+    srs_error_t err;
 
 	if (true) {
 		MockSrsFileReader r("HELLO", 5);
@@ -3076,22 +3091,21 @@ VOID TEST(KernelUtility, RTMPUtils2)
 
 VOID TEST(KernelErrorTest, CoverAll)
 {
+    srs_error_t err;
     if (true) {
-        EXPECT_TRUE(srs_is_system_control_error(srs_error_new(ERROR_CONTROL_RTMP_CLOSE, "err")));
-        EXPECT_TRUE(srs_is_system_control_error(srs_error_new(ERROR_CONTROL_REPUBLISH, "err")));
-        EXPECT_TRUE(srs_is_system_control_error(srs_error_new(ERROR_CONTROL_REDIRECT, "err")));
+        EXPECT_TRUE(srs_is_system_control_error(err = srs_error_new(ERROR_CONTROL_RTMP_CLOSE, "err"))); srs_freep(err);
+        EXPECT_TRUE(srs_is_system_control_error(err = srs_error_new(ERROR_CONTROL_REPUBLISH, "err"))); srs_freep(err);
+        EXPECT_TRUE(srs_is_system_control_error(err = srs_error_new(ERROR_CONTROL_REDIRECT, "err"))); srs_freep(err);
     }
     
     if (true) {
-        srs_error_t err = srs_error_new(ERROR_CONTROL_RTMP_CLOSE, "control error");
-        EXPECT_TRUE(srs_is_system_control_error(err));
-        srs_freep(err);
+        EXPECT_TRUE(srs_is_system_control_error(err = srs_error_new(ERROR_CONTROL_RTMP_CLOSE, "control error"))); srs_freep(err);
     }
     
     if (true) {
-        EXPECT_TRUE(srs_is_client_gracefully_close(srs_error_new(ERROR_SOCKET_READ, "err")));
-        EXPECT_TRUE(srs_is_client_gracefully_close(srs_error_new(ERROR_SOCKET_READ_FULLY, "err")));
-        EXPECT_TRUE(srs_is_client_gracefully_close(srs_error_new(ERROR_SOCKET_WRITE, "err")));
+        EXPECT_TRUE(srs_is_client_gracefully_close(err = srs_error_new(ERROR_SOCKET_READ, "err"))); srs_freep(err);
+        EXPECT_TRUE(srs_is_client_gracefully_close(err = srs_error_new(ERROR_SOCKET_READ_FULLY, "err"))); srs_freep(err);
+        EXPECT_TRUE(srs_is_client_gracefully_close(err = srs_error_new(ERROR_SOCKET_WRITE, "err"))); srs_freep(err);
     }
     
     if (true) {
@@ -5646,8 +5660,11 @@ VOID TEST(KernelMP4Test, CoverMP4M2tsSegmentEncoder)
             0x32, 0x0f, 0x18, 0x31, 0x96, 0x01, 0x00, 0x05, 0x68, 0xeb, 0xec, 0xb2, 0x2c
         };
         HELPER_EXPECT_SUCCESS(fmt.on_video(0, (char*)raw, sizeof(raw)));
+
+        uint8_t* cp = mock_copy_bytes(fmt.raw, fmt.nb_raw);
+        SrsAutoFreeA(uint8_t, cp);
         HELPER_EXPECT_SUCCESS(enc.write_sample(
-            SrsMp4HandlerTypeVIDE, fmt.video->frame_type, 0, 0, mock_copy_bytes(fmt.raw, fmt.nb_raw), fmt.nb_raw
+            SrsMp4HandlerTypeVIDE, fmt.video->frame_type, 0, 0, cp, fmt.nb_raw
         ));
     }
     
@@ -5656,8 +5673,11 @@ VOID TEST(KernelMP4Test, CoverMP4M2tsSegmentEncoder)
             0xaf, 0x00, 0x12, 0x10
         };
         HELPER_EXPECT_SUCCESS(fmt.on_audio(0, (char*)raw, sizeof(raw)));
+
+        uint8_t* cp = mock_copy_bytes(fmt.raw, fmt.nb_raw);
+        SrsAutoFreeA(uint8_t, cp);
         HELPER_EXPECT_SUCCESS(enc.write_sample(
-            SrsMp4HandlerTypeSOUN, 0x00, 0, 0, mock_copy_bytes(fmt.raw, fmt.nb_raw), fmt.nb_raw
+            SrsMp4HandlerTypeSOUN, 0x00, 0, 0, cp, fmt.nb_raw
         ));
     }
     
@@ -5672,8 +5692,11 @@ VOID TEST(KernelMP4Test, CoverMP4M2tsSegmentEncoder)
             0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5a, 0x5e
         };
         HELPER_EXPECT_SUCCESS(fmt.on_audio(0, (char*)raw, sizeof(raw)));
+
+        uint8_t* cp = mock_copy_bytes(fmt.raw, fmt.nb_raw);
+        SrsAutoFreeA(uint8_t, cp);
         HELPER_EXPECT_SUCCESS(enc.write_sample(
-            SrsMp4HandlerTypeSOUN, 0x00, 34, 34, mock_copy_bytes(fmt.raw, fmt.nb_raw), fmt.nb_raw
+            SrsMp4HandlerTypeSOUN, 0x00, 34, 34, cp, fmt.nb_raw
         ));
     }
     
@@ -5691,8 +5714,11 @@ VOID TEST(KernelMP4Test, CoverMP4M2tsSegmentEncoder)
             0xb2, 0x72, 0x5a
         };
         HELPER_EXPECT_SUCCESS(fmt.on_video(0, (char*)raw, sizeof(raw)));
+
+        uint8_t* cp = mock_copy_bytes(fmt.raw, fmt.nb_raw);
+        SrsAutoFreeA(uint8_t, cp);
         HELPER_EXPECT_SUCCESS(enc.write_sample(
-            SrsMp4HandlerTypeVIDE, fmt.video->frame_type, 40, 40, mock_copy_bytes(fmt.raw, fmt.nb_raw), fmt.nb_raw
+            SrsMp4HandlerTypeVIDE, fmt.video->frame_type, 40, 40, cp, fmt.nb_raw
         ));
     }
     

--- a/trunk/src/utest/srs_utest_rtc.cpp
+++ b/trunk/src/utest/srs_utest_rtc.cpp
@@ -68,7 +68,7 @@ VOID TEST(KernelRTCTest, RtpSTAPPayloadException)
     EXPECT_TRUE(nalu_type == kStapA);
     ISrsRtpPayloader* payload = new SrsRtpSTAPPayload();
 
-    EXPECT_TRUE((err = payload->decode(&buf)) != srs_success);
+    HELPER_ASSERT_FAILED(payload->decode(&buf));
     srs_freep(payload);
 }
 
@@ -710,7 +710,8 @@ VOID TEST(KernelRTCTest, NACKFetchRTPPacket)
     SrsRtcPlayStream play(&s, SrsContextId());
 
     SrsRtcTrackDescription ds;
-    SrsRtcVideoSendTrack *track = new SrsRtcVideoSendTrack(&s, &ds);
+    SrsRtcVideoSendTrack* track = new SrsRtcVideoSendTrack(&s, &ds);
+    SrsAutoFree(SrsRtcVideoSendTrack, track);
 
     // The RTP queue will free the packet.
     if (true) {

--- a/trunk/src/utest/srs_utest_rtmp.cpp
+++ b/trunk/src/utest/srs_utest_rtmp.cpp
@@ -435,10 +435,9 @@ VOID TEST(ProtocolRTMPTest, OnDecodeMessages)
         // Always response ACK message.
         HELPER_EXPECT_SUCCESS(p.set_in_window_ack_size(1));
 
-        SrsCommonMessage* msg;
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         io.in_buffer.append(&bytes);
         HELPER_EXPECT_FAILED(p.recv_message(&msg));
-        srs_freep(msg);
     }
 }
 
@@ -884,8 +883,7 @@ VOID TEST(ProtocolRTMPTest, RecvMessage)
         uint8_t bytes[] = {0x01, 0x00, 0x00};
         io.in_buffer.append((char*)bytes, sizeof(bytes));
 
-        SrsCommonMessage* msg;
-        SrsAutoFree(SrsCommonMessage, msg);
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_FAILED(p.recv_message(&msg));
     }
 
@@ -896,8 +894,7 @@ VOID TEST(ProtocolRTMPTest, RecvMessage)
         uint8_t bytes[] = {0x00, 0x00};
         io.in_buffer.append((char*)bytes, sizeof(bytes));
 
-        SrsCommonMessage* msg;
-        SrsAutoFree(SrsCommonMessage, msg);
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_FAILED(p.recv_message(&msg));
     }
 
@@ -908,8 +905,7 @@ VOID TEST(ProtocolRTMPTest, RecvMessage)
         uint8_t bytes[] = {0x00};
         io.in_buffer.append((char*)bytes, sizeof(bytes));
 
-        SrsCommonMessage* msg;
-        SrsAutoFree(SrsCommonMessage, msg);
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_FAILED(p.recv_message(&msg));
     }
 
@@ -917,8 +913,7 @@ VOID TEST(ProtocolRTMPTest, RecvMessage)
         MockBufferIO io;
         SrsProtocol p(&io);
 
-        SrsCommonMessage* msg;
-        SrsAutoFree(SrsCommonMessage, msg);
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_FAILED(p.recv_message(&msg));
     }
 }
@@ -934,8 +929,7 @@ VOID TEST(ProtocolRTMPTest, RecvMessage2)
         uint8_t bytes[] = {0x03, 0,0,0, 0,0,4, 0, 0,0,0,0, 1,2,3};
         io.in_buffer.append((char*)bytes, sizeof(bytes));
 
-        SrsCommonMessage* msg;
-        SrsAutoFree(SrsCommonMessage, msg);
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_FAILED(p.recv_message(&msg));
     }
 
@@ -948,10 +942,12 @@ VOID TEST(ProtocolRTMPTest, RecvMessage2)
         uint8_t bytes[] = {0x03, 0,0,0, 0,0,4, 0, 0,0,0,0, 1,2,3};
         io.in_buffer.append((char*)bytes, sizeof(bytes));
 
-        SrsCommonMessage* msg;
-        SrsAutoFree(SrsCommonMessage, msg);
-        HELPER_EXPECT_FAILED(p.recv_message(&msg));
+        if (true) {
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
+            HELPER_EXPECT_FAILED(p.recv_message(&msg));
+        }
 
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         uint8_t bytes2[] = {0x43, 0,0,0, 0,0,5, 0, 0,0,0,0, 1,2,3};
         io.in_buffer.append((char*)bytes2, sizeof(bytes2));
         HELPER_EXPECT_FAILED(p.recv_message(&msg));
@@ -964,8 +960,7 @@ VOID TEST(ProtocolRTMPTest, RecvMessage2)
         uint8_t bytes[] = {0x03};
         io.in_buffer.append((char*)bytes, sizeof(bytes));
 
-        SrsCommonMessage* msg;
-        SrsAutoFree(SrsCommonMessage, msg);
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_FAILED(p.recv_message(&msg));
     }
 
@@ -976,8 +971,7 @@ VOID TEST(ProtocolRTMPTest, RecvMessage2)
         uint8_t bytes[] = {0x43, 0,0,0, 0,0,0, 0};
         io.in_buffer.append((char*)bytes, sizeof(bytes));
 
-        SrsCommonMessage* msg;
-        SrsAutoFree(SrsCommonMessage, msg);
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_FAILED(p.recv_message(&msg));
     }
 }
@@ -1060,8 +1054,7 @@ VOID TEST(ProtocolRTMPTest, RecvMessage4)
 
         io.in_buffer.append(&io.out_buffer);
 
-        SrsCommonMessage* msg;
-        SrsAutoFree(SrsCommonMessage, msg);
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
 
         EXPECT_EQ(256, p.out_chunk_size);
@@ -1078,8 +1071,7 @@ VOID TEST(ProtocolRTMPTest, RecvMessage4)
 
         io.in_buffer.append(&io.out_buffer);
 
-        SrsCommonMessage* msg;
-        SrsAutoFree(SrsCommonMessage, msg);
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
 
         EXPECT_EQ(256, p.in_buffer_length);
@@ -1534,9 +1526,8 @@ VOID TEST(ProtocolRTMPTest, ServerCommandMessage)
 
             SrsProtocol p(&tio);
 
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
-            srs_freep(msg);
 
             EXPECT_EQ(1024, p.in_chunk_size);
         }
@@ -2239,7 +2230,7 @@ VOID TEST(ProtocolRTMPTest, CoverAll)
         EXPECT_EQ(0, r.get_recv_bytes());
         EXPECT_EQ(0, r.get_send_bytes());
 
-        SrsCommonMessage* msg = NULL;
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_FAILED(r.recv_message(&msg));
 
         SrsCallPacket* pkt = new SrsCallPacket();
@@ -2262,7 +2253,7 @@ VOID TEST(ProtocolRTMPTest, CoverAll)
         EXPECT_EQ(0, r.get_recv_bytes());
         EXPECT_EQ(0, r.get_send_bytes());
 
-        SrsCommonMessage* msg = NULL;
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_FAILED(r.recv_message(&msg));
 
         SrsCallPacket* pkt = new SrsCallPacket();
@@ -2585,8 +2576,8 @@ VOID TEST(ProtocolRTMPTest, ConnectAppWithArgs)
         if (true) {
             tio.in_buffer.append(&io.out_buffer);
 
-            SrsCommonMessage* msg = NULL;
-            SrsConnectAppPacket* pkt = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
+            SrsConnectAppPacket* pkt = NULL; SrsAutoFree(SrsConnectAppPacket, pkt);
             HELPER_ASSERT_SUCCESS(p.expect_message(&msg, &pkt));
 
             SrsAmf0Any* prop = pkt->command_object->get_property("tcUrl");
@@ -2616,9 +2607,8 @@ VOID TEST(ProtocolRTMPTest, AgentMessageCodec)
         }
 
         if (true) {
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
-            srs_freep(msg);
         }
     }
 
@@ -2633,14 +2623,11 @@ VOID TEST(ProtocolRTMPTest, AgentMessageCodec)
         }
 
         if (true) {
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_ASSERT_SUCCESS(p.recv_message(&msg));
 
-            SrsPacket* pkt = NULL;
+            SrsPacket* pkt = NULL; SrsAutoFree(SrsPacket, pkt);
             HELPER_EXPECT_SUCCESS(p.decode_message(msg, &pkt));
-
-            srs_freep(msg);
-            srs_freep(pkt);
         }
     }
 
@@ -2655,9 +2642,8 @@ VOID TEST(ProtocolRTMPTest, AgentMessageCodec)
         }
 
         if (true) {
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
-            srs_freep(msg);
         }
     }
 
@@ -2672,14 +2658,11 @@ VOID TEST(ProtocolRTMPTest, AgentMessageCodec)
         }
 
         if (true) {
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_ASSERT_SUCCESS(p.recv_message(&msg));
 
-            SrsPacket* pkt = NULL;
+            SrsPacket* pkt = NULL; SrsAutoFree(SrsPacket, pkt);
             HELPER_EXPECT_SUCCESS(p.decode_message(msg, &pkt));
-
-            srs_freep(msg);
-            srs_freep(pkt);
         }
     }
 }
@@ -2733,17 +2716,15 @@ VOID TEST(ProtocolRTMPTest, CheckStreamID)
         }
 
         if (true) {
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
             EXPECT_EQ(1, msg->header.stream_id);
-            srs_freep(msg);
         }
 
         if (true) {
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
             EXPECT_EQ(2, msg->header.stream_id);
-            srs_freep(msg);
         }
     }
 }
@@ -2767,9 +2748,8 @@ VOID TEST(ProtocolRTMPTest, AgentMessageTransform)
         }
 
         if (true) {
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
-            srs_freep(msg);
         }
     }
 
@@ -2788,9 +2768,8 @@ VOID TEST(ProtocolRTMPTest, AgentMessageTransform)
         }
 
         if (true) {
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
-            srs_freep(msg);
         }
     }
 
@@ -2809,9 +2788,8 @@ VOID TEST(ProtocolRTMPTest, AgentMessageTransform)
         }
 
         if (true) {
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
-            srs_freep(msg);
         }
     }
 
@@ -2830,9 +2808,8 @@ VOID TEST(ProtocolRTMPTest, AgentMessageTransform)
         }
 
         if (true) {
-            SrsCommonMessage* msg = NULL;
+            SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
             HELPER_EXPECT_SUCCESS(p.recv_message(&msg));
-            srs_freep(msg);
         }
     }
 }
@@ -2865,9 +2842,8 @@ VOID TEST(ProtocolRTMPTest, MergeReadHandler)
     r.set_merge_read(true, &h);
 
     if (true) {
-        SrsCommonMessage* msg = NULL;
+        SrsCommonMessage* msg = NULL; SrsAutoFree(SrsCommonMessage, msg);
         HELPER_EXPECT_SUCCESS(r.recv_message(&msg));
-        srs_freep(msg);
     }
 
     EXPECT_TRUE(h.nn > 0);
@@ -2924,6 +2900,8 @@ VOID TEST(ProtocolRTMPTest, CreateRTMPMessage)
         srs_freep(msg);
     }
 }
+
+extern void srs_utest_free_message_array(SrsMessageArray* arr);
 
 VOID TEST(ProtocolRTMPTest, OthersAll)
 {
@@ -2995,6 +2973,10 @@ VOID TEST(ProtocolRTMPTest, OthersAll)
 
     if (true) {
         SrsMessageArray h(10);
+
+        SrsMessageArray* parr = &h;
+        SrsAutoFreeH(SrsMessageArray, parr, srs_utest_free_message_array);
+
         h.msgs[0] = new SrsSharedPtrMessage();
         h.msgs[1] = new SrsSharedPtrMessage();
         EXPECT_TRUE(NULL != h.msgs[0]);

--- a/trunk/src/utest/srs_utest_service.cpp
+++ b/trunk/src/utest/srs_utest_service.cpp
@@ -636,6 +636,7 @@ VOID TEST(HTTPServerTest, ContentLength)
 
         SrsHttpParser hp; HELPER_ASSERT_SUCCESS(hp.initialize(HTTP_RESPONSE));
         ISrsHttpMessage* msg = NULL; HELPER_ASSERT_SUCCESS(hp.parse_message(&io, &msg));
+        SrsAutoFree(ISrsHttpMessage, msg);
 
         char buf[32]; ssize_t nread = 0;
         ISrsHttpResponseReader* r = msg->body_reader();
@@ -664,6 +665,7 @@ VOID TEST(HTTPServerTest, HTTPChunked)
 
         SrsHttpParser hp; HELPER_ASSERT_SUCCESS(hp.initialize(HTTP_RESPONSE));
         ISrsHttpMessage* msg = NULL; HELPER_ASSERT_SUCCESS(hp.parse_message(&io, &msg));
+        SrsAutoFree(ISrsHttpMessage, msg);
 
         char buf[32]; ssize_t nread = 0;
         ISrsHttpResponseReader* r = msg->body_reader();
@@ -720,6 +722,7 @@ VOID TEST(HTTPServerTest, InfiniteChunked)
 
         SrsHttpParser hp; HELPER_ASSERT_SUCCESS(hp.initialize(HTTP_RESPONSE));
         ISrsHttpMessage* msg = NULL; HELPER_ASSERT_SUCCESS(hp.parse_message(&io, &msg));
+        SrsAutoFree(ISrsHttpMessage, msg);
 
         char buf[32]; ssize_t nread = 0;
         ISrsHttpResponseReader* r = msg->body_reader();
@@ -1110,7 +1113,7 @@ VOID TEST(TCPServerTest, CoverUtility)
         hints.ai_family = AF_INET;
 
         addrinfo* r = NULL;
-        SrsAutoFree(addrinfo, r);
+        SrsAutoFreeH(addrinfo, r, freeaddrinfo);
         ASSERT_TRUE(!getaddrinfo("127.0.0.1", NULL, &hints, &r));
 
         EXPECT_FALSE(srs_net_device_is_internet((sockaddr*)r->ai_addr));
@@ -1123,7 +1126,7 @@ VOID TEST(TCPServerTest, CoverUtility)
         hints.ai_family = AF_INET;
 
         addrinfo* r = NULL;
-        SrsAutoFree(addrinfo, r);
+        SrsAutoFreeH(addrinfo, r, freeaddrinfo);
         ASSERT_TRUE(!getaddrinfo("192.168.0.1", NULL, &hints, &r));
 
         EXPECT_FALSE(srs_net_device_is_internet((sockaddr*)r->ai_addr));
@@ -1168,7 +1171,7 @@ VOID TEST(TCPServerTest, CoverUtility)
         hints.ai_family = AF_INET6;
 
         addrinfo* r = NULL;
-        SrsAutoFree(addrinfo, r);
+        SrsAutoFreeH(addrinfo, r, freeaddrinfo);
         ASSERT_TRUE(!getaddrinfo("2001:da8:6000:291:21f:d0ff:fed4:928c", NULL, &hints, &r));
 
         EXPECT_TRUE(srs_net_device_is_internet((sockaddr*)r->ai_addr));
@@ -1179,7 +1182,7 @@ VOID TEST(TCPServerTest, CoverUtility)
         hints.ai_family = AF_INET6;
 
         addrinfo* r = NULL;
-        SrsAutoFree(addrinfo, r);
+        SrsAutoFreeH(addrinfo, r, freeaddrinfo);
         ASSERT_TRUE(!getaddrinfo("3ffe:dead:beef::1", NULL, &hints, &r));
 
         EXPECT_TRUE(srs_net_device_is_internet((sockaddr*)r->ai_addr));
@@ -1192,7 +1195,7 @@ VOID TEST(TCPServerTest, CoverUtility)
         hints.ai_family = AF_INET6;
 
         addrinfo* r = NULL;
-        SrsAutoFree(addrinfo, r);
+        SrsAutoFreeH(addrinfo, r, freeaddrinfo);
         ASSERT_TRUE(!getaddrinfo("::", NULL, &hints, &r));
 
         EXPECT_FALSE(srs_net_device_is_internet((sockaddr*)r->ai_addr));
@@ -1205,7 +1208,7 @@ VOID TEST(TCPServerTest, CoverUtility)
         hints.ai_family = AF_INET6;
 
         addrinfo* r = NULL;
-        SrsAutoFree(addrinfo, r);
+        SrsAutoFreeH(addrinfo, r, freeaddrinfo);
         ASSERT_TRUE(!getaddrinfo("fec0::", NULL, &hints, &r));
 
         EXPECT_FALSE(srs_net_device_is_internet((sockaddr*)r->ai_addr));
@@ -1218,7 +1221,7 @@ VOID TEST(TCPServerTest, CoverUtility)
         hints.ai_family = AF_INET6;
 
         addrinfo* r = NULL;
-        SrsAutoFree(addrinfo, r);
+        SrsAutoFreeH(addrinfo, r, freeaddrinfo);
         ASSERT_TRUE(!getaddrinfo("FE80::", NULL, &hints, &r));
 
         EXPECT_FALSE(srs_net_device_is_internet((sockaddr*)r->ai_addr));
@@ -1231,7 +1234,7 @@ VOID TEST(TCPServerTest, CoverUtility)
         hints.ai_family = AF_INET6;
 
         addrinfo* r = NULL;
-        SrsAutoFree(addrinfo, r);
+        SrsAutoFreeH(addrinfo, r, freeaddrinfo);
         ASSERT_TRUE(!getaddrinfo("::1", NULL, &hints, &r));
 
         EXPECT_FALSE(srs_net_device_is_internet((sockaddr*)r->ai_addr));


### PR DESCRIPTION
f6c40242e  MP4: Fix memory leak when error.
f7a10f067 Kernel: Support free global objects for utest.
d8f03ea0d HTTP: Fix memory leak when error.
6c189f200  MP4: Support more sample rate for audio.
f89147971 RTMP: Support free field for utest.
b717c56c4 UTest: Support address sanitizer.