### PR TITLE
Windows: Refine cygwin pipeline

### DIFF
--- a/trunk/configure
+++ b/trunk/configure
@@ -525,7 +525,7 @@ help:
 	@echo "     make help"
 
 doclean:
-	(cd ${SRS_OBJS} && rm -rf srs srs_utest $__mcleanups)
+	(cd ${SRS_OBJS} && rm -rf srs srs_utest srs.exe srs_utest.exe $__mcleanups)
 	(cd ${SRS_OBJS} && rm -rf src/* include lib)
 	(mkdir -p ${SRS_OBJS}/utest && cd ${SRS_OBJS}/utest && rm -rf *.o *.a)
 

--- a/trunk/packaging/nsis/srs.nsi
+++ b/trunk/packaging/nsis/srs.nsi
@@ -2,8 +2,7 @@
 ; See https://nsis.sourceforge.io/Download
 ;       "C:\Program Files (x86)\NSIS\makensis.exe" /DSRS_VERSION=5.0.89 /DCYGWIN_DIR="C:\tools\cygwin" srs.nsi
 ;       "/cygdrive/c/Program Files (x86)/NSIS/makensis.exe" /DSRS_VERSION=5.0.89 /DCYGWIN_DIR="C:\cygwin64" srs.nsi
-;       "/cygdrive/c/Program Files (x86)/NSIS/makensis.exe" /DSRS_VERSION=$(../../objs/srs -v 2>&1) /DCYGWIN_DIR="C:\cygwin64" srs.nsi
-;       "/cygdrive/c/Program Files (x86)/NSIS/makensis.exe" /DSRS_VERSION=$(./objs/srs -v 2>&1) /DCYGWIN_DIR="C:\cygwin64" packaging/nsis/srs.nsi
+;       "/cygdrive/c/Program Files (x86)/NSIS/makensis.exe" /DSRS_VERSION=$(./objs/srs.exe -v 2>&1) /DCYGWIN_DIR="C:\cygwin64" packaging/nsis/srs.nsi
 
 ; HM NIS Edit Wizard helper defines
 !define PRODUCT_NAME "SRS"


### PR DESCRIPTION
1. When cleanup, remove srs.exe
2. Refine NSIS command.
