### PR TITLE
Windows: Replace ln by cp for windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 .idea
 .DS_Store
+*.heap
 
 cmake-build-debug
 /trunk/ide/srs_clion/CMakeCache.txt

--- a/trunk/auto/apps.sh
+++ b/trunk/auto/apps.sh
@@ -2,8 +2,7 @@
 #
 # params:
 #     $SRS_OBJS the objs directory to store the Makefile. ie. ./objs
-#     $SRS_OBJS_DIR the objs directory for Makefile. ie. objs
-#     $SRS_MAKEFILE the makefile name. ie. Makefile
+#     $SRS_OBJS the objs directory for Makefile. ie. objs
 #
 #     $MAIN_ENTRANCES array, disable all except the $APP_MAIN itself. ie. ["srs_main_server"]
 #     $APP_MAIN the object file that contains main function. ie. srs_main_server
@@ -13,9 +12,9 @@
 #     $ModuleLibFiles array, the 3rdpart library file to link with. ie. [objs/st-1.9/obj/libst.a objs/libx264/obj/libx264.a]
 #     $LINK_OPTIONS the linker options. ie. -ldl
 
-FILE=${SRS_OBJS}/${SRS_MAKEFILE}
+FILE=${SRS_OBJS}/Makefile
 
-APP_TARGET="${SRS_OBJS_DIR}/${APP_NAME}"
+APP_TARGET="${SRS_OBJS}/${APP_NAME}"
 
 echo "Generating app ${APP_NAME} depends.";
 
@@ -40,15 +39,16 @@ for item in ${MODULE_OBJS[*]}; do
         fi
     done
     
-    if [ ! -f ${item} ]; then
+    if [ ! -f ${SRS_WORKDIR}/${item} ]; then
         ignored=1
     fi
     
     if [ ${ignored} == 1 ]; then
+        echo "Ignore file ${FILE_NAME}"
         continue;
     fi
     
-    OBJ_FILE=${SRS_OBJS_DIR}/$item
+    OBJ_FILE=${SRS_OBJS}/$item
     OBJ_FILE="${OBJ_FILE%.*}.o"
     echo -n "${OBJ_FILE} " >> ${FILE}
 done
@@ -71,15 +71,16 @@ for item in ${MODULE_OBJS[*]}; do
         fi
     done
     
-    if [ ! -f ${item} ]; then
+    if [ ! -f ${SRS_WORKDIR}/${item} ]; then
         ignored=1
     fi
     
     if [ ${ignored} == 1 ]; then
+        echo "Ignore file ${FILE_NAME}"
         continue;
     fi
     
-    OBJ_FILE=${SRS_OBJS_DIR}/$item
+    OBJ_FILE=${SRS_OBJS}/$item
     OBJ_FILE="${OBJ_FILE%.*}.o"
     echo -n "${OBJ_FILE} " >> ${FILE}
 done

--- a/trunk/auto/auto_headers.sh
+++ b/trunk/auto/auto_headers.sh
@@ -44,67 +44,67 @@ function srs_undefine_macro()
 # generate auto headers file, depends on the finished of options.sh
 #####################################################################################
 # auto headers in depends.
-if [ $SRS_HDS = YES ]; then
+if [[ $SRS_HDS == YES ]]; then
     srs_define_macro "SRS_HDS" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_HDS" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_SRT = YES ]; then
+if [[ $SRS_SRT == YES ]]; then
     srs_define_macro "SRS_SRT" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_SRT" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_CXX11 = YES ]; then
+if [[ $SRS_CXX11 == YES ]]; then
     srs_define_macro "SRS_CXX11" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_CXX11" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_CXX14 = YES ]; then
+if [[ $SRS_CXX14 == YES ]]; then
     srs_define_macro "SRS_CXX14" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_CXX14" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_BACKTRACE = YES ]; then
+if [[ $SRS_BACKTRACE == YES ]]; then
     srs_define_macro "SRS_BACKTRACE" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_BACKTRACE" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_RTC = YES ]; then
+if [[ $SRS_RTC == YES ]]; then
     srs_define_macro "SRS_RTC" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_RTC" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_FFMPEG_FIT = YES ]; then
+if [[ $SRS_FFMPEG_FIT == YES ]]; then
     srs_define_macro "SRS_FFMPEG_FIT" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_FFMPEG_FIT" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_SIMULATOR = YES ]; then
+if [[ $SRS_SIMULATOR == YES ]]; then
     srs_define_macro "SRS_SIMULATOR" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_SIMULATOR" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_HTTPS = YES ]; then
+if [[ $SRS_HTTPS == YES ]]; then
     srs_define_macro "SRS_HTTPS" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_HTTPS" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_GB28181 = YES ]; then
+if [[ $SRS_GB28181 == YES ]]; then
     srs_define_macro "SRS_GB28181" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_GB28181" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_UTEST = YES ]; then
+if [[ $SRS_UTEST == YES ]]; then
     srs_define_macro "SRS_UTEST" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_UTEST" $SRS_AUTO_HEADERS_H
@@ -112,33 +112,33 @@ fi
 
 # whatever the FFMPEG tools, if transcode and ingest specified,
 # srs always compile the FFMPEG tool stub which used to start the FFMPEG process.
-if [ $SRS_FFMPEG_STUB = YES ]; then
+if [[ $SRS_FFMPEG_STUB == YES ]]; then
     srs_define_macro "SRS_FFMPEG_STUB" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_FFMPEG_STUB" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_GPERF = YES ]; then
+if [[ $SRS_GPERF == YES ]]; then
     srs_define_macro "SRS_GPERF" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_GPERF" $SRS_AUTO_HEADERS_H
 fi
-if [ $SRS_GPERF_MC = YES ]; then
+if [[ $SRS_GPERF_MC == YES ]]; then
     srs_define_macro "SRS_GPERF_MC" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_GPERF_MC" $SRS_AUTO_HEADERS_H
 fi
-if [ $SRS_GPERF_MD = YES ]; then
+if [[ $SRS_GPERF_MD == YES ]]; then
     srs_define_macro "SRS_GPERF_MD" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_GPERF_MD" $SRS_AUTO_HEADERS_H
 fi
-if [ $SRS_GPERF_MP = YES ]; then
+if [[ $SRS_GPERF_MP == YES ]]; then
     srs_define_macro "SRS_GPERF_MP" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_GPERF_MP" $SRS_AUTO_HEADERS_H
 fi
-if [ $SRS_GPERF_CP = YES ]; then
+if [[ $SRS_GPERF_CP == YES ]]; then
     srs_define_macro "SRS_GPERF_CP" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_GPERF_CP" $SRS_AUTO_HEADERS_H
@@ -148,44 +148,44 @@ fi
 # for embeded.
 #####################################################################################
 # for log level compile settings
-if [ $SRS_LOG_VERBOSE = YES ]; then
+if [[ $SRS_LOG_VERBOSE == YES ]]; then
     srs_define_macro "SRS_VERBOSE" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_VERBOSE" $SRS_AUTO_HEADERS_H
 fi
-if [ $SRS_LOG_INFO = YES ]; then
+if [[ $SRS_LOG_INFO == YES ]]; then
     srs_define_macro "SRS_INFO" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_INFO" $SRS_AUTO_HEADERS_H
 fi
-if [ $SRS_LOG_TRACE = YES ]; then
+if [[ $SRS_LOG_TRACE == YES ]]; then
     srs_define_macro "SRS_TRACE" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_TRACE" $SRS_AUTO_HEADERS_H
 fi
-if [ $SRS_LOG_LEVEL_V2 = YES ]; then
+if [[ $SRS_LOG_LEVEL_V2 == YES ]]; then
     srs_define_macro "SRS_LOG_LEVEL_V2" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_LOG_LEVEL_V2" $SRS_AUTO_HEADERS_H
 fi
-if [ $SRS_CROSS_BUILD = YES ]; then
+if [[ $SRS_CROSS_BUILD == YES ]]; then
     srs_define_macro "SRS_CROSSBUILD" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_CROSSBUILD" $SRS_AUTO_HEADERS_H
 fi
-if [ $SRS_OSX = YES ]; then
+if [[ $SRS_OSX == YES ]]; then
     srs_define_macro "SRS_OSX" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_OSX" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_DEBUG = YES ]; then
+if [[ $SRS_DEBUG == YES ]]; then
     srs_define_macro "SRS_DEBUG" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_DEBUG" $SRS_AUTO_HEADERS_H
 fi
 
-if [ $SRS_DEBUG_STATS = YES ]; then
+if [[ $SRS_DEBUG_STATS == YES ]]; then
     srs_define_macro "SRS_DEBUG_STATS" $SRS_AUTO_HEADERS_H
 else
     srs_undefine_macro "SRS_DEBUG_STATS" $SRS_AUTO_HEADERS_H

--- a/trunk/auto/codecov.sh
+++ b/trunk/auto/codecov.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # In .circleci/config.yml, generate *.gcno with
-#       ./configure --gcov --without-research --without-librtmp && make utest
+#       ./configure --gcov && make utest
 # and generate *.gcda by
 #       ./objs/srs_utest
 
 # Workdir is objs/cover.
-workdir=`pwd`/objs/cover
+workdir=$(cd `dirname $0`/.. && pwd)/objs/cover
 
 # Create trunk under workdir.
 mkdir -p $workdir && cd $workdir

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -14,8 +14,7 @@
 #####################################################################################
 # utilities
 #####################################################################################
-function require_sudoer()
-{
+function require_sudoer() {
     sudo echo "" >/dev/null 2>&1
     
     ret=$?; if [[ 0 -ne $ret ]]; then 
@@ -24,18 +23,10 @@ function require_sudoer()
     fi
 }
 
-# TODO: check gcc/g++
-echo "Checking gcc/g++/gdb/make."
-echo "Required tools are ok."
 #####################################################################################
 # for Ubuntu, auto install tools by apt-get
 #####################################################################################
-OS_IS_UBUNTU=NO
-function Ubuntu_prepare()
-{
-    # For Debian, we think it's ubuntu also.
-    # For example, the wheezy/sid which is debian armv7 linux, can not identified by uname -v.
-    OS_IS_UBUNTU=$(apt-get --version >/dev/null 2>&1 && echo YES)
+function Ubuntu_prepare() {
     if [[ $OS_IS_UBUNTU != YES ]]; then return 0; fi
     echo "Installing tools for Ubuntu."
     
@@ -125,10 +116,7 @@ Ubuntu_prepare; ret=$?; if [[ 0 -ne $ret ]]; then echo "Install tools for ubuntu
 #####################################################################################
 # for Centos, auto install tools by yum
 #####################################################################################
-OS_IS_CENTOS=NO
-function Centos_prepare()
-{
-    OS_IS_CENTOS=$(yum --version >/dev/null 2>&1 && echo YES)
+function Centos_prepare() {
     if [[ $OS_IS_CENTOS != YES ]]; then return 0; fi
     echo "Installing tools for Centos."
     
@@ -215,31 +203,22 @@ Centos_prepare; ret=$?; if [[ 0 -ne $ret ]]; then echo "Install tools for CentOS
 #####################################################################################
 # For OSX, auto install tools by brew
 #####################################################################################
-OS_IS_OSX=NO
-function OSX_prepare()
-{
-    uname -s|grep Darwin >/dev/null 2>&1
-    ret=$?; if [[ 0 -ne $ret ]]; then
-        if [ $SRS_OSX = YES ]; then
-            echo "OSX check failed, actual is `uname -s`"
-            exit 1;
-        fi
-        return 0;
+function OSX_prepare() {
+    if [[ $OS_IS_OSX != YES ]]; then
+        if [[ $SRS_OSX == YES ]]; then echo "OSX check failed, actual is `uname -s`"; exit 1; fi
+        return 0
     fi
 
     # cross build for arm, install the cross build tool chain.
-    if [ $SRS_CROSS_BUILD = YES ]; then
+    if [[ $SRS_CROSS_BUILD == YES ]]; then
         echo "The embeded(arm/mips) is invalid for OSX"
         return 1
     fi
 
-    OS_IS_OSX=YES
-    # requires the osx when os
-    if [ $OS_IS_OSX = YES ]; then
-        if [ $SRS_OSX = NO ]; then
-            echo "OSX detected, please use: ./configure --osx"
-            exit 1
-        fi
+    # Requires the osx when darwin detected
+    if [[ $OS_IS_OSX == YES && $SRS_OSX != YES ]]; then
+        echo "OSX detected, please use: ./configure --osx"
+        exit 1
     fi
 
     echo "OSX detected, install tools if needed"
@@ -312,68 +291,34 @@ function OSX_prepare()
 OSX_prepare; ret=$?; if [[ 0 -ne $ret ]]; then echo "OSX prepare failed, ret=$ret"; exit $ret; fi
 
 #####################################################################################
-# Detect CPU archs.
+# Check OS and CPU architectures.
 #####################################################################################
-OS_IS_LOONGARCH64=$(g++ -dM -E - </dev/null |grep '#define __loongarch64 1' -q && echo YES)
-OS_IS_MIPS64=$(g++ -dM -E - </dev/null |grep '#define __mips64 1' -q && echo YES)
-OS_IS_LOONGSON=$(uname -r |grep -q loongson && echo YES)
-OS_IS_X86_64=$(g++ -dM -E - </dev/null |grep -q '#define __x86_64 1' && echo YES)
-echo "OS_IS_LOONGARCH64:$OS_IS_LOONGARCH64, OS_IS_MIPS64:$OS_IS_MIPS64, OS_IS_LOONGSON:$OS_IS_LOONGSON, OS_IS_X86_64:$OS_IS_X86_64"
-
-#####################################################################################
-# for Centos, auto install tools by yum
-#####################################################################################
-# We must use a bash function instead of variable.
-function sed_utility() {
-    if [ $OS_IS_OSX = YES ]; then
-        sed -i '' "$@"
-    else
-        sed -i "$@"
-    fi
-
-    ret=$?; if [[ $ret -ne 0 ]]; then
-        if [ $OS_IS_OSX = YES ]; then
-            echo "sed -i '' \"$@\""
-        else
-            echo "sed -i \"$@\""
-        fi
-        return $ret
-    fi
-}
-SED="sed_utility" && echo "SED is $SED"
-
-function _srs_link_file()
-{
-    tmp_dir=$1; if [[ $tmp_dir != *'/' ]]; then tmp_dir+='/'; fi
-    tmp_dest=$2; if [[ $tmp_dest != *'/' ]]; then tmp_dest+='/'; fi
-    tmp_prefix=$3; if [[ $tmp_prefix != *'/' ]]; then tmp_prefix+='/'; fi
-
-    echo "LINK files at dir: $tmp_dir, dest: $tmp_dest, prefix: $tmp_prefix, pwd: `pwd`"
-    for file in `(cd $tmp_dir && find . -maxdepth 1 -type f ! -name '*.o' ! -name '*.d' ! -name '*.log')`; do
-        basefile=`basename $file` &&
-        #echo "ln -sf ${tmp_prefix}${tmp_dir}$basefile ${tmp_dest}$basefile" &&
-        ln -sf ${tmp_prefix}${tmp_dir}$basefile ${tmp_dest}$basefile;
-    done
-}
-
-#####################################################################################
-# check the os.
-#####################################################################################
-# Only supports:
-#       linux, centos/ubuntu as such,
-#       cross build for embeded system, for example, mips or arm,
-#       directly build on arm/mips, for example, pi or cubie,
-#       export srs-librtmp
-# others is invalid.
-if [[ $OS_IS_UBUNTU = NO && $OS_IS_CENTOS = NO && $OS_IS_OSX = NO && $SRS_CROSS_BUILD = NO ]]; then
+if [[ $OS_IS_UBUNTU != YES && $OS_IS_CENTOS != YES && $OS_IS_OSX != YES && $SRS_CROSS_BUILD != YES ]]; then
     echo "Your OS `uname -s` is not supported."
     exit 1
 fi
+
+# The absolute path of SRS_OBJS, for prefix and PKG_CONFIG_PATH
+SRS_DEPENDS_LIBS=$(mkdir -p $SRS_OBJS && cd $SRS_OBJS && pwd)
+echo -n "SRS_JOBS: $SRS_JOBS, SRS_DEPENDS_LIBS: ${SRS_DEPENDS_LIBS}"
+if [[ ! -z $OS_IS_LINUX ]]; then echo -n ", OS_IS_LINUX: $OS_IS_LINUX"; fi
+if [[ ! -z $OS_IS_OSX ]]; then echo -n ", OS_IS_OSX: $OS_IS_OSX"; fi
+if [[ ! -z $OS_IS_CYGWIN ]]; then echo -n ", OS_IS_CYGWIN: $OS_IS_CYGWIN"; fi
+if [[ ! -z $OS_IS_UBUNTU ]]; then echo -n ", OS_IS_UBUNTU: $OS_IS_UBUNTU"; fi
+if [[ ! -z $OS_IS_CENTOS ]]; then echo -n ", OS_IS_CENTOS: $OS_IS_CENTOS"; fi
+if [[ ! -z $SRS_CROSS_BUILD ]]; then echo -n ", SRS_CROSS_BUILD: $SRS_CROSS_BUILD"; fi
+if [[ ! -z $OS_IS_LOONGARCH64 ]]; then echo -n ", OS_IS_LOONGARCH64: $OS_IS_LOONGARCH64"; fi
+if [[ ! -z $OS_IS_MIPS64 ]]; then echo -n ", OS_IS_MIPS64: $OS_IS_MIPS64"; fi
+if [[ ! -z $OS_IS_LOONGSON ]]; then echo -n ", OS_IS_LOONGSON: $OS_IS_LOONGSON"; fi
+if [[ ! -z $OS_IS_X86_64 ]]; then echo -n ", OS_IS_X86_64: $OS_IS_X86_64"; fi
+if [[ ! -z $OS_IS_RISCV ]]; then echo -n ", OS_IS_RISCV: $OS_IS_RISCV"; fi
+echo ""
 
 #####################################################################################
 # Try to load cache if exists /usr/local/srs-cache
 #####################################################################################
 # Use srs-cache from base image.
+# See https://github.com/ossrs/dev-docker/blob/ubuntu20-cache/Dockerfile
 if [[ -d /usr/local/srs-cache/srs/trunk/objs && $(pwd) != "/usr/local/srs-cache/srs/trunk" ]]; then
     SOURCE_DIR=$(ls -d /usr/local/srs-cache/srs/trunk/objs/Platform-* 2>/dev/null|head -n 1)
     if [[ -d $SOURCE_DIR ]]; then
@@ -423,27 +368,22 @@ fi
 _ST_MAKE_ARGS="${_ST_MAKE} STATIC_ONLY=${_ST_STATIC_ONLY}"
 _ST_MAKE_ARGS="${_ST_MAKE_ARGS} CC=${SRS_TOOL_CC} AR=${SRS_TOOL_AR} LD=${SRS_TOOL_LD} RANDLIB=${SRS_TOOL_RANDLIB}"
 # Patched ST from https://github.com/ossrs/state-threads/tree/srs
-if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/st-srs/${_ST_OBJ}/libst.a ]]; then
-    echo "The state-threads is ok.";
+if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/st/libst.a ]]; then
+    rm -rf ${SRS_OBJS}/st && cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/st ${SRS_OBJS}/ &&
+    echo "The state-threads is ok."
 else
-    echo "Building state-threads.";
-    (
-        rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/st-srs && mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}/st-srs &&
-        # Create a hidden directory .src
-        cd ${SRS_OBJS}/${SRS_PLATFORM}/st-srs && ln -sf ../../../3rdparty/st-srs .src &&
-        # Link source files under .src
-        _srs_link_file .src/ ./ ./ &&
-        # Build source code.
-        env EXTRA_CFLAGS="${_ST_EXTRA_CFLAGS}" make ${_ST_MAKE_ARGS} &&
-        cd .. && rm -rf st && ln -sf st-srs/${_ST_OBJ} st
-    )
+    echo "Building state-threads." &&
+    rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/st-srs ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/st ${SRS_OBJS}/st &&
+    cp -rf ${SRS_WORKDIR}/3rdparty/st-srs ${SRS_OBJS}/${SRS_PLATFORM}/ &&
+    env EXTRA_CFLAGS="${_ST_EXTRA_CFLAGS}" make -C ${SRS_OBJS}/${SRS_PLATFORM}/st-srs ${_ST_MAKE_ARGS} &&
+    mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/st &&
+    cp -f ${SRS_OBJS}/${SRS_PLATFORM}/st-srs/${_ST_OBJ}/st.h ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/st/ &&
+    cp -f ${SRS_OBJS}/${SRS_PLATFORM}/st-srs/${_ST_OBJ}/libst.a ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/st/ &&
+    cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/st ${SRS_OBJS}/ &&
+    echo "The state-threads is ok."
 fi
 # check status
 ret=$?; if [[ $ret -ne 0 ]]; then echo "Build state-threads failed, ret=$ret"; exit $ret; fi
-# Always update the links.
-(cd ${SRS_OBJS}/${SRS_PLATFORM} && rm -rf st && ln -sf st-srs/${_ST_OBJ} st)
-(cd ${SRS_OBJS} && rm -rf st && ln -sf ${SRS_PLATFORM}/st-srs/${_ST_OBJ} st)
-if [ ! -f ${SRS_OBJS}/st/libst.a ]; then echo "Build state-threads static lib failed."; exit -1; fi
 
 #####################################################################################
 # nginx for HLS, nginx-1.5.0
@@ -462,43 +402,48 @@ mkdir -p ${SRS_OBJS}/nginx
 # the demo dir.
 # create forward dir
 mkdir -p ${SRS_OBJS}/nginx/html/live &&
-html_file=${SRS_OBJS}/nginx/html/live/livestream.html && hls_stream=livestream.m3u8 && write_nginx_html5
+html_file=${SRS_OBJS}/nginx/html/live/livestream.html && hls_stream=livestream.m3u8 && write_nginx_html5 &&
 
 # copy players to nginx html dir.
 rm -rf ${SRS_OBJS}/nginx/html/players &&
-ln -sf `pwd`/research/players ${SRS_OBJS}/nginx/html/players
+cp -rf $SRS_WORKDIR/research/players ${SRS_OBJS}/nginx/html/ &&
 
 # for favicon.ico
 rm -rf ${SRS_OBJS}/nginx/html/favicon.ico &&
-ln -sf `pwd`/research/api-server/static-dir/favicon.ico ${SRS_OBJS}/nginx/html/favicon.ico
+cp -f $SRS_WORKDIR/research/api-server/static-dir/favicon.ico ${SRS_OBJS}/nginx/html/favicon.ico &&
 
 # For srs-console.
 rm -rf ${SRS_OBJS}/nginx/html/console &&
-ln -sf `pwd`/research/console ${SRS_OBJS}/nginx/html/console
+cp -rf $SRS_WORKDIR/research/console ${SRS_OBJS}/nginx/html/ &&
 
 # For SRS signaling.
 rm -rf ${SRS_OBJS}/nginx/html/demos &&
-ln -sf `pwd`/3rdparty/signaling/www/demos ${SRS_OBJS}/nginx/html/demos
+cp -rf $SRS_WORKDIR/3rdparty/signaling/www/demos ${SRS_OBJS}/nginx/html/ &&
 
 # For home page index.html
 rm -rf ${SRS_OBJS}/nginx/html/index.html &&
-ln -sf `pwd`/research/api-server/static-dir/index.html ${SRS_OBJS}/nginx/html/index.html
+cp -f $SRS_WORKDIR/research/api-server/static-dir/index.html ${SRS_OBJS}/nginx/html/index.html &&
 
 # nginx.html to detect whether nginx is alive
 echo "Nginx is ok." > ${SRS_OBJS}/nginx/html/nginx.html
 
+# check status
+ret=$?; if [[ $ret -ne 0 ]]; then echo "Build web pages failed, ret=$ret"; exit $ret; fi
+
 #####################################################################################
 # Generate default self-sign certificate for HTTPS server, test only.
 #####################################################################################
-if [[ ! -f conf/server.key || ! -f conf/server.crt ]]; then
-    openssl genrsa -out conf/server.key 2048
-    openssl req -new -x509 -key conf/server.key -out conf/server.crt -days 3650 -subj "/C=CN/ST=Beijing/L=Beijing/O=Me/OU=Me/CN=ossrs.net"
+if [[ ! -f $SRS_WORKDIR/conf/server.key || ! -f $SRS_WORKDIR/conf/server.crt ]]; then
+    openssl genrsa -out $SRS_WORKDIR/conf/server.key 2048 &&
+    openssl req -new -x509 -key $SRS_WORKDIR/conf/server.key -out $SRS_WORKDIR/conf/server.crt -days 3650 \
+        -subj "/C=CN/ST=Beijing/L=Beijing/O=Me/OU=Me/CN=ossrs.net" &&
     echo "Generate test-only self-sign certificate files"
 fi
 
 #####################################################################################
 # cherrypy for http hooks callback, CherryPy-3.2.4
 #####################################################################################
+# TODO: FIXME: Replace by Go.
 if [[ $SRS_CHERRYPY == YES ]]; then
     # Detect python or python2
     python --version >/dev/null 2>&1 && SYS_PYTHON=python;
@@ -520,13 +465,13 @@ if [[ $SRS_CHERRYPY == YES ]]; then
 
     echo "Link players to cherrypy static-dir"
     rm -rf research/api-server/static-dir/players &&
-    ln -sf `pwd`/research/players research/api-server/static-dir/players &&
+    ln -sf $SRS_WORKDIR/research/players research/api-server/static-dir/players &&
     rm -rf research/api-server/static-dir/live &&
-    mkdir -p `pwd`/${SRS_OBJS}/nginx/html/live &&
-    ln -sf `pwd`/${SRS_OBJS}/nginx/html/live research/api-server/static-dir/live &&
+    mkdir -p $SRS_WORKDIR/${SRS_OBJS}/nginx/html/live &&
+    ln -sf $SRS_WORKDIR/${SRS_OBJS}/nginx/html/live research/api-server/static-dir/live &&
     rm -rf research/api-server/static-dir/forward &&
-    mkdir -p `pwd`/${SRS_OBJS}/nginx/html/forward &&
-    ln -sf `pwd`/${SRS_OBJS}/nginx/html/forward research/api-server/static-dir/forward
+    mkdir -p $SRS_WORKDIR/${SRS_OBJS}/nginx/html/forward &&
+    ln -sf $SRS_WORKDIR/${SRS_OBJS}/nginx/html/forward research/api-server/static-dir/forward
     ret=$?; if [[ $ret -ne 0 ]]; then echo "Warning: Ignore error to link players to cherrypy static-dir."; fi
 fi
 
@@ -548,14 +493,14 @@ if [[ $SRS_SSL == YES && $SRS_USE_SYS_SSL != YES ]]; then
         if [[ $SRS_CROSS_BUILD_ARCH == "arm" ]]; then OPENSSL_CONFIG="./Configure linux-armv4"; fi
         if [[ $SRS_CROSS_BUILD_ARCH == "aarch64" ]]; then OPENSSL_CONFIG="./Configure linux-aarch64"; fi
         if [[ $SRS_CROSS_BUILD_ARCH == "mipsel" ]]; then OPENSSL_CONFIG="./Configure linux-mips32"; fi
-    elif [[ ! -f ${SRS_OBJS}/${SRS_PLATFORM}/openssl/lib/libssl.a ]]; then
+    elif [[ ! -f ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl/lib/libssl.a ]]; then
         # Try to use exists libraries.
         if [[ -f /usr/local/ssl/lib/libssl.a && $SRS_SSL_LOCAL == NO ]]; then
-            (mkdir -p  ${SRS_OBJS}/${SRS_PLATFORM}/openssl/lib && cd ${SRS_OBJS}/${SRS_PLATFORM}/openssl/lib &&
-                ln -sf /usr/local/ssl/lib/libssl.a && ln -sf /usr/local/ssl/lib/libcrypto.a &&
-                mkdir -p /usr/local/ssl/lib/pkgconfig && ln -sf /usr/local/ssl/lib/pkgconfig)
-            (mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}/openssl/include && cd ${SRS_OBJS}/${SRS_PLATFORM}/openssl/include &&
-                ln -sf /usr/local/ssl/include/openssl)
+            (mkdir -p  ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl/lib && cd ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl/lib &&
+                cp /usr/local/ssl/lib/libssl.a . && cp /usr/local/ssl/lib/libcrypto.a . &&
+                mkdir -p /usr/local/ssl/lib/pkgconfig && cp -rf /usr/local/ssl/lib/pkgconfig .)
+            (mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl/include && cd ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl/include &&
+                cp -rf /usr/local/ssl/include/openssl .)
         fi
         # Warning if not use the system ssl.
         if [[ -f /usr/local/ssl/lib/libssl.a && $SRS_SSL_LOCAL == YES ]]; then
@@ -579,10 +524,12 @@ if [[ $SRS_SSL == YES && $SRS_USE_SYS_SSL != YES ]]; then
     # Use 1.0 if required.
     if [[ $SRS_SSL_1_0 == YES ]]; then
         OPENSSL_AR="$SRS_TOOL_AR -r" # For openssl 1.0, MUST specifies the args for ar or build faild.
-        OPENSSL_CANDIDATE="openssl-OpenSSL_1_0_2u" && OPENSSL_UNZIP="tar xf ../../3rdparty/$OPENSSL_CANDIDATE.tar.gz"
+        OPENSSL_CANDIDATE="openssl-OpenSSL_1_0_2u" &&
+        OPENSSL_UNZIP="tar xf ${SRS_WORKDIR}/3rdparty/$OPENSSL_CANDIDATE.tar.gz -C ${SRS_OBJS}/${SRS_PLATFORM}"
     else
         OPENSSL_AR="$SRS_TOOL_AR"
-        OPENSSL_CANDIDATE="openssl-1.1-fit" && OPENSSL_UNZIP="cp -R ../../3rdparty/$OPENSSL_CANDIDATE ."
+        OPENSSL_CANDIDATE="openssl-1.1-fit" &&
+        OPENSSL_UNZIP="cp -R ${SRS_WORKDIR}/3rdparty/$OPENSSL_CANDIDATE ${SRS_OBJS}/${SRS_PLATFORM}/"
     fi
     #
     # https://wiki.openssl.org/index.php/Compilation_and_Installation#Configure_Options
@@ -593,28 +540,26 @@ if [[ $SRS_SSL == YES && $SRS_USE_SYS_SSL != YES ]]; then
     #OPENSSL_OPTIONS="$OPENSSL_OPTIONS -no-ssl2 -no-comp -no-idea -no-hw -no-engine -no-dso -no-err -no-nextprotoneg -no-psk -no-srp -no-ec2m -no-weak-ssl-ciphers"
     #
     # cross build not specified, if exists flag, need to rebuild for no-arm platform.
-    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/$OPENSSL_CANDIDATE/_release/lib/libssl.a ]]; then
-        echo "The $OPENSSL_CANDIDATE is ok.";
+    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl/lib/libssl.a ]]; then
+        rm -rf ${SRS_OBJS}/openssl && cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl ${SRS_OBJS}/ &&
+        echo "The $OPENSSL_CANDIDATE is ok."
     else
-        echo "Building $OPENSSL_CANDIDATE.";
+        echo "Building $OPENSSL_CANDIDATE." &&
+        rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/${OPENSSL_CANDIDATE} ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl \
+            ${SRS_OBJS}/openssl &&
+        ${OPENSSL_UNZIP} &&
         (
-            rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/${OPENSSL_CANDIDATE} && cd ${SRS_OBJS}/${SRS_PLATFORM} &&
-            ${OPENSSL_UNZIP} && cd $OPENSSL_CANDIDATE && ${OPENSSL_CONFIG} --prefix=`pwd`/_release $OPENSSL_OPTIONS &&
-            make CC=${SRS_TOOL_CC} AR="${OPENSSL_AR}" LD=${SRS_TOOL_LD} RANDLIB=${SRS_TOOL_RANDLIB} ${SRS_JOBS} && make install_sw &&
-            cd .. && rm -rf openssl && ln -sf $OPENSSL_CANDIDATE/_release openssl
-        )
-    fi
-    # Which lib we use.
-    OPENSSL_LIB="$OPENSSL_CANDIDATE/_release"
-    if [[ ! -f ${SRS_OBJS}/${SRS_PLATFORM}/${OPENSSL_LIB}/lib/libssl.a ]]; then
-        OPENSSL_LIB="openssl"
+            cd ${SRS_OBJS}/${SRS_PLATFORM}/${OPENSSL_CANDIDATE} &&
+            ${OPENSSL_CONFIG} --prefix=${SRS_DEPENDS_LIBS}/${SRS_PLATFORM}/3rdpatry/openssl $OPENSSL_OPTIONS
+        ) &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/${OPENSSL_CANDIDATE} CC=${SRS_TOOL_CC} AR="${OPENSSL_AR}" \
+            LD=${SRS_TOOL_LD} RANDLIB=${SRS_TOOL_RANDLIB} ${SRS_JOBS} &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/${OPENSSL_CANDIDATE} install_sw &&
+        cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl ${SRS_OBJS}/ &&
+        echo "The $OPENSSL_CANDIDATE is ok."
     fi
     # check status
     ret=$?; if [[ $ret -ne 0 ]]; then echo "Build $OPENSSL_CANDIDATE failed, ret=$ret"; exit $ret; fi
-    # Always update the links.
-    (cd ${SRS_OBJS}/${SRS_PLATFORM} && rm -rf openssl && ln -sf $OPENSSL_CANDIDATE/_release openssl)
-    (cd ${SRS_OBJS} && rm -rf openssl && ln -sf ${SRS_PLATFORM}/${OPENSSL_LIB} openssl)
-    if [ ! -f ${SRS_OBJS}/openssl/lib/libssl.a ]; then echo "Build $OPENSSL_CANDIDATE failed."; exit -1; fi
 fi
 
 #####################################################################################
@@ -631,68 +576,69 @@ if [[ $SRS_RTC == YES ]]; then
     # If use ASM for SRTP, we enable openssl(with ASM).
     if [[ $SRS_SRTP_ASM == YES ]]; then
         SRTP_OPTIONS="--enable-openssl"
-        SRTP_CONFIGURE="env PKG_CONFIG_PATH=$(cd ${SRS_OBJS}/${SRS_PLATFORM} && pwd)/openssl/lib/pkgconfig ./configure"
+        SRTP_CONFIGURE="env PKG_CONFIG_PATH=${SRS_DEPENDS_LIBS}/openssl/lib/pkgconfig ./configure"
     else
+        SRTP_OPTIONS="--disable-openssl"
         SRTP_CONFIGURE="./configure"
     fi
     if [[ $SRS_CROSS_BUILD == YES ]]; then
         SRTP_OPTIONS="$SRTP_OPTIONS --host=$SRS_CROSS_BUILD_HOST"
     fi
-    if [[ $OS_IS_LOONGARCH64 = YES ]]; then
+    if [[ $OS_IS_LOONGARCH64 == YES ]]; then
         SRTP_OPTIONS="$SRTP_OPTIONS --build=loongarch64-unknown-linux-gnu"
     fi
-    # Patched ST from https://github.com/ossrs/state-threads/tree/srs
-    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/libsrtp-2-fit/_release/lib/libsrtp2.a ]]; then
-        echo "The libsrtp-2-fit is ok.";
+    # Copy and patch source files, then build and install libsrtp.
+    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srtp2/lib/libsrtp2.a ]]; then
+        rm -rf ${SRS_OBJS}/srtp2 &&
+        cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srtp2 ${SRS_OBJS} &&
+        echo "The libsrtp-2-fit is ok."
     else
-        echo "Building libsrtp-2-fit.";
+        echo "Building libsrtp-2-fit."
+        rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/libsrtp-2-fit ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srtp2 \
+            ${SRS_OBJS}/srtp2 &&
+        cp -rf ${SRS_WORKDIR}/3rdparty/libsrtp-2-fit ${SRS_OBJS}/${SRS_PLATFORM}/ &&
+        patch -p0 ${SRS_OBJS}/${SRS_PLATFORM}/libsrtp-2-fit/crypto/math/datatypes.c ${SRS_WORKDIR}/3rdparty/patches/srtp/gcc10-01.patch &&
+        patch -p0 ${SRS_OBJS}/${SRS_PLATFORM}/libsrtp-2-fit/config.guess ${SRS_WORKDIR}/3rdparty/patches/srtp/config.guess-02.patch &&
         (
-            rm -rf ${SRS_OBJS}/srtp2 && cd ${SRS_OBJS}/${SRS_PLATFORM} &&
-            rm -rf libsrtp-2-fit && cp -R ../../3rdparty/libsrtp-2-fit . && cd libsrtp-2-fit &&
-            patch -p0 crypto/math/datatypes.c ../../../3rdparty/patches/srtp/gcc10-01.patch &&
-            patch -p0 config.guess ../../../3rdparty/patches/srtp/config.guess-02.patch &&
-            $SRTP_CONFIGURE ${SRTP_OPTIONS} --prefix=`pwd`/_release &&
-            make ${SRS_JOBS} && make install &&
-            cd .. && rm -rf srtp2 && ln -sf libsrtp-2-fit/_release srtp2
-        )
+            cd ${SRS_OBJS}/${SRS_PLATFORM}/libsrtp-2-fit &&
+            $SRTP_CONFIGURE ${SRTP_OPTIONS} --prefix=${SRS_DEPENDS_LIBS}/${SRS_PLATFORM}/3rdpatry/srtp2
+        ) &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/libsrtp-2-fit ${SRS_JOBS} &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/libsrtp-2-fit install &&
+        cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srtp2 ${SRS_OBJS}/ &&
+        echo "The libsrtp-2-fit is ok."
     fi
-    # check status
-    ret=$?; if [[ $ret -ne 0 ]]; then echo "Build libsrtp-2-fit failed, ret=$ret"; exit $ret; fi
-    # Always update the links.
-    (cd ${SRS_OBJS}/${SRS_PLATFORM} && rm -rf srtp2 && ln -sf libsrtp-2-fit/_release srtp2)
-    (cd ${SRS_OBJS} && rm -rf srtp2 && ln -sf ${SRS_PLATFORM}/libsrtp-2-fit/_release srtp2)
-    if [ ! -f ${SRS_OBJS}/srtp2/lib/libsrtp2.a ]; then echo "Build libsrtp-2-fit static lib failed."; exit -1; fi
+    ret=$?; if [[ $ret -ne 0 ]]; then echo "Build libsrtp failed, ret=$ret"; exit $ret; fi
 fi
 
 #####################################################################################
 # libopus, for WebRTC to transcode AAC with Opus.
 #####################################################################################
 # For cross build, we use opus of FFmpeg, so we don't build the libopus.
-if [[ $SRS_RTC == YES && $SRS_CROSS_BUILD == NO ]]; then
+if [[ $SRS_RTC == YES && $SRS_CROSS_BUILD != YES ]]; then
     # Only build static libraries if no shared FFmpeg.
     if [[ $SRS_SHARED_FFMPEG == NO ]]; then
         OPUS_OPTIONS="--disable-shared --disable-doc"
     fi
-    if [[ $OS_IS_LOONGARCH64 = YES ]]; then
+    if [[ $OS_IS_LOONGARCH64 == YES ]]; then
         OPUS_OPTIONS="$OPUS_OPTIONS --build=loongarch64-unknown-linux-gnu"
     fi
-    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1/_release/lib/libopus.a ]]; then
-        echo "The opus-1.3.1 is ok.";
+    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/opus/lib/libopus.a ]]; then
+        rm -rf ${SRS_OBJS}/opus && cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/opus ${SRS_OBJS}/ &&
+        echo "The opus-1.3.1 is ok."
     else
-        echo "Building opus-1.3.1.";
+        echo "Building opus-1.3.1." &&
+        rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/opus ${SRS_OBJS}/opus &&
+        tar xf ${SRS_WORKDIR}/3rdparty/opus-1.3.1.tar.gz -C ${SRS_OBJS}/${SRS_PLATFORM} &&
         (
-            rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 && cd ${SRS_OBJS}/${SRS_PLATFORM} &&
-            tar xf ../../3rdparty/opus-1.3.1.tar.gz && cd opus-1.3.1 &&
-            ./configure --prefix=`pwd`/_release --enable-static $OPUS_OPTIONS &&
-            make ${SRS_JOBS} && make install &&
-            cd .. && rm -rf opus && ln -sf opus-1.3.1/_release opus
-        )
+            cd ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 &&
+            ./configure --prefix=${SRS_DEPENDS_LIBS}/${SRS_PLATFORM}/3rdpatry/opus --enable-static $OPUS_OPTIONS
+        ) &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 ${SRS_JOBS} &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 install &&
+        cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/opus ${SRS_OBJS}/ &&
+        echo "The opus-1.3.1 is ok."
     fi
-    # check status
-    ret=$?; if [[ $ret -ne 0 ]]; then echo "Build opus-1.3.1 failed, ret=$ret"; exit $ret; fi
-    # Always update the links.
-    (cd ${SRS_OBJS}/${SRS_PLATFORM} && rm -rf opus && ln -sf opus-1.3.1/_release opus)
-    (cd ${SRS_OBJS} && rm -rf opus && ln -sf ${SRS_PLATFORM}/opus-1.3.1/_release opus)
     if [ ! -f ${SRS_OBJS}/opus/lib/libopus.a ]; then echo "Build opus-1.3.1 failed."; exit -1; fi
 fi
 
@@ -704,7 +650,7 @@ if [[ $SRS_FFMPEG_FIT == YES ]]; then
     if [[ $SRS_CROSS_BUILD == YES ]]; then
       FFMPEG_CONFIGURE=./configure
     else
-      FFMPEG_CONFIGURE="env PKG_CONFIG_PATH=$(cd ${SRS_OBJS}/${SRS_PLATFORM} && pwd)/opus/lib/pkgconfig ./configure"
+      FFMPEG_CONFIGURE="env PKG_CONFIG_PATH=${SRS_DEPENDS_LIBS}/opus/lib/pkgconfig ./configure"
     fi
 
     # Disable all asm for FFmpeg, to compatible with ARM CPU.
@@ -731,17 +677,18 @@ if [[ $SRS_FFMPEG_FIT == YES ]]; then
         FFMPEG_OPTIONS="$FFMPEG_OPTIONS --enable-decoder=libopus --enable-encoder=libopus --enable-libopus"
     fi
 
-    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/_release/lib/libavcodec.a ]]; then
-        echo "The ffmpeg-4-fit is ok.";
+    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/ffmpeg/lib/libavcodec.a ]]; then
+        rm -rf ${SRS_OBJS}/ffmpeg && cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/ffmpeg ${SRS_OBJS}/ &&
+        echo "The ffmpeg-4-fit is ok."
     else
-        echo "Building ffmpeg-4-fit.";
+        echo "Building ffmpeg-4-fit." &&
+        rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/ffmpeg \
+            ${SRS_OBJS}/ffmpeg &&
+        cp -rf ${SRS_WORKDIR}/3rdparty/ffmpeg-4-fit ${SRS_OBJS}/${SRS_PLATFORM}/ &&
         (
-            rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit && mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit &&
-            # Create a hidden directory .src
-            cd ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit && cp -R ../../../3rdparty/ffmpeg-4-fit/* . &&
-            # Build source code.
+            cd ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit &&
             $FFMPEG_CONFIGURE \
-              --prefix=`pwd`/_release --pkg-config=pkg-config \
+              --prefix=${SRS_DEPENDS_LIBS}/${SRS_PLATFORM}/3rdpatry/ffmpeg --pkg-config=pkg-config \
               --pkg-config-flags="--static" --extra-libs="-lpthread" --extra-libs="-lm" \
               --disable-everything ${FFMPEG_OPTIONS} \
               --disable-programs --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages \
@@ -751,56 +698,54 @@ if [[ $SRS_FFMPEG_FIT == YES ]]; then
               --disable-d3d11va --disable-dxva2 --disable-ffnvcodec --disable-nvdec --disable-nvenc --disable-v4l2-m2m --disable-vaapi \
               --disable-vdpau --disable-appkit --disable-coreimage --disable-avfoundation --disable-securetransport --disable-iconv \
               --disable-lzma --disable-sdl2 --enable-decoder=aac --enable-decoder=aac_fixed --enable-decoder=aac_latm \
-              --enable-encoder=aac &&
-            # See https://www.laoyuyu.me/2019/05/23/android/clang_compile_ffmpeg/
-            if [[ $SRS_CROSS_BUILD == YES ]]; then
-              sed -i -e 's/#define getenv(x) NULL/\/\*#define getenv(x) NULL\*\//g' config.h &&
-              sed -i -e 's/#define HAVE_GMTIME_R 0/#define HAVE_GMTIME_R 1/g' config.h &&
-              sed -i -e 's/#define HAVE_LOCALTIME_R 0/#define HAVE_LOCALTIME_R 1/g' config.h &&
-              # For MIPS, which fail with:
-              #     ./libavutil/libm.h:54:32: error: static declaration of 'cbrt' follows non-static declaration
-              #     /root/openwrt/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl/include/math.h:163:13: note: previous declaration of 'cbrt' was here
-              if [[ $SRS_CROSS_BUILD_ARCH == "mipsel" || $SRS_CROSS_BUILD_ARCH == "arm" ]]; then
-                sed -i -e 's/#define HAVE_CBRT 0/#define HAVE_CBRT 1/g' config.h &&
-                sed -i -e 's/#define HAVE_CBRTF 0/#define HAVE_CBRTF 1/g' config.h &&
-                sed -i -e 's/#define HAVE_COPYSIGN 0/#define HAVE_COPYSIGN 1/g' config.h &&
-                sed -i -e 's/#define HAVE_ERF 0/#define HAVE_ERF 1/g' config.h &&
-                sed -i -e 's/#define HAVE_HYPOT 0/#define HAVE_HYPOT 1/g' config.h &&
-                sed -i -e 's/#define HAVE_RINT 0/#define HAVE_RINT 1/g' config.h &&
-                sed -i -e 's/#define HAVE_LRINT 0/#define HAVE_LRINT 1/g' config.h &&
-                sed -i -e 's/#define HAVE_LRINTF 0/#define HAVE_LRINTF 1/g' config.h &&
-                sed -i -e 's/#define HAVE_ROUND 0/#define HAVE_ROUND 1/g' config.h &&
-                sed -i -e 's/#define HAVE_ROUNDF 0/#define HAVE_ROUNDF 1/g' config.h &&
-                sed -i -e 's/#define HAVE_TRUNC 0/#define HAVE_TRUNC 1/g' config.h &&
-                sed -i -e 's/#define HAVE_TRUNCF 0/#define HAVE_TRUNCF 1/g' config.h
-              fi
-            fi &&
-            make ${SRS_JOBS} && make install &&
-            cd .. && rm -rf ffmpeg && ln -sf ffmpeg-4-fit/_release ffmpeg
-        )
+              --enable-encoder=aac
+        ) &&
+        # See https://www.laoyuyu.me/2019/05/23/android/clang_compile_ffmpeg/
+        if [[ $SRS_CROSS_BUILD == YES ]]; then
+          sed -i -e 's/#define getenv(x) NULL/\/\*#define getenv(x) NULL\*\//g' ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+          sed -i -e 's/#define HAVE_GMTIME_R 0/#define HAVE_GMTIME_R 1/g'       ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+          sed -i -e 's/#define HAVE_LOCALTIME_R 0/#define HAVE_LOCALTIME_R 1/g' ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+          # For MIPS, which fail with:
+          #     ./libavutil/libm.h:54:32: error: static declaration of 'cbrt' follows non-static declaration
+          #     /root/openwrt/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl/include/math.h:163:13: note: previous declaration of 'cbrt' was here
+          if [[ $SRS_CROSS_BUILD_ARCH == "mipsel" || $SRS_CROSS_BUILD_ARCH == "arm" ]]; then
+            sed -i -e 's/#define HAVE_CBRT 0/#define HAVE_CBRT 1/g'         ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_CBRTF 0/#define HAVE_CBRTF 1/g'       ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_COPYSIGN 0/#define HAVE_COPYSIGN 1/g' ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_ERF 0/#define HAVE_ERF 1/g'           ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_HYPOT 0/#define HAVE_HYPOT 1/g'       ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_RINT 0/#define HAVE_RINT 1/g'         ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_LRINT 0/#define HAVE_LRINT 1/g'       ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_LRINTF 0/#define HAVE_LRINTF 1/g'     ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_ROUND 0/#define HAVE_ROUND 1/g'       ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_ROUNDF 0/#define HAVE_ROUNDF 1/g'     ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_TRUNC 0/#define HAVE_TRUNC 1/g'       ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            sed -i -e 's/#define HAVE_TRUNCF 0/#define HAVE_TRUNCF 1/g'     ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit/config.h &&
+            echo "FFmpeg sed ok"
+          fi
+        fi &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit ${SRS_JOBS} &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4-fit install &&
+        cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/ffmpeg ${SRS_OBJS}/ &&
+        echo "The ffmpeg-4-fit is ok."
     fi
     # check status
     ret=$?; if [[ $ret -ne 0 ]]; then echo "Build ffmpeg-4-fit failed, ret=$ret"; exit $ret; fi
-    # Always update the links.
-    (cd ${SRS_OBJS}/${SRS_PLATFORM} && rm -rf ffmpeg && ln -sf ffmpeg-4-fit/_release ffmpeg)
-    (cd ${SRS_OBJS} && rm -rf ffmpeg && ln -sf ${SRS_PLATFORM}/ffmpeg-4-fit/_release ffmpeg)
-    if [ ! -f ${SRS_OBJS}/ffmpeg/lib/libavcodec.a ]; then echo "Build ffmpeg-4-fit failed."; exit -1; fi
 fi
 
 #####################################################################################
 # live transcoding, ffmpeg-4.1, x264-core157, lame-3.99.5, libaacplus-2.0.2.
 #####################################################################################
-# Guess whether the ffmpeg is.
-SYSTEMP_FFMPEG_BIN=/usr/local/bin/ffmpeg
-if [[ ! -f $SYSTEMP_FFMPEG_BIN ]]; then SYSTEMP_FFMPEG_BIN=/usr/local/ffmpeg/bin/ffmpeg; fi
+# Guess where is the ffmpeg.
+SYSTEMP_FFMPEG_BIN=`which ffmpeg`
 # Always link the ffmpeg tools if exists.
-if [[ -f $SYSTEMP_FFMPEG_BIN && ! -f ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg ]]; then
-    mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg/bin &&
-    ln -sf $SYSTEMP_FFMPEG_BIN ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg/bin/ffmpeg &&
-    (cd ${SRS_OBJS} && rm -rf ffmpeg && ln -sf ${SRS_PLATFORM}/ffmpeg)
+if [[ -f $SYSTEMP_FFMPEG_BIN && ! -f ${SRS_OBJS}/ffmpeg/bin/ffmpeg ]]; then
+    mkdir -p ${SRS_OBJS}/ffmpeg/bin &&
+    cp -f $SYSTEMP_FFMPEG_BIN ${SRS_OBJS}/ffmpeg/bin/
 fi
-if [ $SRS_FFMPEG_TOOL = YES ]; then
-    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg/bin/ffmpeg ]]; then
+if [[ $SRS_FFMPEG_TOOL == YES ]]; then
+    if [[ -f ${SRS_OBJS}/ffmpeg/bin/ffmpeg ]]; then
+        cp -f $SYSTEMP_FFMPEG_BIN ${SRS_OBJS}/ffmpeg/bin/ &&
         echo "ffmpeg-4.1 is ok.";
     else
         echo -e "${RED}Error: No FFmpeg found at /usr/local/bin/ffmpeg${BLACK}"
@@ -809,98 +754,99 @@ if [ $SRS_FFMPEG_TOOL = YES ]; then
         echo -e "${RED}    or disable it by --without-ffmpeg${BLACK}"
         exit -1;
     fi
-    # Always update the links.
-    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg ]]; then
-        (cd ${SRS_OBJS} && rm -rf ffmpeg && ln -sf ${SRS_PLATFORM}/ffmpeg)
-    fi
 fi
 
 #####################################################################################
 # SRT module, https://github.com/ossrs/srs/issues/1147#issuecomment-577469119
 #####################################################################################
 if [[ $SRS_SRT == YES ]]; then
-    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/srt/lib/libsrt.a ]]; then
-        echo "libsrt-1-fit is ok.";
+    # Always disable c++11 for libsrt, because only the srt-app requres it.
+    LIBSRT_OPTIONS="--enable-apps=0  --enable-static=1 --enable-c++11=0"
+    if [[ $SRS_SHARED_SRT == YES ]]; then
+        LIBSRT_OPTIONS="$LIBSRT_OPTIONS --enable-shared=1"
     else
-        echo "Build srt-1-fit"
-        (
-            if [[ ! -d ${SRS_OBJS}/${SRS_PLATFORM}/openssl/lib/pkgconfig ]]; then
-                echo "OpenSSL pkgconfig no found, build srt-1-fit failed.";
-                exit -1;
-            fi
-            # Always disable c++11 for libsrt, because only the srt-app requres it.
-            LIBSRT_OPTIONS="--enable-apps=0  --enable-static=1 --enable-c++11=0"
-            if [[ $SRS_SHARED_SRT == YES ]]; then
-                LIBSRT_OPTIONS="$LIBSRT_OPTIONS --enable-shared=1"
-            else
-                LIBSRT_OPTIONS="$LIBSRT_OPTIONS --enable-shared=0"
-            fi
-            # For cross-build.
-            if [[ $SRS_CROSS_BUILD == YES ]]; then
-                TOOL_GCC_REALPATH=$(realpath $(which $SRS_TOOL_CC))
-                SRT_COMPILER_PREFIX=$(echo $TOOL_GCC_REALPATH |sed 's/-gcc.*$/-/')
-                LIBSRT_OPTIONS="$LIBSRT_OPTIONS --with-compiler-prefix=$SRT_COMPILER_PREFIX"
-            fi
-            # Start build libsrt.
-            rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/srt-1-fit && cd ${SRS_OBJS}/${SRS_PLATFORM} &&
-            cp -R ../../3rdparty/srt-1-fit srt-1-fit && cd srt-1-fit &&
-            PKG_CONFIG_PATH=../openssl/lib/pkgconfig ./configure --prefix=`pwd`/_release $LIBSRT_OPTIONS &&
-            make ${SRS_JOBS} && make install &&
-            cd .. && rm -rf srt && ln -sf srt-1-fit/_release srt &&
-            # If exists lib64 of libsrt, link it to lib
-            if [[ -d srt/lib64 ]]; then
-                cd srt && ln -sf lib64 lib
-            fi
-        )
-        ret=$?; if [[ $ret -ne 0 ]]; then echo "Build srt-1-fit failed, ret=$ret"; exit $ret; fi
+        LIBSRT_OPTIONS="$LIBSRT_OPTIONS --enable-shared=0"
     fi
-    # Always update the links.
-    (cd ${SRS_OBJS}/${SRS_PLATFORM} && rm -rf srt && ln -sf srt-1-fit/_release srt)
-    (cd ${SRS_OBJS} && rm -rf srt && ln -sf ${SRS_PLATFORM}/srt-1-fit/_release srt)
-    if [ ! -f ${SRS_OBJS}/srt/lib/libsrt.a ]; then echo "Build srt-1-fit failed."; exit -1; fi
+    # For cross-build.
+    if [[ $SRS_CROSS_BUILD == YES ]]; then
+        TOOL_GCC_REALPATH=$(realpath $(which $SRS_TOOL_CC))
+        SRT_COMPILER_PREFIX=$(echo $TOOL_GCC_REALPATH |sed 's/-gcc.*$/-/')
+        LIBSRT_OPTIONS="$LIBSRT_OPTIONS --with-compiler-prefix=$SRT_COMPILER_PREFIX"
+    fi
+    # For windows build, over cygwin
+    if [[ $SRS_CYGWIN64 == YES ]]; then
+        LIBSRT_OPTIONS="$LIBSRT_OPTIONS --cygwin-use-posix"
+    fi
+
+    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srt/lib/libsrt.a ]]; then
+        rm -rf ${SRS_OBJS}/srt && cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srt ${SRS_OBJS}/ &&
+        echo "libsrt-1-fit is ok."
+    else
+        if [[ ! -d ${SRS_OBJS}/openssl/lib/pkgconfig ]]; then
+            echo "OpenSSL pkgconfig no found, build srt-1-fit failed."
+            exit -1
+        fi
+        echo "Build srt-1-fit" &&
+        rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/srt-1-fit ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srt ${SRS_OBJS}/srt &&
+        cp -rf ${SRS_WORKDIR}/3rdparty/srt-1-fit ${SRS_OBJS}/${SRS_PLATFORM}/ &&
+        (
+            cd ${SRS_OBJS}/${SRS_PLATFORM}/srt-1-fit &&
+            env PKG_CONFIG_PATH=${SRS_DEPENDS_LIBS}/openssl/lib/pkgconfig \
+                ./configure --prefix=${SRS_DEPENDS_LIBS}/${SRS_PLATFORM}/3rdpatry/srt $LIBSRT_OPTIONS
+        ) &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/srt-1-fit ${SRS_JOBS} &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/srt-1-fit install &&
+        # If exists lib64 of libsrt, copy it to lib
+        if [[ -d ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srt/lib64 ]]; then
+            cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srt/lib64 ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srt/lib
+        fi &&
+        cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srt ${SRS_OBJS}/ &&
+        echo "libsrt-1-fit is ok."
+    fi
+    ret=$?; if [[ $ret -ne 0 ]]; then echo "Build srt-1-fit failed, ret=$ret"; exit $ret; fi
 fi
 
 #####################################################################################
 # build utest code
 #####################################################################################
-if [ $SRS_UTEST = YES ]; then
-    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/gtest-fit/googletest/include/gtest/gtest.h ]]; then
-        echo "The gtest-fit is ok.";
+if [[ $SRS_UTEST == YES ]]; then
+    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gtest/googletest/include/gtest/gtest.h ]]; then
+        rm -rf ${SRS_OBJS}/gtest && cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gtest ${SRS_OBJS}/ &&
+        echo "The gtest-fit is ok."
     else
-        echo "Build gtest-fit";
-        (
-            cd ${SRS_OBJS}/${SRS_PLATFORM} && rm -rf gtest-fit && cp -R ../../3rdparty/gtest-fit gtest-fit
-            rm -rf gtest && ln -sf gtest-fit/googletest gtest
-        )
+        echo "Build gtest-fit" &&
+        rm -rf ${SRS_OBJS}/${SRS_PLATFORM}gtest-fit ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gtest ${SRS_OBJS}/gtest &&
+        cp -rf ${SRS_WORKDIR}/3rdparty/gtest-fit ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gtest &&
+        cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gtest ${SRS_OBJS}/ &&
+        echo "The gtest-fit is ok."
     fi
     # check status
-    ret=$?; if [[ $ret -ne 0 ]]; then echo "Build gtest-fit failed, ret=$ret"; exit $ret; fi
-    # Always update the links.
-    (cd ${SRS_OBJS}/${SRS_PLATFORM} && rm -rf gtest && ln -sf gtest-fit/googletest gtest)
-    (cd ${SRS_OBJS} && rm -rf gtest && ln -sf ${SRS_PLATFORM}/gtest-fit/googletest gtest)
-    if [ ! -f ${SRS_OBJS}/gtest/include/gtest/gtest.h ]; then echo "Build gtest-fit failed."; exit -1; fi
+    ret=$?; if [[ $ret -ne 0 ]]; then echo "Build gtest-1.6.0 failed, ret=$ret"; exit $ret; fi
 fi
 
 #####################################################################################
 # build gperf code
 #####################################################################################
-if [ $SRS_GPERF = YES ]; then
-    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/gperf/bin/pprof ]]; then
-        echo "The gperftools-2-fit is ok.";
+if [[ $SRS_GPERF == YES ]]; then
+    if [[ -f ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gperf/bin/pprof ]]; then
+        rm -rf ${SRS_OBJS}/gperf && cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gperf ${SRS_OBJS}/ &&
+        cp -f ${SRS_OBJS}/gperf/bin/pprof ${SRS_OBJS}/ &&
+        echo "The gperftools-2-fit is ok."
     else
-        echo "Build gperftools-2-fit";
+        echo "Build gperftools-2-fit" &&
+        rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/gperftools-2-fit ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gperf \
+            ${SRS_OBJS}/gperf ${SRS_OBJS}/pprof &&
+        cp -rf ${SRS_WORKDIR}/3rdparty/gperftools-2-fit ${SRS_OBJS}/${SRS_PLATFORM}/ &&
         (
-            rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/gperftools-2-fit && cd ${SRS_OBJS}/${SRS_PLATFORM} &&
-            cp -R ../../3rdparty/gperftools-2-fit . && cd gperftools-2-fit &&
-            ./configure --prefix=`pwd`/_release --enable-frame-pointers && make ${SRS_JOBS} && make install &&
-            cd .. && rm -rf gperf && ln -sf gperftools-2-fit/_release gperf &&
-            rm -rf pprof && ln -sf gperf/bin/pprof pprof
-        )
+            cd ${SRS_OBJS}/${SRS_PLATFORM}/gperftools-2-fit &&
+            ./configure --prefix=${SRS_DEPENDS_LIBS}/${SRS_PLATFORM}/3rdpatry/gperf --enable-frame-pointers
+        ) &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/gperftools-2-fit ${SRS_JOBS} &&
+        make -C ${SRS_OBJS}/${SRS_PLATFORM}/gperftools-2-fit install &&
+        cp -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gperf ${SRS_OBJS}/ &&
+        cp -f ${SRS_OBJS}/gperf/bin/pprof ${SRS_OBJS}/ &&
+        echo "The gperftools-2-fit is ok."
     fi
     # check status
     ret=$?; if [[ $ret -ne 0 ]]; then echo "Build gperftools-2-fit failed, ret=$ret"; exit $ret; fi
-    # Always update the links.
-    (cd ${SRS_OBJS} && rm -rf pprof && ln -sf ${SRS_PLATFORM}/gperf/bin/pprof pprof)
-    (cd ${SRS_OBJS} && rm -rf gperf && ln -sf ${SRS_PLATFORM}/gperftools-2-fit/_release gperf)
-    if [ ! -f ${SRS_OBJS}/pprof ]; then echo "Build gperftools-2-fit failed."; exit -1; fi
 fi

--- a/trunk/auto/modules.sh
+++ b/trunk/auto/modules.sh
@@ -3,8 +3,7 @@
 #
 # params:
 #     $SRS_OBJS the objs directory to store the Makefile. ie. ./objs
-#     $SRS_OBJS_DIR the objs directory for Makefile. ie. objs
-#     $SRS_MAKEFILE the makefile name. ie. Makefile
+#     $SRS_OBJS the objs directory for Makefile. ie. objs
 #
 #     $MODULE_DIR the module dir. ie. src/os/linux
 #     $MODULE_ID the id of module. ie. CORE
@@ -16,7 +15,7 @@
 # returns:
 #     $MODULE_OBJS array, the objects of the modules, used for link the binary
 
-FILE=${SRS_OBJS}/${SRS_MAKEFILE}
+FILE=${SRS_OBJS}/Makefile
 echo "#####################################################################################" >> ${FILE}
 echo "# The module ${MODULE_ID}." >> ${FILE}
 echo "#####################################################################################" >> ${FILE}
@@ -27,7 +26,7 @@ echo "# INCS for ${MODULE_ID}, headers of module and its depends to compile" >> 
 #
 # the public include files, for example:
 #       CORE_MODULE_INCS = -Isrc/core
-echo "${MODULE_ID}_MODULE_INCS = -I${MODULE_DIR} " >> ${FILE}
+echo "${MODULE_ID}_MODULE_INCS = -I${SRS_WORKDIR}/${MODULE_DIR} " >> ${FILE}
 #
 # the private include files, for example:
 #       CORE_INCS = -Isrc/core -Iobjs
@@ -36,7 +35,7 @@ echo "${MODULE_ID}_MODULE_INCS = -I${MODULE_DIR} " >> ${FILE}
 INCS_NAME="${MODULE_ID}_INCS"
 #
 # current module header files
-echo -n "${INCS_NAME} = -I${MODULE_DIR} " >> ${FILE}
+echo -n "${INCS_NAME} = -I${SRS_WORKDIR}/${MODULE_DIR} " >> ${FILE}
 #
 # depends module header files
 for item in ${MODULE_DEPENDS[*]}; do
@@ -60,8 +59,7 @@ echo "# DEPS for ${MODULE_ID}, the depends of make schema" >> ${FILE}
 DEPS_NAME="${MODULE_ID}_DEPS"
 echo -n "${DEPS_NAME} = " >> ${FILE}
 for item in ${MODULE_FILES[*]}; do
-    HEADER_FILE="${MODULE_DIR}/${item}.hpp"
-    if [[ ! -f ${HEADER_FILE} ]]; then HEADER_FILE="${MODULE_DIR}/${item}.h"; fi
+    HEADER_FILE="${SRS_WORKDIR}/${MODULE_DIR}/${item}.hpp"
     if [ -f ${HEADER_FILE} ]; then
         echo -n " ${HEADER_FILE}" >> ${FILE}
     fi
@@ -78,10 +76,9 @@ echo "" >> ${FILE}; echo "" >> ${FILE}
 echo "# OBJ for ${MODULE_ID}, each object file" >> ${FILE}
 MODULE_OBJS=()
 for item in ${MODULE_FILES[*]}; do
-    CPP_FILE="${MODULE_DIR}/${item}.cpp"
-    if [[ ! -f ${CPP_FILE} ]]; then CPP_FILE="${MODULE_DIR}/${item}.cc"; fi
-    OBJ_FILE="${SRS_OBJS_DIR}/${MODULE_DIR}/${item}.o"
-    MODULE_OBJS="${MODULE_OBJS[@]} ${CPP_FILE}"
+    CPP_FILE="${SRS_WORKDIR}/${MODULE_DIR}/${item}.cpp"
+    OBJ_FILE="${SRS_OBJS}/${MODULE_DIR}/${item}.o"
+    MODULE_OBJS="${MODULE_OBJS[@]} ${MODULE_DIR}/${item}.cpp"
     if [ -f ${CPP_FILE} ]; then
         echo "${OBJ_FILE}: \$(${DEPS_NAME}) ${CPP_FILE} " >> ${FILE}
         echo "	\$(CXX) -c \$(CXXFLAGS) ${DEFINES}\\" >> ${FILE}
@@ -94,6 +91,6 @@ done
 echo "" >> ${FILE}
 
 # parent Makefile, to create module output dir before compile it.
-echo "	@mkdir -p ${SRS_OBJS_DIR}/${MODULE_DIR}" >> ${SRS_WORKDIR}/${SRS_MAKEFILE}
+echo "	@mkdir -p ${SRS_OBJS}/${MODULE_DIR}" >> ${SRS_MAKEFILE}
 
 echo -n "Generate modules ${MODULE_ID} ok"; echo '!';

--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -82,9 +82,8 @@ SRS_GPROF=NO # Performance test: gprof
 #
 ################################################################
 # Preset options
-SRS_X86_X64=NO # For x86_64 servers
-SRS_OSX=NO #For osx/macOS PC.
-SRS_CROSS_BUILD=NO #For cross build, for example, on Ubuntu.
+SRS_OSX= #For OSX/macOS/Darwin PC.
+SRS_CROSS_BUILD= #For cross build, for example, on Ubuntu.
 # For cross build, the cpu, for example(FFmpeg), --cpu=24kc
 SRS_CROSS_BUILD_CPU=
 # For cross build, the arch, for example(FFmpeg), --arch=aarch64
@@ -117,7 +116,6 @@ function show_help() {
     cat << END
 
 Presets:
-  --x86-64, --x86-x64       For x86/x64 cpu, common pc and servers. Default: $(value2switch $SRS_X86_X64)
   --cross-build             Enable cross-build, please set bellow Toolchain also. Default: $(value2switch $SRS_CROSS_BUILD)
   --osx                     Enable build for OSX/Darwin AppleOS. Default: $(value2switch $SRS_OSX)
 
@@ -252,8 +250,6 @@ function parse_user_option() {
         --extra-flags)                  SRS_EXTRA_FLAGS=${value}    ;;
         --build-tag)                    SRS_BUILD_TAG=${value}      ;;
 
-        --x86-x64)                      SRS_X86_X64=YES             ;;
-        --x86-64)                       SRS_X86_X64=YES             ;;
         --osx)                          SRS_OSX=YES                 ;;
 
         --without-srtp-nasm)            SRS_SRTP_ASM=NO             ;;
@@ -365,6 +361,8 @@ function parse_user_option() {
         --enable-cross-compile)         SRS_CROSS_BUILD=YES         ;;
 
         # Deprecated, might be removed in future.
+        --x86-x64)                      SRS_X86_X64=YES             ;;
+        --x86-64)                       SRS_X86_X64=YES             ;;
         --with-nginx)                   SRS_NGINX=YES               ;;
         --without-nginx)                SRS_NGINX=NO                ;;
         --nginx)                        SRS_NGINX=$(switch2value $value) ;;
@@ -411,6 +409,32 @@ function switch2value() {
 }
 
 #####################################################################################
+function apply_system_options() {
+    OS_IS_OSX=$(uname -s |grep -q Darwin && echo YES)
+    OS_IS_LINUX=$(uname -s |grep -q Linux && echo YES)
+    OS_IS_CYGWIN=$(uname -s |grep -q CYGWIN && echo YES)
+
+    OS_IS_CENTOS=$(yum --version >/dev/null 2>&1 && echo YES)
+    # For Debian, we think it's ubuntu also.
+    # For example, the wheezy/sid which is debian armv7 linux, can not identified by uname -v.
+    OS_IS_UBUNTU=$(apt-get --version >/dev/null 2>&1 && echo YES)
+    OS_IS_LOONGSON=$(uname -r |grep -q loongson && echo YES)
+
+    # Use gcc to detect the CPU arch.
+    gcc --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then echo "Please install gcc"; exit 1; fi
+    OS_IS_LOONGARCH64=$(gcc -dM -E - </dev/null |grep '#define __loongarch64 1' -q && echo YES)
+    OS_IS_MIPS64=$(gcc -dM -E - </dev/null |grep '#define __mips64 1' -q && echo YES)
+    OS_IS_X86_64=$(gcc -dM -E - </dev/null |grep -q '#define __x86_64 1' && echo YES)
+    OS_IS_RISCV=$(gcc -dM -E - </dev/null |grep -q '#define __riscv 1' && echo YES)
+
+    if [[ $OS_IS_OSX == YES ]]; then SRS_JOBS=$(sysctl -n hw.ncpu 2>/dev/null || echo 1); fi
+    if [[ $OS_IS_LINUX == YES || $OS_IS_CYGWIN == YES ]]; then
+        SRS_JOBS=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || echo 1)
+    fi
+}
+apply_system_options
+
+#####################################################################################
 # parse preset options
 #####################################################################################
 opt=
@@ -423,11 +447,6 @@ do
 done
 
 function apply_auto_options() {
-    # set default preset if not specifies
-    if [[ $SRS_X86_X64 == NO && $SRS_OSX == NO && $SRS_CROSS_BUILD == NO ]]; then
-        SRS_X86_X64=YES; opt="--x86-x64 $opt";
-    fi
-
     if [[ $SRS_CROSS_BUILD == YES ]]; then
         if [[ $SRS_CROSS_BUILD_PREFIX != "" && $SRS_CROSS_BUILD_HOST == "" ]]; then
             SRS_CROSS_BUILD_HOST=$(echo $SRS_CROSS_BUILD_PREFIX| sed 's/-$//g')
@@ -460,10 +479,16 @@ function apply_auto_options() {
         SRS_FFMPEG_FIT=YES
     fi
 
+    # If enable gperf, disable sanitizer.
+    if [[ $SRS_GPERF == YES && $SRS_SANITIZER == YES ]]; then
+        echo "Disable sanitizer for gperf"
+        SRS_SANITIZER=NO
+    fi
+
     # if transcode/ingest specified, requires the ffmpeg stub classes.
     SRS_FFMPEG_STUB=NO
-    if [ $SRS_TRANSCODE = YES ]; then SRS_FFMPEG_STUB=YES; fi
-    if [ $SRS_INGEST = YES ]; then SRS_FFMPEG_STUB=YES; fi
+    if [[ $SRS_TRANSCODE == YES ]]; then SRS_FFMPEG_STUB=YES; fi
+    if [[ $SRS_INGEST == YES ]]; then SRS_FFMPEG_STUB=YES; fi
 
     if [[ $SRS_SRTP_ASM == YES && $SRS_RTC == NO ]]; then
         echo "Disable SRTP-ASM, because RTC is disabled."
@@ -474,9 +499,14 @@ function apply_auto_options() {
         echo "Disable SRTP-ASM, because NASM is disabled."
         SRS_SRTP_ASM=NO
     fi
+
+    # parse the jobs for make
+    if [[ ! -z SRS_JOBS ]]; then
+        export SRS_JOBS="--jobs=${SRS_JOBS}"
+    fi
 }
 
-if [ $help = yes ]; then
+if [[ $help == YES ]]; then
     apply_auto_options
     show_help
     exit 0
@@ -488,24 +518,17 @@ fi
 
 function apply_detail_options() {
     # Always enable HTTP utilies.
-    if [ $SRS_HTTP_CORE = NO ]; then SRS_HTTP_CORE=YES; echo -e "${YELLOW}[WARN] Always enable HTTP utilies.${BLACK}"; fi
-    if [ $SRS_STREAM_CASTER = NO ]; then SRS_STREAM_CASTER=YES; echo -e "${YELLOW}[WARN] Always enable StreamConverter.${BLACK}"; fi
-    if [ $SRS_INGEST = NO ]; then SRS_INGEST=YES; echo -e "${YELLOW}[WARN] Always enable Ingest.${BLACK}"; fi
-    if [ $SRS_SSL = NO ]; then SRS_SSL=YES; echo -e "${YELLOW}[WARN] Always enable SSL.${BLACK}"; fi
-    if [ $SRS_STAT = NO ]; then SRS_STAT=YES; echo -e "${YELLOW}[WARN] Always enable Statistic.${BLACK}"; fi
-    if [ $SRS_TRANSCODE = NO ]; then SRS_TRANSCODE=YES; echo -e "${YELLOW}[WARN] Always enable Transcode.${BLACK}"; fi
-    if [ $SRS_HTTP_CALLBACK = NO ]; then SRS_HTTP_CALLBACK=YES; echo -e "${YELLOW}[WARN] Always enable HTTP callback.${BLACK}"; fi
-    if [ $SRS_HTTP_SERVER = NO ]; then SRS_HTTP_SERVER=YES; echo -e "${YELLOW}[WARN] Always enable HTTP server.${BLACK}"; fi
-    if [ $SRS_HTTP_API = NO ]; then SRS_HTTP_API=YES; echo -e "${YELLOW}[WARN] Always enable HTTP API.${BLACK}"; fi
-    if [ $SRS_HLS = NO ]; then SRS_HLS=YES; echo -e "${YELLOW}[WARN] Always enable HLS.${BLACK}"; fi
-    if [ $SRS_DVR = NO ]; then SRS_DVR=YES; echo -e "${YELLOW}[WARN] Always enable DVR.${BLACK}"; fi
-
-    # parse the jobs for make
-    if [[ "" -eq SRS_JOBS ]]; then 
-        export SRS_JOBS="--jobs=1" 
-    else
-        export SRS_JOBS="--jobs=${SRS_JOBS}"
-    fi
+    if [[ $SRS_HTTP_CORE == NO ]]; then SRS_HTTP_CORE=YES; echo -e "${YELLOW}[WARN] Always enable HTTP utilies.${BLACK}"; fi
+    if [[ $SRS_STREAM_CASTER == NO ]]; then SRS_STREAM_CASTER=YES; echo -e "${YELLOW}[WARN] Always enable StreamConverter.${BLACK}"; fi
+    if [[ $SRS_INGEST == NO ]]; then SRS_INGEST=YES; echo -e "${YELLOW}[WARN] Always enable Ingest.${BLACK}"; fi
+    if [[ $SRS_SSL == NO ]]; then SRS_SSL=YES; echo -e "${YELLOW}[WARN] Always enable SSL.${BLACK}"; fi
+    if [[ $SRS_STAT == NO ]]; then SRS_STAT=YES; echo -e "${YELLOW}[WARN] Always enable Statistic.${BLACK}"; fi
+    if [[ $SRS_TRANSCODE == NO ]]; then SRS_TRANSCODE=YES; echo -e "${YELLOW}[WARN] Always enable Transcode.${BLACK}"; fi
+    if [[ $SRS_HTTP_CALLBACK == NO ]]; then SRS_HTTP_CALLBACK=YES; echo -e "${YELLOW}[WARN] Always enable HTTP callback.${BLACK}"; fi
+    if [[ $SRS_HTTP_SERVER == NO ]]; then SRS_HTTP_SERVER=YES; echo -e "${YELLOW}[WARN] Always enable HTTP server.${BLACK}"; fi
+    if [[ $SRS_HTTP_API == NO ]]; then SRS_HTTP_API=YES; echo -e "${YELLOW}[WARN] Always enable HTTP API.${BLACK}"; fi
+    if [[ $SRS_HLS == NO ]]; then SRS_HLS=YES; echo -e "${YELLOW}[WARN] Always enable HLS.${BLACK}"; fi
+    if [[ $SRS_DVR == NO ]]; then SRS_DVR=YES; echo -e "${YELLOW}[WARN] Always enable DVR.${BLACK}"; fi
 }
 apply_auto_options
 apply_detail_options
@@ -600,13 +623,13 @@ function check_option_conflicts() {
 
     __check_ok=YES
     # check conflict
-    if [ $SRS_GPERF = NO ]; then
-        if [ $SRS_GPERF_MC = YES ]; then echo "gperf-mc depends on gperf, see: ./configure --help"; __check_ok=NO; fi
-        if [ $SRS_GPERF_MD = YES ]; then echo "gperf-md depends on gperf, see: ./configure --help"; __check_ok=NO; fi
-        if [ $SRS_GPERF_MP = YES ]; then echo "gperf-mp depends on gperf, see: ./configure --help"; __check_ok=NO; fi
-        if [ $SRS_GPERF_CP = YES ]; then echo "gperf-cp depends on gperf, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_GPERF == NO ]]; then
+        if [[ $SRS_GPERF_MC == YES ]]; then echo "gperf-mc depends on gperf, see: ./configure --help"; __check_ok=NO; fi
+        if [[ $SRS_GPERF_MD == YES ]]; then echo "gperf-md depends on gperf, see: ./configure --help"; __check_ok=NO; fi
+        if [[ $SRS_GPERF_MP == YES ]]; then echo "gperf-mp depends on gperf, see: ./configure --help"; __check_ok=NO; fi
+        if [[ $SRS_GPERF_CP == YES ]]; then echo "gperf-cp depends on gperf, see: ./configure --help"; __check_ok=NO; fi
     fi
-    if [[ $SRS_GPERF_MC = YES && $SRS_GPERF_MP = YES ]]; then
+    if [[ $SRS_GPERF_MC == YES && $SRS_GPERF_MP == YES ]]; then
         echo "gperf-mc not compatible with gperf-mp, see: ./configure --help";
         echo "@see: https://gperftools.github.io/gperftools/heap_checker.html";
         echo "Note that since the heap-checker uses the heap-profiling framework internally, it is not possible to run both the heap-checker and heap profiler at the same time";
@@ -614,27 +637,27 @@ function check_option_conflicts() {
     fi
     # generate the group option: SRS_GPERF
     __gperf_slow=NO
-    if [ $SRS_GPERF_MC = YES ]; then SRS_GPERF=YES; __gperf_slow=YES; fi
-    if [ $SRS_GPERF_MD = YES ]; then SRS_GPERF=YES; __gperf_slow=YES; fi
-    if [ $SRS_GPERF_MP = YES ]; then SRS_GPERF=YES; __gperf_slow=YES; fi
-    if [ $SRS_GPERF_CP = YES ]; then SRS_GPERF=YES; __gperf_slow=YES; fi
-    if [ $__gperf_slow = YES ]; then if [ $SRS_GPROF = YES ]; then 
+    if [[ $SRS_GPERF_MC == YES ]]; then SRS_GPERF=YES; __gperf_slow=YES; fi
+    if [[ $SRS_GPERF_MD == YES ]]; then SRS_GPERF=YES; __gperf_slow=YES; fi
+    if [[ $SRS_GPERF_MP == YES ]]; then SRS_GPERF=YES; __gperf_slow=YES; fi
+    if [[ $SRS_GPERF_CP == YES ]]; then SRS_GPERF=YES; __gperf_slow=YES; fi
+    if [[ $__gperf_slow == YES ]]; then if [[ $SRS_GPROF == YES ]]; then 
         echo "gmc/gmp/gcp not compatible with gprof, see: ./configure --help"; __check_ok=NO; 
     fi fi
 
     # check variable neccessary
-    if [ $SRS_HDS = RESERVED ]; then echo "you must specifies the hds, see: ./configure --help"; __check_ok=NO; fi
-    if [ $SRS_SSL = RESERVED ]; then echo "you must specifies the ssl, see: ./configure --help"; __check_ok=NO; fi
-    if [ $SRS_STREAM_CASTER = RESERVED ]; then echo "you must specifies the stream-converter, see: ./configure --help"; __check_ok=NO; fi
-    if [ $SRS_UTEST = RESERVED ]; then echo "you must specifies the utest, see: ./configure --help"; __check_ok=NO; fi
-    if [ $SRS_GPERF = RESERVED ]; then echo "you must specifies the gperf, see: ./configure --help"; __check_ok=NO; fi
-    if [ $SRS_GPERF_MC = RESERVED ]; then echo "you must specifies the gperf-mc, see: ./configure --help"; __check_ok=NO; fi
-    if [ $SRS_GPERF_MD = RESERVED ]; then echo "you must specifies the gperf-md, see: ./configure --help"; __check_ok=NO; fi
-    if [ $SRS_GPERF_MP = RESERVED ]; then echo "you must specifies the gperf-mp, see: ./configure --help"; __check_ok=NO; fi
-    if [ $SRS_GPERF_CP = RESERVED ]; then echo "you must specifies the gperf-cp, see: ./configure --help"; __check_ok=NO; fi
-    if [ $SRS_GPROF = RESERVED ]; then echo "you must specifies the gprof, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_HDS == RESERVED ]]; then echo "you must specifies the hds, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_SSL == RESERVED ]]; then echo "you must specifies the ssl, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_STREAM_CASTER == RESERVED ]]; then echo "you must specifies the stream-converter, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_UTEST == RESERVED ]]; then echo "you must specifies the utest, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_GPERF == RESERVED ]]; then echo "you must specifies the gperf, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_GPERF_MC == RESERVED ]]; then echo "you must specifies the gperf-mc, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_GPERF_MD == RESERVED ]]; then echo "you must specifies the gperf-md, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_GPERF_MP == RESERVED ]]; then echo "you must specifies the gperf-mp, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_GPERF_CP == RESERVED ]]; then echo "you must specifies the gperf-cp, see: ./configure --help"; __check_ok=NO; fi
+    if [[ $SRS_GPROF == RESERVED ]]; then echo "you must specifies the gprof, see: ./configure --help"; __check_ok=NO; fi
     if [[ -z $SRS_PREFIX ]]; then echo "you must specifies the prefix, see: ./configure --prefix"; __check_ok=NO; fi
-    if [ $__check_ok = NO ]; then
+    if [[ $__check_ok == NO ]]; then
         exit 1;
     fi
 }

--- a/trunk/auto/setup_variables.sh
+++ b/trunk/auto/setup_variables.sh
@@ -24,22 +24,30 @@ if [[ $SRS_CROSS_BUILD == YES ]]; then
     SRS_PLATFORM="${SRS_PLATFORM}-crossbuild-$(echo $SRS_TOOL_CC_NAME|awk -F - '{print $1"-"$2}')"
 fi
 
-echo "SRS_WORKDIR: ${SRS_WORKDIR}, SRS_OBJS_DIR: ${SRS_OBJS_DIR}, SRS_OBJS: ${SRS_OBJS}, SRS_PLATFORM: ${SRS_PLATFORM}"
+echo "SRS_WORKDIR: ${SRS_WORKDIR}, SRS_OBJS: ${SRS_OBJS}, SRS_PLATFORM: ${SRS_PLATFORM}"
+echo "All outputs to: ${SRS_OBJS}/${SRS_PLATFORM}"
 
 # For src object files on each platform.
 (
-    mkdir -p ${SRS_OBJS_DIR} && cd ${SRS_OBJS_DIR} &&
-    rm -rf src utest srs srs_utest research include lib srs_hls_ingester srs_mp4_parser &&
-    mkdir -p ${SRS_PLATFORM}/src && ln -sf ${SRS_PLATFORM}/src &&
-    mkdir -p ${SRS_PLATFORM}/utest && ln -sf ${SRS_PLATFORM}/utest &&
-    mkdir -p ${SRS_PLATFORM}/research && ln -sf ${SRS_PLATFORM}/research &&
-    mkdir -p ${SRS_PLATFORM}/include && ln -sf ${SRS_PLATFORM}/include &&
-    mkdir -p ${SRS_PLATFORM}/lib && ln -sf ${SRS_PLATFORM}/lib
+    mkdir -p ${SRS_OBJS} &&
+    (cd ${SRS_OBJS} && rm -rf src utest srs srs_utest research include lib srs_hls_ingester srs_mp4_parser) &&
+    mkdir -p ${SRS_OBJS}/src ${SRS_OBJS}/research ${SRS_OBJS}/utest &&
+
+    mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry &&
+    (cd ${SRS_OBJS} && rm -rf st ffmpeg opus srtp2 openssl srt) &&
+    mkdir -p ${SRS_OBJS}/st ${SRS_OBJS}/ffmpeg ${SRS_OBJS}/opus ${SRS_OBJS}/srtp2 ${SRS_OBJS}/openssl \
+        ${SRS_OBJS}/srt &&
+    mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/st ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/ffmpeg \
+        ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/opus ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srtp2 \
+        ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srt
 )
+ret=$?; if [[ $ret -ne 0 ]]; then echo "Create build directory failed, ret=$ret"; exit $ret; fi
+
 if [[ $SRS_CLEAN == NO ]]; then
   echo "Fast cleanup, if need to do full cleanup, please use: make clean"
 fi
 
+# TODO: FIXME: Remove python, use Go for api server demo.
 # Python or python2, for CentOS8.
 python2 --version >/dev/null 2>&1 && alias python=python2 &&
 echo "Alias python2 as python"

--- a/trunk/auto/summary.sh
+++ b/trunk/auto/summary.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 
 # colorful summary
-SrsHlsSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_HLS = YES ]; then SrsHlsSummaryColor="\${GREEN}"; fi
-SrsDvrSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_DVR = YES ]; then SrsDvrSummaryColor="\${GREEN}"; fi
-SrsNginxSummaryColor="\${GREEN}(Disabled) "; if [ $SRS_NGINX = YES ]; then SrsNginxSummaryColor="\${GREEN}"; fi
-SrsSslSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_SSL = YES ]; then SrsSslSummaryColor="\${GREEN}"; fi
-SrsFfmpegSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_FFMPEG_TOOL = YES ]; then SrsFfmpegSummaryColor="\${GREEN}"; fi
-SrsTranscodeSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_TRANSCODE = YES ]; then SrsTranscodeSummaryColor="\${GREEN}"; fi
-SrsIngestSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_INGEST = YES ]; then SrsIngestSummaryColor="\${GREEN}"; fi
-SrsHttpCallbackSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_HTTP_CALLBACK = YES ]; then SrsHttpCallbackSummaryColor="\${GREEN}"; fi
-SrsHttpServerSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_HTTP_SERVER = YES ]; then SrsHttpServerSummaryColor="\${GREEN}"; fi
-SrsHttpApiSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_HTTP_API = YES ]; then SrsHttpApiSummaryColor="\${GREEN}"; fi
-SrsStreamConverterSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_STREAM_CASTER = YES ]; then SrsStreamConverterSummaryColor="\${GREEN}"; fi
-SrsUtestSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_UTEST = YES ]; then SrsUtestSummaryColor="\${GREEN}"; fi
-SrsGperfSummaryColor="\${GREEN}(Disabled) "; if [ $SRS_GPERF = YES ]; then SrsGperfSummaryColor="\${GREEN}"; fi
-SrsGperfMCSummaryColor="\${GREEN}(Disabled) "; if [ $SRS_GPERF_MC = YES ]; then SrsGperfMCSummaryColor="\${YELLOW}"; fi
-SrsGperfMDSummaryColor="\${GREEN}(Disabled) "; if [ $SRS_GPERF_MD = YES ]; then SrsGperfMDSummaryColor="\${YELLOW}"; fi
-SrsGperfMPSummaryColor="\${GREEN}(Disabled) "; if [ $SRS_GPERF_MP = YES ]; then SrsGperfMPSummaryColor="\${YELLOW}"; fi
-SrsGperfCPSummaryColor="\${GREEN}(Disabled) "; if [ $SRS_GPERF_CP = YES ]; then SrsGperfCPSummaryColor="\${YELLOW}"; fi
-SrsGprofSummaryColor="\${GREEN}(Disabled) "; if [ $SRS_GPROF = YES ]; then SrsGprofSummaryColor="\${YELLOW}"; fi
-SrsValgrindSummaryColor="\${YELLOW}(Disabled) "; if [ $SRS_VALGRIND = YES ]; then SrsValgrindSummaryColor="\${GREEN}"; fi
+SrsHlsSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_HLS == YES ]]; then SrsHlsSummaryColor="\${GREEN}"; fi
+SrsDvrSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_DVR == YES ]]; then SrsDvrSummaryColor="\${GREEN}"; fi
+SrsNginxSummaryColor="\${GREEN}(Disabled) "; if [[ $SRS_NGINX == YES ]]; then SrsNginxSummaryColor="\${GREEN}"; fi
+SrsSslSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_SSL == YES ]]; then SrsSslSummaryColor="\${GREEN}"; fi
+SrsFfmpegSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_FFMPEG_TOOL == YES ]]; then SrsFfmpegSummaryColor="\${GREEN}"; fi
+SrsTranscodeSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_TRANSCODE == YES ]]; then SrsTranscodeSummaryColor="\${GREEN}"; fi
+SrsIngestSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_INGEST == YES ]]; then SrsIngestSummaryColor="\${GREEN}"; fi
+SrsHttpCallbackSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_HTTP_CALLBACK == YES ]]; then SrsHttpCallbackSummaryColor="\${GREEN}"; fi
+SrsHttpServerSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_HTTP_SERVER == YES ]]; then SrsHttpServerSummaryColor="\${GREEN}"; fi
+SrsHttpApiSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_HTTP_API == YES ]]; then SrsHttpApiSummaryColor="\${GREEN}"; fi
+SrsStreamConverterSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_STREAM_CASTER == YES ]]; then SrsStreamConverterSummaryColor="\${GREEN}"; fi
+SrsUtestSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_UTEST == YES ]]; then SrsUtestSummaryColor="\${GREEN}"; fi
+SrsGperfSummaryColor="\${GREEN}(Disabled) "; if [[ $SRS_GPERF == YES ]]; then SrsGperfSummaryColor="\${GREEN}"; fi
+SrsGperfMCSummaryColor="\${GREEN}(Disabled) "; if [[ $SRS_GPERF_MC == YES ]]; then SrsGperfMCSummaryColor="\${YELLOW}"; fi
+SrsGperfMDSummaryColor="\${GREEN}(Disabled) "; if [[ $SRS_GPERF_MD == YES ]]; then SrsGperfMDSummaryColor="\${YELLOW}"; fi
+SrsGperfMPSummaryColor="\${GREEN}(Disabled) "; if [[ $SRS_GPERF_MP == YES ]]; then SrsGperfMPSummaryColor="\${YELLOW}"; fi
+SrsGperfCPSummaryColor="\${GREEN}(Disabled) "; if [[ $SRS_GPERF_CP == YES ]]; then SrsGperfCPSummaryColor="\${YELLOW}"; fi
+SrsGprofSummaryColor="\${GREEN}(Disabled) "; if [[ $SRS_GPROF == YES ]]; then SrsGprofSummaryColor="\${YELLOW}"; fi
+SrsValgrindSummaryColor="\${YELLOW}(Disabled) "; if [[ $SRS_VALGRIND == YES ]]; then SrsValgrindSummaryColor="\${GREEN}"; fi
 
 cat <<END > ${SRS_OBJS}/${SRS_BUILD_SUMMARY}
 #!/bin/bash

--- a/trunk/auto/utest.sh
+++ b/trunk/auto/utest.sh
@@ -2,26 +2,25 @@
 #
 # params:
 #     $SRS_OBJS the objs directory to store the Makefile. ie. ./objs
-#     $SRS_OBJS_DIR the objs directory for Makefile. ie. objs
-#     $SRS_MAKEFILE the makefile name. ie. Makefile
+#     $SRS_OBJS the objs directory for Makefile. ie. objs
 #
 #     $APP_NAME the app name to output. ie. srs_utest
 #     $MODULE_DIR the src dir of utest code. ie. src/utest
 #     $LINK_OPTIONS the link options for utest. ie. -lpthread -ldl
 
-FILE=${SRS_OBJS}/utest/${SRS_MAKEFILE}
+FILE=${SRS_OBJS}/${SRS_PLATFORM}/utest/Makefile
 # create dir for Makefile
-mkdir -p ${SRS_OBJS}/utest
+mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}/utest
 
 # the prefix to generate the objs/utest/Makefile
 # dirs relative to current dir(objs/utest), it's trunk/objs/utest
 # trunk of srs, which contains the src dir, relative to objs/utest, it's trunk
 SRS_TRUNK_PREFIX=../../..
-# gest dir, relative to objs/utest, it's trunk/objs/gtest
-GTEST_DIR=${SRS_TRUNK_PREFIX}/${SRS_OBJS_DIR}/gtest
+# gest dir, relative to objs/utest, it's trunk/objs/{Platform}/gtest
+GTEST_DIR=${SRS_TRUNK_PREFIX}/${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gtest/googletest
 
 cat << END > ${FILE}
-# user must run make the ${SRS_OBJS_DIR}/utest dir
+# user must run make the ${SRS_OBJS}/utest dir
 # at the same dir of Makefile.
 
 # A sample Makefile for building Google Test and using it in user
@@ -58,7 +57,7 @@ CXXFLAGS += -std=c++11
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.
-TESTS = ${SRS_TRUNK_PREFIX}/${SRS_OBJS_DIR}/${APP_NAME}
+TESTS = ${SRS_TRUNK_PREFIX}/${SRS_OBJS}/${APP_NAME}
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -139,7 +138,7 @@ echo "# Depends, the depends objects" >> ${FILE}
 echo -n "SRS_UTEST_DEPS = " >> ${FILE}
 for item in ${MODULE_OBJS[*]}; do
     FILE_NAME=${item%.*}
-    echo -n "${SRS_TRUNK_PREFIX}/${SRS_OBJS_DIR}/${FILE_NAME}.o " >> ${FILE}
+    echo -n "${SRS_TRUNK_PREFIX}/${SRS_OBJS}/${FILE_NAME}.o " >> ${FILE}
 done
 echo "" >> ${FILE}; echo "" >> ${FILE}
 #
@@ -183,12 +182,12 @@ echo "" >> ${FILE}; echo "" >> ${FILE}
 #
 echo "# generate the utest binary" >> ${FILE}
 cat << END >> ${FILE}
-${SRS_TRUNK_PREFIX}/${SRS_OBJS_DIR}/${APP_NAME} : \$(SRS_UTEST_DEPS) ${MODULE_OBJS} gtest.a
+${SRS_TRUNK_PREFIX}/${SRS_OBJS}/${APP_NAME} : \$(SRS_UTEST_DEPS) ${MODULE_OBJS} gtest.a
 	\$(CXX) -o \$@ \$(CPPFLAGS) \$(CXXFLAGS) \$^ \$(DEPS_LIBRARIES_FILES) ${LINK_OPTIONS}
 END
 
 #####################################################################################
 # parent Makefile, to create module output dir before compile it.
-echo "	@mkdir -p ${SRS_OBJS_DIR}/utest" >> ${SRS_WORKDIR}/${SRS_MAKEFILE}
+echo "	@mkdir -p ${SRS_OBJS}/utest" >> ${SRS_MAKEFILE}
 
 echo -n "Generate utest ok"; echo '!';

--- a/trunk/configure
+++ b/trunk/configure
@@ -3,11 +3,16 @@
 #####################################################################################
 # the main output dir, all configure and make output are in this dir.
 #####################################################################################
-# create the main objs
-SRS_WORKDIR="."
-SRS_OBJS_DIR="objs"
-SRS_OBJS="${SRS_WORKDIR}/${SRS_OBJS_DIR}"
-SRS_MAKEFILE="Makefile"
+# Configure SRS from other directory, for example:
+#       env SRS_WORKDIR=~/git/srs/trunk ./configure
+if [[ -z $SRS_WORKDIR ]]; then SRS_WORKDIR="."; fi
+# Set the objs to other directory, for example:
+#       env SRS_OUTPUT=$(pwd) ./configure
+if [[ -z $SRS_OUTPUT ]]; then
+    SRS_OBJS="${SRS_WORKDIR}/objs" && SRS_MAKEFILE=${SRS_WORKDIR}/Makefile
+else
+    SRS_OBJS="${SRS_OUTPUT}/objs" && SRS_MAKEFILE=${SRS_OUTPUT}/Makefile
+fi
 
 # linux shell color support.
 RED="\\033[31m"
@@ -21,13 +26,13 @@ BLACK="\\033[0m"
 # build options: SRS_JOBS
 #####################################################################################
 # parse options, exit with error when parse options invalid.
-. auto/options.sh
+. $SRS_WORKDIR/auto/options.sh
 
 # setup variables when options parsed.
-. auto/setup_variables.sh
+. $SRS_WORKDIR/auto/setup_variables.sh
 
 # We don't need to cleanup the exists files.
-rm -f ${SRS_WORKDIR}/${SRS_MAKEFILE}
+rm -f ${SRS_MAKEFILE}
 
 # Create objs and platform directories.
 mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}
@@ -35,10 +40,10 @@ mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}
 if [[ $SRS_GENERATE_OBJS == YES ]]; then exit 0; fi
 
 # apply user options.
-. auto/depends.sh
+. $SRS_WORKDIR/auto/depends.sh
 
 # the auto generated variables.
-. auto/auto_headers.sh
+. $SRS_WORKDIR/auto/auto_headers.sh
 
 #####################################################################################
 # generate Makefile.
@@ -48,13 +53,13 @@ SRS_BUILD_SUMMARY="_srs_build_summary.sh"
 
 # utest make entry, (cd utest; make)
 SrsUtestMakeEntry="@echo -e \"ignore utest for it's disabled\""
-if [ $SRS_UTEST = YES ]; then SrsUtestMakeEntry="(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM}/utest && \$(MAKE))"; fi
+if [[ $SRS_UTEST == YES ]]; then SrsUtestMakeEntry="\$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/utest"; fi
 
 #####################################################################################
 # finger out modules to install.
 # where srs module is a dir which contains a config file.
 SRS_MODULES=()
-__mfiles=`find modules -name "config"` && for __mfile in $__mfiles; do
+__mfiles=$(find $SRS_WORKDIR/modules -name "config") && for __mfile in $__mfiles; do
     SRS_MODULES+=("`dirname $__mfile`")
 done
 
@@ -63,7 +68,7 @@ __mphonys="" && __mdefaults="" && __mcleanups=""
 # add each modules for application
 for SRS_MODULE in ${SRS_MODULES[*]}; do
     echo "install module at: $SRS_MODULE"
-    . auto/reset_module.sh && . $SRS_MODULE/config
+    . $SRS_WORKDIR/auto/reset_module.sh && . $SRS_MODULE/config
     if [[ 0 -ne ${#SRS_MODULE_MAIN[@]} ]]; then
         __mphonys="$__mphonys $SRS_MODULE_NAME"
         __mdefaults="$__mdefaults $SRS_MODULE_NAME"
@@ -72,7 +77,7 @@ for SRS_MODULE in ${SRS_MODULES[*]}; do
 done
 
 # generate extra phony for each modules.
-cat << END > ${SRS_OBJS}/${SRS_MAKEFILE}
+cat << END > ${SRS_OBJS}/Makefile
 
 .PHONY: $__mphonys
 
@@ -93,12 +98,12 @@ if [[ $SRS_CXX14 == YES ]]; then
     CppStd="-std=c++14"
 fi
 # performance of gprof
-SrsGprof=""; SrsGprofLink=""; if [ $SRS_GPROF = YES ]; then SrsGprof=" -pg -lc_p"; SrsGprofLink=" -pg"; fi
+SrsGprof=""; SrsGprofLink=""; if [[ $SRS_GPROF == YES ]]; then SrsGprof=" -pg -lc_p"; SrsGprofLink=" -pg"; fi
 # performance of gperf
-SrsGperf=""; SrsGperfLink=""; if [ $SRS_GPERF = YES ]; then SrsGperfLink=" -lpthread"; fi
+SrsGperf=""; SrsGperfLink=""; if [[ $SRS_GPERF == YES ]]; then SrsGperfLink=" -lpthread"; fi
 # the cxx flag generated.
 CXXFLAGS="${CXXFLAGS} ${CppStd}${WarnLevel}${GDBDebug}${LibraryCompile}${SrsGprof}"
-if [ $SRS_GPERF = YES ]; then
+if [[ $SRS_GPERF == YES ]]; then
     CXXFLAGS="${CXXFLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free";
 fi
 # For coverage.
@@ -123,7 +128,7 @@ if [[ $SRS_SANITIZER == YES && $OS_IS_X86_64 == YES ]]; then
 fi
 
 # Start to generate the Makefile.
-cat << END >> ${SRS_OBJS}/${SRS_MAKEFILE}
+cat << END >> ${SRS_OBJS}/Makefile
 GCC = ${SRS_TOOL_CC}
 CXX = ${SRS_TOOL_CXX}
 AR = ${SRS_TOOL_AR}
@@ -142,42 +147,42 @@ END
 # library(.a): add to ModuleLibFiles if binary need the specifeid library. for example, LibSTfile
 #
 # st(state-threads) the basic network library for SRS.
-LibSTRoot="${SRS_OBJS_DIR}/st"; LibSTfile="${LibSTRoot}/libst.a"
+LibSTRoot="${SRS_OBJS}/st"; LibSTfile="${LibSTRoot}/libst.a"
 if [[ $SRS_SHARED_ST == YES ]]; then LibSTfile="-L${LibSTRoot} -lst"; fi
 
 # srtp
 if [[ $SRS_RTC == YES ]]; then
-  LibSrtpRoot="${SRS_OBJS_DIR}/srtp2/include"; LibSrtpFile="${SRS_OBJS_DIR}/srtp2/lib/libsrtp2.a"
+  LibSrtpRoot="${SRS_OBJS}/srtp2/include"; LibSrtpFile="${SRS_OBJS}/srtp2/lib/libsrtp2.a"
 fi
 
 # FFMPEG for WebRTC transcoding, such as aac to opus.
 if [[ $SRS_FFMPEG_FIT == YES ]]; then
-    LibFfmpegRoot="${SRS_OBJS_DIR}/ffmpeg/include"; LibFfmpegFile="${SRS_OBJS_DIR}/ffmpeg/lib/libavcodec.a ${SRS_OBJS_DIR}/ffmpeg/lib/libswresample.a ${SRS_OBJS_DIR}/ffmpeg/lib/libavutil.a"
-    if [[ $SRS_CROSS_BUILD == NO ]]; then
-        LibFfmpegFile="${LibFfmpegFile} ${SRS_OBJS_DIR}/opus/lib/libopus.a"
+    LibFfmpegRoot="${SRS_OBJS}/ffmpeg/include"; LibFfmpegFile="${SRS_OBJS}/ffmpeg/lib/libavcodec.a ${SRS_OBJS}/ffmpeg/lib/libswresample.a ${SRS_OBJS}/ffmpeg/lib/libavutil.a"
+    if [[ $SRS_CROSS_BUILD != YES ]]; then
+        LibFfmpegFile="${LibFfmpegFile} ${SRS_OBJS}/opus/lib/libopus.a"
     fi
-    if [[ $SRS_SHARED_FFMPEG == YES ]]; then LibFfmpegFile="-L${SRS_OBJS_DIR}/ffmpeg/lib -lavcodec -lswresample -lavutil -L${SRS_OBJS_DIR}/opus/lib -lopus"; fi
+    if [[ $SRS_SHARED_FFMPEG == YES ]]; then LibFfmpegFile="-L${SRS_OBJS}/ffmpeg/lib -lavcodec -lswresample -lavutil -L${SRS_OBJS}/opus/lib -lopus"; fi
 fi
 
 # openssl-1.1.0e, for the RTMP complex handshake.
 LibSSLRoot="";LibSSLfile=""
 if [[ $SRS_SSL == YES && $SRS_USE_SYS_SSL == NO ]]; then
-    LibSSLRoot="${SRS_OBJS_DIR}/openssl/include"; LibSSLfile="${SRS_OBJS_DIR}/openssl/lib/libssl.a ${SRS_OBJS_DIR}/openssl/lib/libcrypto.a";
+    LibSSLRoot="${SRS_OBJS}/openssl/include"; LibSSLfile="${SRS_OBJS}/openssl/lib/libssl.a ${SRS_OBJS}/openssl/lib/libcrypto.a";
 fi
 
 # gperftools-2.1, for mem check and mem/cpu profile
 LibGperfRoot=""; LibGperfFile=""
-if [ $SRS_GPERF = YES ]; then
-    LibGperfRoot="${SRS_OBJS_DIR}/gperf/include"; LibGperfFile="${SRS_OBJS_DIR}/gperf/lib/libtcmalloc_and_profiler.a";
+if [[ $SRS_GPERF == YES ]]; then
+    LibGperfRoot="${SRS_OBJS}/gperf/include"; LibGperfFile="${SRS_OBJS}/gperf/lib/libtcmalloc_and_profiler.a";
 fi
-if [ $SRS_GPERF_MD = YES ]; then
-    LibGperfFile="${SRS_OBJS_DIR}/gperf/lib/libtcmalloc_debug.a";
+if [[ $SRS_GPERF_MD == YES ]]; then
+    LibGperfFile="${SRS_OBJS}/gperf/lib/libtcmalloc_debug.a";
 fi
 
 # srt code path
 if [[ $SRS_SRT == YES ]]; then
-    LibSRTRoot="${SRS_OBJS_DIR}/srt/include"; LibSRTfile="${SRS_OBJS_DIR}/srt/lib/libsrt.a"
-    if [[ $SRS_SHARED_SRT == YES ]]; then LibSRTfile="-L${SRS_OBJS_DIR}/srt/lib -lsrt"; fi
+    LibSRTRoot="${SRS_OBJS}/srt/include"; LibSRTfile="${SRS_OBJS}/srt/lib/libsrt.a"
+    if [[ $SRS_SHARED_SRT == YES ]]; then LibSRTfile="-L${SRS_OBJS}/srt/lib -lsrt"; fi
 fi
 
 # the link options, always use static link
@@ -189,7 +194,7 @@ fi
 # Static link the c++ libraries, for user who build SRS by a new version of gcc,
 # so we need to link the c++ libraries staticly but not all.
 # @see https://stackoverflow.com/a/26107550
-if [ $SRS_STATIC = YES ]; then
+if [[ $SRS_STATIC == YES ]]; then
     SrsLinkOptions="${SrsLinkOptions} -static-libstdc++";
 fi
 
@@ -223,16 +228,16 @@ fi
 #Core, depends only on system apis.
 MODULE_ID="CORE"
 MODULE_DEPENDS=()
-ModuleLibIncs=(${SRS_OBJS_DIR})
+ModuleLibIncs=(${SRS_OBJS})
 MODULE_FILES=("srs_core" "srs_core_version5" "srs_core_autofree" "srs_core_performance"
 		"srs_core_time" "srs_core_platform")
-CORE_INCS="src/core"; MODULE_DIR=${CORE_INCS} . auto/modules.sh
+CORE_INCS="src/core"; MODULE_DIR=${CORE_INCS} . $SRS_WORKDIR/auto/modules.sh
 CORE_OBJS="${MODULE_OBJS[@]}"
 #
 #Kernel, depends on core, provides error/log/config, nothing about stream information.
 MODULE_ID="KERNEL" 
 MODULE_DEPENDS=("CORE") 
-ModuleLibIncs=(${SRS_OBJS_DIR} ${LibSSLRoot})
+ModuleLibIncs=(${SRS_OBJS} ${LibSSLRoot})
 MODULE_FILES=("srs_kernel_error" "srs_kernel_log" "srs_kernel_buffer"
         "srs_kernel_utility" "srs_kernel_flv" "srs_kernel_codec" "srs_kernel_io"
         "srs_kernel_consts" "srs_kernel_aac" "srs_kernel_mp3" "srs_kernel_ts" "srs_kernel_ps"
@@ -241,13 +246,13 @@ MODULE_FILES=("srs_kernel_error" "srs_kernel_log" "srs_kernel_buffer"
 if [[ $SRS_RTC == YES ]]; then
     MODULE_FILES+=("srs_kernel_rtc_rtp" "srs_kernel_rtc_rtcp")
 fi
-KERNEL_INCS="src/kernel"; MODULE_DIR=${KERNEL_INCS} . auto/modules.sh
+KERNEL_INCS="src/kernel"; MODULE_DIR=${KERNEL_INCS} . $SRS_WORKDIR/auto/modules.sh
 KERNEL_OBJS="${MODULE_OBJS[@]}"
 #
 #RTMP/HTTP/Raw Protocol, depends on core/kernel, provides rtmp/htttp protocol features.
 MODULE_ID="PROTOCOL" 
 MODULE_DEPENDS=("CORE" "KERNEL") 
-ModuleLibIncs=(${SRS_OBJS_DIR} ${LibSTRoot} ${LibSSLRoot})
+ModuleLibIncs=(${SRS_OBJS} ${LibSTRoot} ${LibSSLRoot})
 MODULE_FILES=("srs_protocol_amf0" "srs_protocol_io" "srs_protocol_conn" "srs_protocol_rtmp_handshake"
         "srs_protocol_rtmp_stack" "srs_protocol_utility" "srs_protocol_rtmp_msg_array" "srs_protocol_stream"
         "srs_protocol_raw_avc" "srs_protocol_http_stack" "srs_protocol_kbps" "srs_protocol_json"
@@ -260,15 +265,15 @@ fi
 if [[ $SRS_RTC == YES ]]; then
     MODULE_FILES+=("srs_protocol_rtc_stun")
 fi
-PROTOCOL_INCS="src/protocol"; MODULE_DIR=${PROTOCOL_INCS} . auto/modules.sh
+PROTOCOL_INCS="src/protocol"; MODULE_DIR=${PROTOCOL_INCS} . $SRS_WORKDIR/auto/modules.sh
 PROTOCOL_OBJS="${MODULE_OBJS[@]}"
 
 #
 #App Module, for SRS server only.
 MODULE_ID="APP"
 MODULE_DEPENDS=("CORE" "KERNEL" "PROTOCOL")
-ModuleLibIncs=(${SRS_OBJS_DIR} ${LibSSLRoot})
-if [ $SRS_GPERF = YES ]; then
+ModuleLibIncs=(${SRS_OBJS} ${LibSSLRoot})
+if [[ $SRS_GPERF == YES ]]; then
     ModuleLibIncs+=(${LibGperfRoot})
 fi
 if [[ $SRS_RTC == YES ]]; then
@@ -305,17 +310,17 @@ fi
 DEFINES=""
 # add each modules for app
 for SRS_MODULE in ${SRS_MODULES[*]}; do
-    . auto/reset_module.sh && . $SRS_MODULE/config
+    . $SRS_WORKDIR/auto/reset_module.sh && . $SRS_MODULE/config
     MODULE_FILES+=("${SRS_MODULE_APP[*]}")
     DEFINES="${DEFINES} ${SRS_MODULE_DEFINES}"
 done
-APP_INCS="src/app"; MODULE_DIR=${APP_INCS} . auto/modules.sh
+APP_INCS="src/app"; MODULE_DIR=${APP_INCS} . $SRS_WORKDIR/auto/modules.sh
 APP_OBJS="${MODULE_OBJS[@]}"
 #
 #Server Module, for SRS only.
 MODULE_ID="SERVER"
 MODULE_DEPENDS=("CORE" "KERNEL" "PROTOCOL" "APP")
-ModuleLibIncs=(${SRS_OBJS_DIR} ${LibGperfRoot} ${LibSSLRoot})
+ModuleLibIncs=(${SRS_OBJS} ${LibGperfRoot} ${LibSSLRoot})
 if [[ $SRS_RTC == YES ]]; then
     ModuleLibIncs+=(${LibSrtpRoot})
 fi
@@ -323,13 +328,13 @@ if [[ $SRS_FFMPEG_FIT == YES ]]; then
     ModuleLibIncs+=("${LibFfmpegRoot[*]}")
 fi
 MODULE_FILES=("srs_main_server")
-SERVER_INCS="src/main"; MODULE_DIR=${SERVER_INCS} . auto/modules.sh
+SERVER_INCS="src/main"; MODULE_DIR=${SERVER_INCS} . $SRS_WORKDIR/auto/modules.sh
 SERVER_OBJS="${MODULE_OBJS[@]}"
 #
 #Main Module, for app from modules.
 MODULE_ID="MAIN"
 MODULE_DEPENDS=("CORE" "KERNEL" "PROTOCOL" "APP")
-ModuleLibIncs=(${SRS_OBJS_DIR} ${LibGperfRoot} ${LibSSLRoot})
+ModuleLibIncs=(${SRS_OBJS} ${LibGperfRoot} ${LibSSLRoot})
 if [[ $SRS_RTC == YES ]]; then
     ModuleLibIncs+=(${LibSrtpRoot})
 fi
@@ -340,11 +345,11 @@ MODULE_FILES=()
 DEFINES=""
 # add each modules for main
 for SRS_MODULE in ${SRS_MODULES[*]}; do
-    . auto/reset_module.sh && . $SRS_MODULE/config
+    . $SRS_WORKDIR/auto/reset_module.sh && . $SRS_MODULE/config
     MODULE_FILES+=("${SRS_MODULE_MAIN[*]}")
     DEFINES="${DEFINES} ${SRS_MODULE_DEFINES}"
 done
-MAIN_INCS="src/main"; MODULE_DIR=${MAIN_INCS} . auto/modules.sh
+MAIN_INCS="src/main"; MODULE_DIR=${MAIN_INCS} . $SRS_WORKDIR/auto/modules.sh
 MAIN_OBJS="${MODULE_OBJS[@]}"
 
 #####################################################################################
@@ -354,7 +359,7 @@ MAIN_OBJS="${MODULE_OBJS[@]}"
 # all main entrances
 MAIN_ENTRANCES=("srs_main_server")
 for SRS_MODULE in ${SRS_MODULES[*]}; do
-    . auto/reset_module.sh && . $SRS_MODULE/config
+    . $SRS_WORKDIR/auto/reset_module.sh && . $SRS_MODULE/config
     MAIN_ENTRANCES+=("${SRS_MODULE_MAIN[*]}")
 done
 #
@@ -371,7 +376,7 @@ if [[ $SRS_SRT == YES ]]; then
 fi
 # all depends objects
 MODULE_OBJS="${CORE_OBJS[@]} ${KERNEL_OBJS[@]} ${PROTOCOL_OBJS[@]} ${APP_OBJS[@]} ${SERVER_OBJS[@]}"
-ModuleLibIncs=(${SRS_OBJS_DIR} ${LibSTRoot} ${LibGperfRoot} ${LibSSLRoot})
+ModuleLibIncs=(${SRS_OBJS} ${LibSTRoot} ${LibGperfRoot} ${LibSSLRoot})
 if [[ $SRS_RTC == YES ]]; then
     ModuleLibIncs+=(${LibSrtpRoot})
 fi
@@ -385,7 +390,7 @@ fi
 LINK_OPTIONS="${SrsLinkOptions}${SrsGprofLink}${SrsGperfLink}"
 #
 # srs: srs(simple rtmp server) over st(state-threads)
-BUILD_KEY="srs" APP_MAIN="srs_main_server" APP_NAME="srs" . auto/apps.sh
+BUILD_KEY="srs" APP_MAIN="srs_main_server" APP_NAME="srs" . $SRS_WORKDIR/auto/apps.sh
 #
 # For modules, with the app module.
 MODULE_OBJS="${CORE_OBJS[@]} ${KERNEL_OBJS[@]} ${PROTOCOL_OBJS[@]} ${APP_OBJS[@]} ${MAIN_OBJS[@]}"
@@ -401,10 +406,10 @@ if [[ $SRS_SRT == YES ]]; then
 fi
 #
 for SRS_MODULE in ${SRS_MODULES[*]}; do
-    . auto/reset_module.sh && . $SRS_MODULE/config
+    . $SRS_WORKDIR/auto/reset_module.sh && . $SRS_MODULE/config
     # no SRS_MODULE_MAIN
     if [[ 0 -eq ${#SRS_MODULE_MAIN[@]} ]]; then continue; fi
-    BUILD_KEY="$SRS_MODULE_NAME" APP_MAIN="${SRS_MODULE_MAIN[0]}" APP_NAME="$SRS_MODULE_NAME" . auto/apps.sh
+    BUILD_KEY="$SRS_MODULE_NAME" APP_MAIN="${SRS_MODULE_MAIN[0]}" APP_NAME="$SRS_MODULE_NAME" . $SRS_WORKDIR/auto/apps.sh
 done
 # For utest on mac.
 # @see https://github.com/protocolbuffers/protobuf/issues/51#issuecomment-111044468
@@ -413,7 +418,7 @@ if [[ $SRS_OSX == YES ]]; then
 fi
 #
 # utest, the unit-test cases of srs, base on gtest1.6
-if [ $SRS_UTEST = YES ]; then
+if [[ $SRS_UTEST == YES ]]; then
     MODULE_FILES=("srs_utest" "srs_utest_amf0" "srs_utest_kernel" "srs_utest_core"
         "srs_utest_config" "srs_utest_rtmp" "srs_utest_http" "srs_utest_avc" "srs_utest_reload"
         "srs_utest_mp4" "srs_utest_service" "srs_utest_app" "srs_utest_rtc"
@@ -424,7 +429,7 @@ if [ $SRS_UTEST = YES ]; then
     if [[ $SRS_GB28181 == YES ]]; then
         MODULE_FILES+=("srs_utest_gb28181")
     fi
-    ModuleLibIncs=(${SRS_OBJS_DIR} ${LibSTRoot} ${LibSSLRoot})
+    ModuleLibIncs=(${SRS_OBJS} ${LibSTRoot} ${LibSSLRoot})
     if [[ $SRS_RTC == YES ]]; then
         ModuleLibIncs+=(${LibSrtpRoot})
     fi
@@ -446,23 +451,23 @@ if [ $SRS_UTEST = YES ]; then
     fi
     MODULE_DEPENDS=("CORE" "KERNEL" "PROTOCOL" "APP")
     MODULE_OBJS="${CORE_OBJS[@]} ${KERNEL_OBJS[@]} ${PROTOCOL_OBJS[@]} ${APP_OBJS[@]} ${SRT_OBJS[@]}"
-    LINK_OPTIONS="-lpthread ${SrsLinkOptions}" MODULE_DIR="src/utest" APP_NAME="srs_utest" . auto/utest.sh
+    LINK_OPTIONS="-lpthread ${SrsLinkOptions}" MODULE_DIR="src/utest" APP_NAME="srs_utest" . $SRS_WORKDIR/auto/utest.sh
 fi
 
 #####################################################################################
 # generate colorful summary script
-. auto/summary.sh
+. $SRS_WORKDIR/auto/summary.sh
 
 #####################################################################################
 # makefile
 echo "Generate Makefile"
 
 # backup old makefile.
-rm -f ${SRS_WORKDIR}/${SRS_MAKEFILE}.bk &&
-mv ${SRS_WORKDIR}/${SRS_MAKEFILE} ${SRS_WORKDIR}/${SRS_MAKEFILE}.bk
+rm -f ${SRS_MAKEFILE}.bk &&
+mv ${SRS_MAKEFILE} ${SRS_MAKEFILE}.bk
 
 # generate phony header
-cat << END > ${SRS_WORKDIR}/${SRS_MAKEFILE}
+cat << END > ${SRS_MAKEFILE}
 .PHONY: default all _default install help clean destroy server srs_ingest_hls utest _prepare_dir $__mphonys
 .PHONY: clean_srs clean_modules clean_openssl clean_srtp2 clean_opus clean_ffmpeg clean_st
 .PHONY: st ffmpeg
@@ -479,6 +484,7 @@ SRS_PREFIX=${SRS_PREFIX}
 SRS_DEFAULT_CONFIG=${SRS_DEFAULT_CONFIG}
 __REAL_INSTALL=\$(DESTDIR)\$(SRS_PREFIX)
 
+JOBS=\$(shell echo \$(MAKEFLAGS)| grep -qE '\-j[0-9]+' || echo " ${SRS_JOBS}")
 default: server
 
 all: _default
@@ -486,20 +492,20 @@ all: _default
 END
 
 # the real entry for all platform:
-cat << END >> ${SRS_WORKDIR}/${SRS_MAKEFILE}
+cat << END >> ${SRS_MAKEFILE}
 _default: server srs_ingest_hls utest $__mdefaults
 
 help:
 	@echo "Usage: make <help>|<clean>|<destroy>|<server>|<utest>|<install>|<uninstall>"
 	@echo "     help            Display this help menu"
 	@echo "     clean           Cleanup project and all depends"
-	@echo "     destroy         Cleanup all files for this platform in ${SRS_OBJS_DIR}/${SRS_PLATFORM}"
+	@echo "     destroy         Cleanup all files for this platform in ${SRS_OBJS}/${SRS_PLATFORM}"
 	@echo "     server          Build the srs and other modules in main"
 	@echo "     utest           Build the utest for srs"
 	@echo "     install         Install srs to the prefix path"
 	@echo "     uninstall       Uninstall srs from prefix path"
 	@echo "To rebuild special module:"
-	@echo "     st              Rebuild st-srs in ${SRS_OBJS_DIR}/${SRS_PLATFORM}/st-srs"
+	@echo "     st              Rebuild st-srs in ${SRS_OBJS}/${SRS_PLATFORM}/st-srs"
 	@echo "     ffmpeg          Rebuild ffmpeg in ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4.2-fit"
 	@echo "To reconfigure special depends:"
 	@echo "     clean_openssl   Remove the openssl cache."
@@ -512,77 +518,75 @@ help:
 	@echo "     make help"
 
 doclean:
-	(cd ${SRS_OBJS_DIR} && rm -rf srs srs_utest $__mcleanups)
-	(cd ${SRS_OBJS_DIR} && rm -rf src/* include lib)
-	(mkdir -p ${SRS_OBJS_DIR}/utest && cd ${SRS_OBJS_DIR}/utest && rm -rf *.o *.a)
+	(cd ${SRS_OBJS} && rm -rf srs srs_utest $__mcleanups)
+	(cd ${SRS_OBJS} && rm -rf src/* include lib)
+	(mkdir -p ${SRS_OBJS}/utest && cd ${SRS_OBJS}/utest && rm -rf *.o *.a)
 
 clean: clean_srs clean_modules
 
 destroy:
-	(cd ${SRS_OBJS_DIR} && rm -rf ${SRS_PLATFORM})
+	(cd ${SRS_OBJS} && rm -rf ${SRS_PLATFORM})
 
 clean_srs:
-	@(cd ${SRS_OBJS_DIR} && rm -rf srs srs_utest)
-	@(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM} && rm -rf include/* lib/*)
-	@(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM} && find src -name "*.o" -delete)
-	@(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM} && find utest -name "*.o" -delete)
+	@(cd ${SRS_OBJS} && rm -rf srs srs_utest src/* utest/*)
 
 clean_modules:
-	@(cd ${SRS_OBJS_DIR} && rm -rf $__mdefaults)
+	@(cd ${SRS_OBJS} && rm -rf $__mdefaults)
 
 clean_openssl:
-	(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM} && rm -rf openssl*)
+	@rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/openssl
 	@echo "Please rebuild openssl by: ./configure"
 
 clean_srtp2:
-	(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM} && rm -rf libsrtp-2.0.0)
+	@rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/srtp2
 	@echo "Please rebuild libsrtp2 by: ./configure"
 
 clean_opus:
-	(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM} && rm -rf opus-1.3.1)
+	@rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/opus
 	@echo "Please rebuild opus by: ./configure"
 
 clean_ffmpeg:
-	(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM} && rm -rf ffmpeg-4.2-fit)
+	@rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/ffmpeg
 	@echo "Please rebuild FFmpeg by: ./configure"
 
 clean_st:
-	(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM} && rm -rf st-srs)
+	@rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/st
 	@echo "Please rebuild ST by: ./configure"
 
 st:
-	(cd ${SRS_OBJS_DIR} && rm -f srs srs_utest)
-	(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM}/st-srs && \$(MAKE) clean)
-	(cd ${SRS_OBJS_DIR}/${SRS_PLATFORM}/st-srs && env EXTRA_CFLAGS="${_ST_EXTRA_CFLAGS}" \$(MAKE) ${_ST_MAKE_ARGS} CC=\$(GCC) AR=\$(AR) LD=\$(LINK) RANDLIB=\$(RANDLIB))
-	@echo "Please rebuild srs by: rm -f objs/srs && make"
+	@rm -f ${SRS_OBJS}/srs srs_utest
+	@\$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/st-srs clean)
+	@env EXTRA_CFLAGS="${_ST_EXTRA_CFLAGS}" \$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/st-srs ${_ST_MAKE_ARGS} CC=\$(GCC) AR=\$(AR) LD=\$(LINK) RANDLIB=\$(RANDLIB))
+	@echo "Please rebuild srs by: make"
 
 ffmpeg:
-	(cd ${SRS_OBJS_DIR} && rm -f srs srs_utest)
-	(cd ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4.2-fit && \$(MAKE) && \$(MAKE) install-libs)
-	@echo "Please rebuild srs by: rm -f objs/srs && make"
+	@rm -f ${SRS_OBJS}/srs srs_utest
+	\$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4.2-fit
+	\$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/ffmpeg-4.2-fit install-libs
+	@echo "Please rebuild srs by: make"
 
 END
 
-cat << END >> ${SRS_WORKDIR}/${SRS_MAKEFILE}
+cat << END >> ${SRS_MAKEFILE}
 server: _prepare_dir
 	@echo "Build the SRS server"
-	\$(MAKE) -f ${SRS_OBJS_DIR}/${SRS_MAKEFILE} srs
+	\$(MAKE)\$(JOBS) -f ${SRS_OBJS}/Makefile srs
 	@bash objs/_srs_build_summary.sh
 
 END
 # generate all modules entry
 for SRS_MODULE in ${SRS_MODULES[*]}; do
-    . auto/reset_module.sh && . $SRS_MODULE/config
-    cat << END >> ${SRS_WORKDIR}/${SRS_MAKEFILE}
+    . $SRS_WORKDIR/auto/reset_module.sh && . $SRS_MODULE/config
+    cat << END >> ${SRS_MAKEFILE}
 $SRS_MODULE_NAME: _prepare_dir server
 	@echo "Build the $SRS_MODULE_NAME over SRS"
-	\$(MAKE) -f ${SRS_OBJS_DIR}/${SRS_MAKEFILE} $SRS_MODULE_NAME
+	\$(MAKE)\$(JOBS) -f ${SRS_OBJS}/Makefile $SRS_MODULE_NAME
 
 END
 done
 
 # install entry
-cat << END >> ${SRS_WORKDIR}/${SRS_MAKEFILE}
+cat << END >> ${SRS_MAKEFILE}
 uninstall:
 	@echo "rmdir \$(SRS_PREFIX)"
 	@rm -rf \$(SRS_PREFIX)
@@ -618,8 +622,8 @@ install:
 
 END
 
-if [ $SRS_UTEST = YES ]; then
-    cat << END >> ${SRS_WORKDIR}/${SRS_MAKEFILE}
+if [[ $SRS_UTEST == YES ]]; then
+    cat << END >> ${SRS_MAKEFILE}
 utest: server
 	@echo "Building the utest for srs"
 	${SrsUtestMakeEntry}
@@ -627,22 +631,22 @@ utest: server
 
 END
 else
-    cat << END >> ${SRS_WORKDIR}/${SRS_MAKEFILE}
+    cat << END >> ${SRS_MAKEFILE}
 utest: server
 	@echo "Ignore utest for it's disabled."
 
 END
 fi
 
-cat << END >> ${SRS_WORKDIR}/${SRS_MAKEFILE}
+cat << END >> ${SRS_MAKEFILE}
 # the ./configure will generate it.
 _prepare_dir:
-	@mkdir -p ${SRS_OBJS_DIR}
+	@mkdir -p ${SRS_OBJS}
 END
 
 # generate makefile ok, append the tails.
-cat ${SRS_WORKDIR}/${SRS_MAKEFILE}.bk >> ${SRS_WORKDIR}/${SRS_MAKEFILE} &&
-rm -f ${SRS_WORKDIR}/${SRS_MAKEFILE}.bk
+cat ${SRS_MAKEFILE}.bk >> ${SRS_MAKEFILE} &&
+rm -f ${SRS_MAKEFILE}.bk
 
 echo 'Configure ok! '
 
@@ -660,47 +664,47 @@ echo ""
 echo "Configure summary:"
 echo "     ${SRS_AUTO_USER_CONFIGURE}"
 echo "     ${SRS_AUTO_CONFIGURE}"
-if [ $SRS_HLS = YES ]; then
+if [[ $SRS_HLS == YES ]]; then
     echo -e "${GREEN}HLS is enabled.${BLACK}"
 else
     echo -e "${YELLOW}Warning: HLS is disabled.${BLACK}"
 fi
-if [ $SRS_STREAM_CASTER = YES ]; then
+if [[ $SRS_STREAM_CASTER == YES ]]; then
     echo -e "${YELLOW}Experiment: StreamConverter is enabled.${BLACK}"
 else
     echo -e "${GREEN}Note: StreamConverter is disabled.${BLACK}"
 fi
-if [ $SRS_HDS = YES ]; then
+if [[ $SRS_HDS == YES ]]; then
     echo -e "${YELLOW}Experiment: HDS is enabled.${BLACK}"
 else
     echo -e "${GREEN}Warning: HDS is disabled.${BLACK}"
 fi
-if [ $SRS_GB28181 = YES ]; then
+if [[ $SRS_GB28181 == YES ]]; then
     echo -e "${YELLOW}Experiment: GB28181 is enabled. https://github.com/ossrs/srs/issues/3176${BLACK}"
 else
     echo -e "${GREEN}Warning: GB28181 is disabled.${BLACK}"
 fi
-if [ $SRS_SRT = YES ]; then
+if [[ $SRS_SRT == YES ]]; then
     echo -e "${YELLOW}Experiment: SRT is enabled. https://github.com/ossrs/srs/issues/1147${BLACK}"
 else
     echo -e "${GREEN}Warning: SRT is disabled.${BLACK}"
 fi
-if [ $SRS_RTC = YES ]; then
+if [[ $SRS_RTC == YES ]]; then
     echo -e "${YELLOW}Experiment: RTC is enabled. https://github.com/ossrs/srs/issues/307${BLACK}"
 else
     echo -e "${GREEN}Warning: RTC is disabled.${BLACK}"
 fi
-if [ $SRS_HTTPS = YES ]; then
+if [[ $SRS_HTTPS == YES ]]; then
     echo -e "${YELLOW}Experiment: HTTPS is enabled. https://github.com/ossrs/srs/issues/1657${BLACK}"
 else
     echo -e "${GREEN}Warning: HTTPS is disabled.${BLACK}"
 fi
-if [ $SRS_DVR = YES ]; then
+if [[ $SRS_DVR == YES ]]; then
     echo -e "${GREEN}DVR is enabled.${BLACK}"
 else
     echo -e "${YELLOW}Warning: DVR is disabled.${BLACK}"
 fi
-if [ $SRS_SSL = YES ]; then
+if [[ $SRS_SSL == YES ]]; then
     echo -e "${GREEN}RTMP complex handshake is enabled${BLACK}"
 else
     echo -e "${YELLOW}Warning: RTMP complex handshake is disabled, flash cann't play h264/aac.${BLACK}"
@@ -715,72 +719,72 @@ if [[ $SRS_SRTP_ASM == YES ]]; then
 else
     echo -e "${YELLOW}Warning: SRTP-NASM for WebRTC(openssl) is disabled${BLACK}"
 fi
-if [ $SRS_TRANSCODE = YES ]; then
+if [[ $SRS_TRANSCODE == YES ]]; then
     echo -e "${GREEN}The transcoding is enabled${BLACK}"
 else
     echo -e "${YELLOW}Warning: The transcoding is disabled.${BLACK}"
 fi
-if [ $SRS_INGEST = YES ]; then
+if [[ $SRS_INGEST == YES ]]; then
     echo -e "${GREEN}The ingesting is enabled.${BLACK}"
 else
     echo -e "${YELLOW}Warning: The ingesting is disabled.${BLACK}"
 fi
-if [ $SRS_HTTP_CALLBACK = YES ]; then
+if [[ $SRS_HTTP_CALLBACK == YES ]]; then
     echo -e "${GREEN}The http-callback is enabled${BLACK}"
 else
     echo -e "${YELLOW}Warning: The http-callback is disabled.${BLACK}"
 fi
-if [ $SRS_HTTP_SERVER = YES ]; then
+if [[ $SRS_HTTP_SERVER == YES ]]; then
     echo -e "${GREEN}Embeded HTTP server for HTTP-FLV/HLS is enabled.${BLACK}"
 else
     echo -e "${YELLOW}Warning: Embeded HTTP server is disabled, HTTP-FLV is disabled, please use nginx to delivery HLS.${BLACK}"
 fi
-if [ $SRS_HTTP_API = YES ]; then
+if [[ $SRS_HTTP_API == YES ]]; then
     echo -e "${GREEN}The HTTP API is enabled${BLACK}"
 else
     echo -e "${YELLOW}Warning: The HTTP API is disabled.${BLACK}"
 fi
-if [ $SRS_UTEST = YES ]; then
+if [[ $SRS_UTEST == YES ]]; then
     echo -e "${GREEN}The utests are enabled.${BLACK}"
 else
     echo -e "${YELLOW}Note: The utests are disabled.${BLACK}"
 fi
-if [ $SRS_GPERF = YES ]; then
+if [[ $SRS_GPERF == YES ]]; then
     echo -e "${GREEN}The gperf(tcmalloc) is enabled.${BLACK}"
 else
     echo -e "${GREEN}Note: The gperf(tcmalloc) is disabled.${BLACK}"
 fi
-if [ $SRS_GPERF_MC = YES ]; then
+if [[ $SRS_GPERF_MC == YES ]]; then
     echo -e "${YELLOW}The gmc(gperf memory check) is enabled, performance may suffer.${BLACK}"
 else
     echo -e "${GREEN}Note: The gmc(gperf memory check) is disabled.${BLACK}"
 fi
-if [ $SRS_GPERF_MD = YES ]; then
+if [[ $SRS_GPERF_MD == YES ]]; then
     echo -e "${YELLOW}The gmd(gperf memory defense) is enabled, performance may suffer.${BLACK}"
 else
     echo -e "${GREEN}Note: The gmd(gperf memory defense) is disabled.${BLACK}"
 fi
-if [ $SRS_GPERF_MP = YES ]; then
+if [[ $SRS_GPERF_MP == YES ]]; then
     echo -e "${YELLOW}The gmp(gperf memory profile) is enabled, performance may suffer.${BLACK}"
 else
     echo -e "${GREEN}Note: The gmp(gperf memory profile) is disabled.${BLACK}"
 fi
-if [ $SRS_GPERF_CP = YES ]; then
+if [[ $SRS_GPERF_CP == YES ]]; then
     echo -e "${YELLOW}The gcp(gperf cpu profile) is enabled, performance may suffer.${BLACK}"
 else
     echo -e "${GREEN}Note: The gcp(gperf cpu profile) is disabled.${BLACK}"
 fi
-if [ $SRS_GPROF = YES ]; then
+if [[ $SRS_GPROF == YES ]]; then
     echo -e "${YELLOW}The gprof(GNU profile tool) is enabled, performance may suffer.${BLACK}"
 else
     echo -e "${GREEN}Note: The gprof(GNU profile tool) is disabled.${BLACK}"
 fi
-if [ $SRS_CROSS_BUILD = YES ]; then
+if [[ $SRS_CROSS_BUILD == YES ]]; then
     echo -e "${YELLOW}The cross-build is enabled.${BLACK}"
 else
     echo -e "${GREEN}Note: The cross-build is disabled.${BLACK}"
 fi
-if [ $SRS_VALGRIND = YES ]; then
+if [[ $SRS_VALGRIND == YES ]]; then
     echo -e "${GREEN}The valgrind is enabled.${BLACK}"
 else
     echo -e "${GREEN}Note: The valgrind is disabled.${BLACK}"
@@ -804,7 +808,7 @@ fi
 if [[ $SRS_CHERRYPY == YES ]]; then
   echo ""
   echo "You can run 3rdparty applications:"
-  if [ $SRS_HTTP_CALLBACK = YES ]; then
+  if [[ $SRS_HTTP_CALLBACK == YES ]]; then
       echo -e "\" python ./research/api-server/server.py 8085  \" to start the api-server"
   fi
 fi

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-11-18, For [#2532](https://github.com/ossrs/srs/issues/2532): Windows: Replace ln by cp for windows. v5.0.87
 * v5.0, 2022-10-31, For [#2899](https://github.com/ossrs/srs/issues/2899): Exporter: Add metrics cpu, memory and uname. v5.0.86
 * v5.0, 2022-10-30, Config: Support startting with environment variable only. v5.0.85
 * v5.0, 2022-10-26, Fix [#3218](https://github.com/ossrs/srs/issues/3218): Log: Follow Java/log4j log level specs. v5.0.83

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    86
+#define VERSION_REVISION    87
 
 #endif


### PR DESCRIPTION
1. Replase ln by cp for windows.
2. Refine OS and CPU arch detecting.
3. Support configure from any directory by `SRS_WORKDIR`.
4. Support output to any directory by `SRS_OUTPUT`.
5. Disable sanitizer for gperf.
6. Use parallels build for make.
7. Refine bash variable check.