### PR TITLE
H265: Support HEVC over RTMP or HTTP-FLV. v6.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
           which make gcc g++ patch cmake pkg-config uname grep sed &&
           (make --version; gcc --version; patch --version; cmake --version; pkg-config --version) && 
           (aclocal --version; autoconf --version; automake --version; uname -a) &&
-          cd $(cygpath -u $SRS_WORKSPACE)/trunk && ./configure && make
+          cd $(cygpath -u $SRS_WORKSPACE)/trunk && ./configure --gb28181=on --h265=on && make
       ##################################################################################################################
       - name: Package SRS
         env:

--- a/trunk/Dockerfile
+++ b/trunk/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /srs/trunk
 
 # Build and install SRS.
 # Note that SRT is enabled by default, so we configure without --srt=on.
-RUN ./configure --gb28181=on  --sanitizer-static=on && make && make install
+RUN ./configure --gb28181=on --h265=on --sanitizer-static=on && make && make install
 
 # All config files for SRS.
 RUN cp -R conf /usr/local/srs/conf && \

--- a/trunk/Dockerfile.builds
+++ b/trunk/Dockerfile.builds
@@ -13,7 +13,7 @@ RUN cd /srs/trunk && ./configure --srt=off --gb28181=off --nasm=off --srtp-nasm=
 
 FROM ossrs/srs:dev-cache AS centos7-all
 COPY . /srs
-RUN cd /srs/trunk && ./configure --srt=on --gb28181=on && make
+RUN cd /srs/trunk && ./configure --srt=on --gb28181=on --h265=on && make
 
 FROM ossrs/srs:dev-cache AS centos7-ansi-no-ffmpeg
 COPY . /srs
@@ -26,7 +26,7 @@ RUN cd /srs/trunk && ./configure --srt=off --gb28181=off --cxx11=off --cxx14=off
 
 FROM ossrs/srs:dev6-cache AS centos6-all
 COPY . /srs
-RUN cd /srs/trunk && ./configure --srt=on --gb28181=on --cxx11=off --cxx14=off --sanitizer=off && make
+RUN cd /srs/trunk && ./configure --srt=on --gb28181=on --h265=on --cxx11=off --cxx14=off --sanitizer=off && make
 
 ########################################################
 FROM ossrs/srs:ubuntu16-cache AS ubuntu16-baseline
@@ -35,7 +35,7 @@ RUN cd /srs/trunk && ./configure --srt=off --gb28181=off && make
 
 FROM ossrs/srs:ubuntu16-cache AS ubuntu16-all
 COPY . /srs
-RUN cd /srs/trunk && ./configure --srt=on --gb28181=on && make
+RUN cd /srs/trunk && ./configure --srt=on --gb28181=on --h265=on && make
 
 ########################################################
 FROM ossrs/srs:ubuntu18-cache AS ubuntu18-baseline
@@ -44,7 +44,7 @@ RUN cd /srs/trunk && ./configure --srt=off --gb28181=off && make
 
 FROM ossrs/srs:ubuntu18-cache AS ubuntu18-all
 COPY . /srs
-RUN cd /srs/trunk && ./configure --srt=on --gb28181=on && make
+RUN cd /srs/trunk && ./configure --srt=on --gb28181=on --h265=on && make
 
 ########################################################
 FROM ossrs/srs:ubuntu20-cache AS ubuntu20-baseline
@@ -53,7 +53,7 @@ RUN cd /srs/trunk && ./configure --srt=off --gb28181=off && make
 
 FROM ossrs/srs:ubuntu20-cache AS ubuntu20-all
 COPY . /srs
-RUN cd /srs/trunk && ./configure --srt=on --gb28181=on && make
+RUN cd /srs/trunk && ./configure --srt=on --gb28181=on --h265=on && make
 
 ########################################################
 FROM ossrs/srs:ubuntu16-cross-arm AS ubuntu16-cross-armv7

--- a/trunk/Dockerfile.cov
+++ b/trunk/Dockerfile.cov
@@ -8,5 +8,5 @@ COPY . /srs
 WORKDIR /srs/trunk
 
 # Note that we must enable the gcc7 or link failed.
-RUN scl enable devtoolset-7 -- ./configure --srt=on --gb28181=on --utest=on --gcov=on --sanitizer=off
+RUN scl enable devtoolset-7 -- ./configure --srt=on --gb28181=on --h265=on --utest=on --gcov=on --sanitizer=off
 RUN scl enable devtoolset-7 -- make utest

--- a/trunk/Dockerfile.pkg
+++ b/trunk/Dockerfile.pkg
@@ -10,5 +10,5 @@ RUN yum install -y zip
 # Build and install SRS.
 ADD srs-server-${version}.tar.gz /srs
 WORKDIR /srs/srs-server-${version}/trunk
-RUN ./scripts/package.sh --x86-x64 --tag=${version}
+RUN ./scripts/package.sh --x86-x64 --gb28181=on --h265=on --tag=${version}
 

--- a/trunk/Dockerfile.test
+++ b/trunk/Dockerfile.test
@@ -6,7 +6,7 @@ COPY . /srs
 WORKDIR /srs/trunk
 
 # Note that we must enable the gcc7 or link failed.
-RUN scl enable devtoolset-7 -- ./configure --srt=on --gb28181=on --utest=on
+RUN scl enable devtoolset-7 -- ./configure --srt=on --gb28181=on --h265=on --utest=on
 RUN scl enable devtoolset-7 -- make utest
 
 # Build benchmark tool.

--- a/trunk/auto/auto_headers.sh
+++ b/trunk/auto/auto_headers.sh
@@ -86,6 +86,12 @@ else
     srs_undefine_macro "SRS_FFMPEG_FIT" $SRS_AUTO_HEADERS_H
 fi
 
+if [[ $SRS_H265 == YES ]]; then
+    srs_define_macro "SRS_H265" $SRS_AUTO_HEADERS_H
+else
+    srs_undefine_macro "SRS_H265" $SRS_AUTO_HEADERS_H
+fi
+
 if [[ $SRS_SIMULATOR == YES ]]; then
     srs_define_macro "SRS_SIMULATOR" $SRS_AUTO_HEADERS_H
 else

--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -6,6 +6,7 @@ help=no
 SRS_HDS=NO
 SRS_SRT=YES
 SRS_RTC=YES
+SRS_H265=NO
 SRS_GB28181=NO
 SRS_CXX11=YES
 SRS_CXX14=NO
@@ -136,6 +137,7 @@ Features:
   --cxx14=on|off            Whether enable the C++14. Default: $(value2switch $SRS_CXX14)
   --backtrace=on|off        Whether show backtrace when crashing. Default: $(value2switch $SRS_BACKTRACE)
   --ffmpeg-fit=on|off       Whether enable the FFmpeg fit(source code). Default: $(value2switch $SRS_FFMPEG_FIT)
+  --h265=on|off             Whether build the HEVC(H.265) support. Default: $(value2switch $SRS_H265)
 
   --prefix=<path>           The absolute installation path. Default: $SRS_PREFIX
   --config=<path>           The default config file for SRS. Default: $SRS_DEFAULT_CONFIG
@@ -305,6 +307,7 @@ function parse_user_option() {
         --generate-objs)                SRS_GENERATE_OBJS=$(switch2value $value) ;;
         --single-thread)                SRS_SINGLE_THREAD=$(switch2value $value) ;;
         --ffmpeg-fit)                   SRS_FFMPEG_FIT=$(switch2value $value) ;;
+        --h265)                         SRS_H265=$(switch2value $value) ;;
         --gb28181)                      SRS_GB28181=$(switch2value $value) ;;
 
         --cxx11)                        SRS_CXX11=$(switch2value $value) ;;
@@ -587,6 +590,7 @@ function regenerate_options() {
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --cherrypy=$(value2switch $SRS_CHERRYPY)"
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --srt=$(value2switch $SRS_SRT)"
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --rtc=$(value2switch $SRS_RTC)"
+    SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --h265=$(value2switch $SRS_H265)"
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --gb28181=$(value2switch $SRS_GB28181)"
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --simulator=$(value2switch $SRS_SIMULATOR)"
     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --cxx11=$(value2switch $SRS_CXX11)"

--- a/trunk/conf/hevc.flv.conf
+++ b/trunk/conf/hevc.flv.conf
@@ -1,0 +1,18 @@
+listen              1935;
+max_connections     1000;
+daemon              off;
+srs_log_tank        console;
+http_api {
+    enabled         on;
+    listen          1985;
+}
+http_server {
+    enabled         on;
+    listen          8080;
+}
+vhost __defaultVhost__ {
+    http_remux {
+        enabled     on;
+        mount       [vhost]/[app]/[stream].flv;
+    }
+}

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,7 +8,8 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
-* v5.0, 2022-11-22, Merge [#3268](https://github.com/ossrs/srs/pull/3268): H265: Update mpegts.js to play HEVC over HTTP-TS/FLV. v6.0.1
+* v6.0, 2022-11-22, Merge [#3272](https://github.com/ossrs/srs/pull/3272): H265: Support HEVC over RTMP or HTTP-FLV. v6.0.2
+* v6.0, 2022-11-22, Merge [#3268](https://github.com/ossrs/srs/pull/3268): H265: Update mpegts.js to play HEVC over HTTP-TS/FLV. v6.0.1
 * v6.0, 2022-11-22, Init SRS 6. v6.0.0
 
 <a name="v5-changes"></a>

--- a/trunk/ide/srs_clion/CMakeLists.txt
+++ b/trunk/ide/srs_clion/CMakeLists.txt
@@ -27,7 +27,7 @@ ProcessorCount(JOBS)
 # We should always configure SRS for switching between branches.
 IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     EXECUTE_PROCESS(
-        COMMAND ./configure --osx --srt=on --gb28181=on --utest=on --jobs=${JOBS}
+        COMMAND ./configure --osx --srt=on --gb28181=on --h265=on --utest=on --jobs=${JOBS}
         WORKING_DIRECTORY ${SRS_DIR} RESULT_VARIABLE ret)
 ELSE ()
     EXECUTE_PROCESS(

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -621,11 +621,13 @@ srs_error_t SrsGopCache::cache(SrsSharedPtrMessage* shared_msg)
     
     // got video, update the video count if acceptable
     if (msg->is_video()) {
-        // drop video when not h.264
-        if (!SrsFlvVideo::h264(msg->payload, msg->size)) {
-            return err;
-        }
-        
+        // Drop video when not h.264 or h.265.
+        bool codec_ok = SrsFlvVideo::h264(msg->payload, msg->size);
+#ifdef SRS_H265
+        codec_ok = codec_ok ? : SrsFlvVideo::hevc(msg->payload, msg->size);
+#endif
+        if (!codec_ok) return err;
+
         cached_video_count++;
         audio_after_last_video_count = 0;
     }
@@ -1063,14 +1065,22 @@ srs_error_t SrsOriginHub::on_video(SrsSharedPtrMessage* shared_video, bool is_se
         
         // when got video stream info.
         SrsStatistic* stat = SrsStatistic::instance();
-        if ((err = stat->on_video_info(req_, SrsVideoCodecIdAVC, c->avc_profile, c->avc_level, c->width, c->height)) != srs_success) {
+
+        if (c->id == SrsVideoCodecIdAVC) {
+            err = stat->on_video_info(req_, c->id, c->avc_profile, c->avc_level, c->width, c->height);
+            srs_trace("%dB video sh, codec(%d, profile=%s, level=%s, %dx%d, %dkbps, %.1ffps, %.1fs)",
+                msg->size, c->id, srs_avc_profile2str(c->avc_profile).c_str(), srs_avc_level2str(c->avc_level).c_str(),
+                c->width, c->height, c->video_data_rate / 1000, c->frame_rate, c->duration);
+#ifdef SRS_H265
+        } else if (c->id == SrsVideoCodecIdHEVC) {
+            // TODO: FIXME: Use the correct information for HEVC.
+            err = stat->on_video_info(req_, c->id, c->avc_profile, c->avc_level, c->width, c->height);
+            srs_trace("%dB video sh, codec(%d)", msg->size, c->id);
+#endif
+        }
+        if (err != srs_success) {
             return srs_error_wrap(err, "stat video");
         }
-        
-        srs_trace("%dB video sh,  codec(%d, profile=%s, level=%s, %dx%d, %dkbps, %.1ffps, %.1fs)",
-                  msg->size, c->id, srs_avc_profile2str(c->avc_profile).c_str(),
-                  srs_avc_level2str(c->avc_level).c_str(), c->width, c->height,
-                  c->video_data_rate / 1000, c->frame_rate, c->duration);
     }
 
     // Ignore video data when no sps/pps

--- a/trunk/src/app/srs_app_statistic.cpp
+++ b/trunk/src/app/srs_app_statistic.cpp
@@ -622,6 +622,17 @@ void SrsStatistic::dumps_hints_kv(std::stringstream & ss)
     if (kbps->get_send_kbps_30s()) {
         ss << "&send=" << kbps->get_send_kbps_30s();
     }
+
+#ifdef SRS_H265
+    // For HEVC, we should check active stream which is HEVC codec.
+    for (std::map<std::string, SrsStatisticStream*>::iterator it = streams.begin(); it != streams.end(); it++) {
+        SrsStatisticStream* stream = it->second;
+        if (stream->vcodec == SrsVideoCodecIdHEVC) {
+            ss << "&h265=1";
+            break;
+        }
+    }
+#endif
 }
 
 void SrsStatistic::dumps_cls_summaries(SrsClsSugar* sugar)

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    1
+#define VERSION_REVISION    2
 
 #endif

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -25,6 +25,7 @@ class SrsBuffer;
  *      5 = On2 VP6 with alpha channel
  *      6 = Screen video version 2
  *      7 = AVC
+ *     12 = HEVC
  */
 enum SrsVideoCodecId
 {
@@ -258,6 +259,10 @@ public:
      * check codec h264.
      */
     static bool h264(char* data, int size);
+#ifdef SRS_H265
+    // Check whether codec is HEVC(H.265).
+    static bool hevc(char* data, int size);
+#endif
     /**
      * check the video RTMP/flv header info,
      * @return true if video RTMP/flv header is ok.
@@ -393,6 +398,110 @@ enum SrsAvcNaluType
     SrsAvcNaluTypeCodedSliceExt = 20,
 };
 std::string srs_avc_nalu2str(SrsAvcNaluType nalu_type);
+
+#ifdef SRS_H265
+// The enum NALU type for HEVC.
+enum SrsHevcNaluType {
+    SrsHevcNaluType_CODED_SLICE_TRAIL_N =       0,
+    SrsHevcNaluType_CODED_SLICE_TRAIL_R, //1
+    SrsHevcNaluType_CODED_SLICE_TSA_N,   //2
+    SrsHevcNaluType_CODED_SLICE_TLA,     //3
+    SrsHevcNaluType_CODED_SLICE_STSA_N,  //4
+    SrsHevcNaluType_CODED_SLICE_STSA_R,  //5
+    SrsHevcNaluType_CODED_SLICE_RADL_N,  //6
+    SrsHevcNaluType_CODED_SLICE_DLP,     //7
+    SrsHevcNaluType_CODED_SLICE_RASL_N,  //8
+    SrsHevcNaluType_CODED_SLICE_TFD,     //9
+    SrsHevcNaluType_RESERVED_10,
+    SrsHevcNaluType_RESERVED_11,
+    SrsHevcNaluType_RESERVED_12,
+    SrsHevcNaluType_RESERVED_13,
+    SrsHevcNaluType_RESERVED_14,
+    SrsHevcNaluType_RESERVED_15,
+    SrsHevcNaluType_CODED_SLICE_BLA,      //16
+    SrsHevcNaluType_CODED_SLICE_BLANT,    //17
+    SrsHevcNaluType_CODED_SLICE_BLA_N_LP, //18
+    SrsHevcNaluType_CODED_SLICE_IDR,      //19
+    SrsHevcNaluType_CODED_SLICE_IDR_N_LP, //20
+    SrsHevcNaluType_CODED_SLICE_CRA,      //21
+    SrsHevcNaluType_RESERVED_22,
+    SrsHevcNaluType_RESERVED_23,
+    SrsHevcNaluType_RESERVED_24,
+    SrsHevcNaluType_RESERVED_25,
+    SrsHevcNaluType_RESERVED_26,
+    SrsHevcNaluType_RESERVED_27,
+    SrsHevcNaluType_RESERVED_28,
+    SrsHevcNaluType_RESERVED_29,
+    SrsHevcNaluType_RESERVED_30,
+    SrsHevcNaluType_RESERVED_31,
+    SrsHevcNaluType_VPS,                   // 32
+    SrsHevcNaluType_SPS,                   // 33
+    SrsHevcNaluType_PPS,                   // 34
+    SrsHevcNaluType_ACCESS_UNIT_DELIMITER, // 35
+    SrsHevcNaluType_EOS,                   // 36
+    SrsHevcNaluType_EOB,                   // 37
+    SrsHevcNaluType_FILLER_DATA,           // 38
+    SrsHevcNaluType_SEI ,                  // 39 Prefix SEI
+    SrsHevcNaluType_SEI_SUFFIX,            // 40 Suffix SEI
+    SrsHevcNaluType_RESERVED_41,
+    SrsHevcNaluType_RESERVED_42,
+    SrsHevcNaluType_RESERVED_43,
+    SrsHevcNaluType_RESERVED_44,
+    SrsHevcNaluType_RESERVED_45,
+    SrsHevcNaluType_RESERVED_46,
+    SrsHevcNaluType_RESERVED_47,
+    SrsHevcNaluType_UNSPECIFIED_48,
+    SrsHevcNaluType_UNSPECIFIED_49,
+    SrsHevcNaluType_UNSPECIFIED_50,
+    SrsHevcNaluType_UNSPECIFIED_51,
+    SrsHevcNaluType_UNSPECIFIED_52,
+    SrsHevcNaluType_UNSPECIFIED_53,
+    SrsHevcNaluType_UNSPECIFIED_54,
+    SrsHevcNaluType_UNSPECIFIED_55,
+    SrsHevcNaluType_UNSPECIFIED_56,
+    SrsHevcNaluType_UNSPECIFIED_57,
+    SrsHevcNaluType_UNSPECIFIED_58,
+    SrsHevcNaluType_UNSPECIFIED_59,
+    SrsHevcNaluType_UNSPECIFIED_60,
+    SrsHevcNaluType_UNSPECIFIED_61,
+    SrsHevcNaluType_UNSPECIFIED_62,
+    SrsHevcNaluType_UNSPECIFIED_63,
+    SrsHevcNaluType_INVALID,
+};
+
+struct SrsHevcNalData {
+    uint16_t nal_unit_length;
+    std::vector<uint8_t> nal_unit_data;
+};
+
+struct SrsHevcHvccNalu {
+    uint8_t array_completeness;
+    uint8_t nal_unit_type;
+    uint16_t num_nalus;
+    std::vector<SrsHevcNalData> nal_data_vec;
+};
+
+struct SrsHevcDecoderConfigurationRecord {
+    uint8_t  configuration_version;
+    uint8_t  general_profile_space;
+    uint8_t  general_tier_flag;
+    uint8_t  general_profile_idc;
+    uint32_t general_profile_compatibility_flags;
+    uint64_t general_constraint_indicator_flags;
+    uint8_t  general_level_idc;
+    uint16_t min_spatial_segmentation_idc;
+    uint8_t  parallelism_type;
+    uint8_t  chroma_format;
+    uint8_t  bit_depth_luma_minus8;
+    uint8_t  bit_depth_chroma_minus8;
+    uint16_t avg_frame_rate;
+    uint8_t  constant_frame_rate;
+    uint8_t  num_temporal_layers;
+    uint8_t  temporal_id_nested;
+    uint8_t  length_size_minus_one;
+    std::vector<SrsHevcHvccNalu> nalu_vec;
+};
+#endif
 
 /**
  * Table 7-6 – Name association to slice_type
@@ -639,6 +748,10 @@ public:
 public:
     // the avc payload format.
     SrsAvcPayloadFormat payload_format;
+#ifdef SRS_H265
+public:
+    SrsHevcDecoderConfigurationRecord hevc_dec_conf_record_;
+#endif
 public:
     SrsVideoCodecConfig();
     virtual ~SrsVideoCodecConfig();
@@ -757,13 +870,18 @@ private:
     //          Demux the sps/pps from sequence header.
     //          Demux the samples from NALUs.
     virtual srs_error_t video_avc_demux(SrsBuffer* stream, int64_t timestamp);
+#ifdef SRS_H265
+private:
+    virtual srs_error_t hevc_demux_hvcc(SrsBuffer* stream);
+    virtual srs_error_t hevc_demux_ibmf_format(SrsBuffer* stream);
+#endif
 private:
     // Parse the H.264 SPS/PPS.
     virtual srs_error_t avc_demux_sps_pps(SrsBuffer* stream);
     virtual srs_error_t avc_demux_sps();
     virtual srs_error_t avc_demux_sps_rbsp(char* rbsp, int nb_rbsp);
 private:
-    // Parse the H.264 NALUs.
+    // Parse the H.264 or H.265 NALUs.
     virtual srs_error_t video_nalu_demux(SrsBuffer* stream);
     // Demux the avc NALU in "AnnexB" from ISO_IEC_14496-10-AVC-2003.pdf, page 211.
     virtual srs_error_t avc_demux_annexb_format(SrsBuffer* stream);

--- a/trunk/src/utest/srs_utest_kernel.cpp
+++ b/trunk/src/utest/srs_utest_kernel.cpp
@@ -3327,7 +3327,9 @@ VOID TEST(KernelCodecTest, CoverAll)
         EXPECT_TRUE(!v.acceptable((char*)"\xf0", 1));
         EXPECT_TRUE(!v.acceptable((char*)"\x10", 1));
         EXPECT_TRUE(!v.acceptable((char*)"\x1f", 1));
-        EXPECT_TRUE(v.acceptable((char*)"\x13", 1));
+        EXPECT_TRUE(v.acceptable((char*)"\x17", 1)); // AVC = 7
+        EXPECT_TRUE(v.acceptable((char*)"\x1c", 1)); // HEVC = 12
+        EXPECT_TRUE(v.acceptable((char*)"\x1d", 1)); // AV1 = 13
     }
     
     if (true) {


### PR DESCRIPTION
1. Support configure with --h265=on.
2. Parse HEVC(H.265) from FLV or RTMP packet.
3. Support HEVC over RTMP or HTTP-FLV.
