### PR TITLE
For #2532: Windows: Support CYGWIN64 for SRS

### DIFF
--- a/trunk/auto/auto_headers.sh
+++ b/trunk/auto/auto_headers.sh
@@ -178,6 +178,11 @@ if [[ $SRS_CROSS_BUILD == YES ]]; then
 else
     srs_undefine_macro "SRS_CROSSBUILD" $SRS_AUTO_HEADERS_H
 fi
+if [[ $SRS_CYGWIN64 == YES ]]; then
+    srs_define_macro "SRS_CYGWIN64" $SRS_AUTO_HEADERS_H
+else
+    srs_undefine_macro "SRS_CYGWIN64" $SRS_AUTO_HEADERS_H
+fi
 if [[ $SRS_OSX == YES ]]; then
     srs_define_macro "SRS_OSX" $SRS_AUTO_HEADERS_H
 else

--- a/trunk/auto/setup_variables.sh
+++ b/trunk/auto/setup_variables.sh
@@ -5,6 +5,10 @@ OS_KERNEL_NAME=$(uname -s)
 OS_KERNRL_RELEASE=$(uname -r|awk -F '-' '{print $1}')
 OS_PREFIX="Platform"
 
+if [[ $OSTYPE == cygwin ]]; then
+    OS_KERNRL_RELEASE=$(uname -r|awk -F '(' '{print $1}')
+fi
+
 # Build platform cache.
 SRS_PLATFORM="${SRS_BUILD_TAG}${OS_PREFIX}-${OS_KERNEL_NAME}-${OS_KERNRL_RELEASE}"
 # Build platform cache with gcc version.

--- a/trunk/auto/utest.sh
+++ b/trunk/auto/utest.sh
@@ -17,7 +17,13 @@ mkdir -p ${SRS_OBJS}/${SRS_PLATFORM}/utest
 # trunk of srs, which contains the src dir, relative to objs/utest, it's trunk
 SRS_TRUNK_PREFIX=../../..
 # gest dir, relative to objs/utest, it's trunk/objs/{Platform}/gtest
-GTEST_DIR=${SRS_TRUNK_PREFIX}/${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/gtest/googletest
+GTEST_DIR=../3rdpatry/gtest/googletest
+
+# Whether enable C++11 or higher versions.
+# For linux, always use C++11 for gtest required, see https://github.com/google/googletest
+# For cygwin64, ignore because it use -std=gnu++11 by default.
+SRS_CPP_VERSION="-std=c++11"
+if [[ $SRS_CYGWIN64 == YES ]]; then SRS_CPP_VERSION="-std=gnu++11"; fi
 
 cat << END > ${FILE}
 # user must run make the ${SRS_OBJS}/utest dir
@@ -51,9 +57,9 @@ CXX = ${SRS_TOOL_CXX}
 CPPFLAGS += -I\$(GTEST_DIR)/include
 
 # Flags passed to the C++ compiler.
-CXXFLAGS += ${CXXFLAGS} ${UTEST_EXTRA_DEFINES} -Wno-unused-private-field -Wno-unused-command-line-argument
-# Always use C++11 for gtest required, see https://github.com/google/googletest
-CXXFLAGS += -std=c++11
+CXXFLAGS += ${CXXFLAGS} ${UTEST_EXTRA_DEFINES}
+CXXFLAGS += -Wno-unused-private-field -Wno-unused-command-line-argument
+CXXFLAGS += ${SRS_CPP_VERSION}
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.

--- a/trunk/configure
+++ b/trunk/configure
@@ -93,9 +93,11 @@ WarnLevel=" -Wall"
 CppStd="-ansi"
 if [[ $SRS_CXX11 == YES ]]; then
     CppStd="-std=c++11"
+    if [[ $SRS_CYGWIN64 == YES ]]; then CppStd="-std=gnu++11"; fi
 fi
 if [[ $SRS_CXX14 == YES ]]; then
     CppStd="-std=c++14"
+    if [[ $SRS_CYGWIN64 == YES ]]; then CppStd="-std=gnu++14"; fi
 fi
 # performance of gprof
 SrsGprof=""; SrsGprofLink=""; if [[ $SRS_GPROF == YES ]]; then SrsGprof=" -pg -lc_p"; SrsGprofLink=" -pg"; fi
@@ -204,7 +206,7 @@ if [[ $SRS_GCOV == YES ]]; then
 fi
 
 # For FFMPEG/RTC on Linux.
-if [[ $SRS_OSX != YES && $SRS_RTC == YES && $SRS_FFMPEG_FIT == YES ]]; then
+if [[ $SRS_OSX != YES && $SRS_CYGWIN64 != YES && $SRS_RTC == YES && $SRS_FFMPEG_FIT == YES ]]; then
     SrsLinkOptions="${SrsLinkOptions} -lrt";
 fi
 
@@ -220,6 +222,11 @@ if [[ $SRS_SANITIZER == YES && $OS_IS_X86_64 == YES ]]; then
     if [[ $SRS_SANITIZER_STATIC == YES ]]; then
         SrsLinkOptions="${SrsLinkOptions} -static-libasan";
     fi
+fi
+
+# For FFMPEG/RTC on windows.
+if [[ $SRS_CYGWIN64 == YES && $SRS_FFMPEG_FIT == YES ]]; then
+    SrsLinkOptions="${SrsLinkOptions} -lbcrypt";
 fi
 
 #####################################################################################
@@ -555,8 +562,8 @@ clean_st:
 
 st:
 	@rm -f ${SRS_OBJS}/srs srs_utest
-	@\$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/st-srs clean)
-	@env EXTRA_CFLAGS="${_ST_EXTRA_CFLAGS}" \$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/st-srs ${_ST_MAKE_ARGS} CC=\$(GCC) AR=\$(AR) LD=\$(LINK) RANDLIB=\$(RANDLIB))
+	@\$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/st-srs clean
+	@env EXTRA_CFLAGS="${_ST_EXTRA_CFLAGS}" \$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/st-srs ${_ST_MAKE_ARGS} CC=\$(GCC) AR=\$(AR) LD=\$(LINK) RANDLIB=\$(RANDLIB)
 	@echo "Please rebuild srs by: make"
 
 ffmpeg:

--- a/trunk/src/app/srs_app_latest_version.cpp
+++ b/trunk/src/app/srs_app_latest_version.cpp
@@ -41,6 +41,8 @@ void srs_build_features(stringstream& ss)
 {
     if (SRS_OSX_BOOL) {
         ss << "&os=mac";
+    } else if (SRS_CYGWIN64_BOOL) {
+        ss << "&os=windows";
     } else {
         ss << "&os=linux";
     }

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -13,7 +13,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <algorithm>
-#ifndef SRS_OSX
+#if !defined(SRS_OSX) && !defined(SRS_CYGWIN64)
 #include <sys/inotify.h>
 #endif
 using namespace std;
@@ -191,7 +191,7 @@ srs_error_t SrsInotifyWorker::start()
 {
     srs_error_t err = srs_success;
 
-#ifndef SRS_OSX
+#if !defined(SRS_OSX) && !defined(SRS_CYGWIN64)
     // Whether enable auto reload config.
     bool auto_reload = _srs_config->inotify_auto_reload();
     if (!auto_reload && _srs_in_docker && _srs_config->auto_reload_for_docker()) {
@@ -271,7 +271,7 @@ srs_error_t SrsInotifyWorker::cycle()
 {
     srs_error_t err = srs_success;
 
-#ifndef SRS_OSX
+#if !defined(SRS_OSX) && !defined(SRS_CYGWIN64)
     string config_path = _srs_config->config();
     string config_file = srs_path_basename(config_path);
     string k8s_file = "..data";

--- a/trunk/src/app/srs_app_threads.cpp
+++ b/trunk/src/app/srs_app_threads.cpp
@@ -36,7 +36,7 @@ using namespace std;
 #include <unistd.h>
 #include <fcntl.h>
 
-#ifdef SRS_OSX
+#if defined(SRS_OSX) || defined(SRS_CYGWIN64)
     pid_t gettid() {
         return 0;
     }
@@ -49,7 +49,7 @@ using namespace std;
 
 // These functions first appeared in glibc in version 2.12.
 // See https://man7.org/linux/man-pages/man3/pthread_setname_np.3.html
-#if defined(SRS_CROSSBUILD) && ((__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 12))
+#if defined(SRS_CYGWIN64) || (defined(SRS_CROSSBUILD) && ((__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 12)))
     void pthread_setname_np(pthread_t trd, const char* name) {
     }
 #endif

--- a/trunk/src/app/srs_app_utility.cpp
+++ b/trunk/src/app/srs_app_utility.cpp
@@ -330,7 +330,7 @@ SrsProcSystemStat* srs_get_system_proc_stat()
 
 bool get_proc_system_stat(SrsProcSystemStat& r)
 {
-#ifndef SRS_OSX
+#if !defined(SRS_OSX)
     FILE* f = fopen("/proc/stat", "r");
     if (f == NULL) {
         srs_warn("open system cpu stat failed, ignore");
@@ -369,7 +369,7 @@ bool get_proc_system_stat(SrsProcSystemStat& r)
 
 bool get_proc_self_stat(SrsProcSelfStat& r)
 {
-#ifndef SRS_OSX
+#if !defined(SRS_OSX)
     FILE* f = fopen("/proc/self/stat", "r");
     if (f == NULL) {
         srs_warn("open self cpu stat failed, ignore");
@@ -493,7 +493,7 @@ SrsDiskStat* srs_get_disk_stat()
 
 bool srs_get_disk_vmstat_stat(SrsDiskStat& r)
 {
-#ifndef SRS_OSX
+#if !defined(SRS_OSX) && !defined(SRS_CYGWIN64)
     FILE* f = fopen("/proc/vmstat", "r");
     if (f == NULL) {
         srs_warn("open vmstat failed, ignore");
@@ -525,7 +525,7 @@ bool srs_get_disk_diskstats_stat(SrsDiskStat& r)
     r.ok = true;
     r.sample_time = srsu2ms(srs_update_system_time());
 
-#ifndef SRS_OSX
+#if !defined(SRS_OSX)
     // if disabled, ignore all devices.
     SrsConfDirective* conf = _srs_config->get_stats_disk_device();
     if (conf == NULL) {
@@ -689,7 +689,7 @@ void srs_update_meminfo()
 {
     SrsMemInfo& r = _srs_system_meminfo;
 
-#ifndef SRS_OSX
+#if !defined(SRS_OSX)
     FILE* f = fopen("/proc/meminfo", "r");
     if (f == NULL) {
         srs_warn("open meminfo failed, ignore");
@@ -783,7 +783,7 @@ void srs_update_platform_info()
     
     r.srs_startup_time = srsu2ms(srs_get_system_startup_time());
 
-#ifndef SRS_OSX
+#if !defined(SRS_OSX)
     if (true) {
         FILE* f = fopen("/proc/uptime", "r");
         if (f == NULL) {
@@ -877,7 +877,7 @@ static SrsSnmpUdpStat _srs_snmp_udp_stat;
 
 bool get_udp_snmp_statistic(SrsSnmpUdpStat& r)
 {
-#ifndef SRS_OSX
+#if !defined(SRS_OSX) && !defined(SRS_CYGWIN64)
     if (true) {
         FILE* f = fopen("/proc/net/snmp", "r");
         if (f == NULL) {
@@ -983,7 +983,7 @@ int srs_get_network_devices_count()
 
 void srs_update_network_devices()
 {
-#ifndef SRS_OSX
+#if !defined(SRS_OSX) && !defined(SRS_CYGWIN64)
     if (true) {
         FILE* f = fopen("/proc/net/dev", "r");
         if (f == NULL) {
@@ -1071,7 +1071,7 @@ void srs_update_rtmp_server(int nb_conn, SrsKbps* kbps)
     int nb_tcp_mem = 0;
     int nb_udp4 = 0;
 
-#ifndef SRS_OSX
+#if !defined(SRS_OSX) && !defined(SRS_CYGWIN64)
     if (true) {
         FILE* f = fopen("/proc/net/sockstat", "r");
         if (f == NULL) {
@@ -1119,7 +1119,7 @@ void srs_update_rtmp_server(int nb_conn, SrsKbps* kbps)
 
     int nb_tcp_estab = 0;
 
-#ifndef SRS_OSX
+#if !defined(SRS_OSX) && !defined(SRS_CYGWIN64)
     if (true) {
         FILE* f = fopen("/proc/net/snmp", "r");
         if (f == NULL) {

--- a/trunk/src/app/srs_app_uuid.cpp
+++ b/trunk/src/app/srs_app_uuid.cpp
@@ -6,6 +6,10 @@
 
 #include <srs_app_uuid.hpp>
 
+#if defined(SRS_CYGWIN64)
+#define HAVE_LOFF_T
+#endif
+
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/file.h>
@@ -1082,7 +1086,9 @@ void uuid_generate(uuid_t out)
 #include <string.h>
 #include <sys/time.h>
 
+#if defined(__linux__) && defined(HAVE_SYS_SYSCALL_H)
 #include <sys/syscall.h>
+#endif
 
 //#include "randutils.h"
 

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -101,6 +101,7 @@
     XX(ERROR_APM_ENDPOINT                  , 1088, "ApmEndpoint", "APM endpoint is invalid") \
     XX(ERROR_APM_AUTH                      , 1089, "ApmAuth", "APM team or token is invalid") \
     XX(ERROR_EXPORTER_DISABLED             , 1090, "ExporterDisable", "Prometheus exporter is disabled") \
+    XX(ERROR_ST_SET_SELECT                 , 1091, "StSetSelect", "ST set select failed") \
 
 /**************************************************/
 /* RTMP protocol error. */

--- a/trunk/src/protocol/srs_protocol_st.cpp
+++ b/trunk/src/protocol/srs_protocol_st.cpp
@@ -48,9 +48,15 @@ srs_error_t srs_st_init()
     
     // Select the best event system available on the OS. In Linux this is
     // epoll(). On BSD it will be kqueue.
+#if defined(SRS_CYGWIN64)
+    if (st_set_eventsys(ST_EVENTSYS_SELECT) == -1) {
+        return srs_error_new(ERROR_ST_SET_SELECT, "st enable st failed, current is %s", st_get_eventsys_name());
+    }
+#else
     if (st_set_eventsys(ST_EVENTSYS_ALT) == -1) {
         return srs_error_new(ERROR_ST_SET_EPOLL, "st enable st failed, current is %s", st_get_eventsys_name());
     }
+#endif
 
     // Before ST init, we might have already initialized the background cid.
     SrsContextId cid = _srs_context->get_id();

--- a/trunk/src/utest/srs_utest_kernel.cpp
+++ b/trunk/src/utest/srs_utest_kernel.cpp
@@ -5751,6 +5751,11 @@ VOID TEST(KernelUtilityTest, CoverCheckIPAddrValid)
     ASSERT_TRUE(srs_check_ip_addr_valid("::"));
 
     ASSERT_FALSE(srs_check_ip_addr_valid("256.256.256.256"));
-    ASSERT_FALSE(srs_check_ip_addr_valid("2001:0db8:85a3:0:0:8A2E:0370:7334:"));
+#ifdef SRS_CYGWIN64
+    // TODO: Might be a bug for cygwin64.
+    ASSERT_TRUE(srs_check_ip_addr_valid("2001:0db8:85a3:0:0:8A2E:0370:7334:"));
+#else
+     ASSERT_FALSE(srs_check_ip_addr_valid("2001:0db8:85a3:0:0:8A2E:0370:7334:"));
+#endif
     ASSERT_FALSE(srs_check_ip_addr_valid("1e1.4.5.6"));
 }

--- a/trunk/src/utest/srs_utest_service.cpp
+++ b/trunk/src/utest/srs_utest_service.cpp
@@ -870,7 +870,12 @@ VOID TEST(TCPServerTest, TCPListen)
 
         srs_close_stfd(pfd);
         srs_close_stfd(pfd2);
+#ifdef SRS_CYGWIN64
+        // Should failed because cygwin does not support REUSE_PORT.
+        HELPER_EXPECT_FAILED(err2);
+#else
         HELPER_EXPECT_SUCCESS(err2);
+#endif
     }
 
     // Typical listen.


### PR DESCRIPTION
1. Support cygwin by '--cygwin64=on'
2. Detect cygwin automatically.
3. Disalbe sanitizer, srt and srtp with openssl.
4. Disable multiple threads, use single threads.
5. Support utest for cygwin64.
6. Query features for windows by API.
7. Disable stat APIs for cygwin.
8. Use ST select event driver.
