### PR TITLE
SRT: Config file does not enable srt for srt2rtc.conf

### DIFF
--- a/trunk/conf/srt2rtc.conf
+++ b/trunk/conf/srt2rtc.conf
@@ -44,9 +44,9 @@ vhost __defaultVhost__ {
     rtc {
         enabled     on;
         # @see https://ossrs.net/lts/zh-cn/docs/v4/doc/webrtc#rtmp-to-rtc
-        rtmp_to_rtc off;
+        rtmp_to_rtc on;
         # @see https://ossrs.net/lts/zh-cn/docs/v4/doc/webrtc#rtc-to-rtmp
-        rtc_to_rtmp off;
+        rtc_to_rtmp on;
     }
     http_remux {
         enabled     on;

--- a/trunk/conf/srt2rtc.conf
+++ b/trunk/conf/srt2rtc.conf
@@ -38,6 +38,9 @@ rtc_server {
 
 # @doc https://github.com/ossrs/srs/issues/1147#issuecomment-577607026
 vhost __defaultVhost__ {
+    srt {
+        enabled     on;
+    }
     rtc {
         enabled     on;
         # @see https://ossrs.net/lts/zh-cn/docs/v4/doc/webrtc#rtmp-to-rtc


### PR DESCRIPTION
Changed the default config srt2rtc.conf because otherwise (in v5)  srs throws ''srt serve error code 6006''
see #3249 and #3104