### PR TITLE
H265: Support HEVC over HTTP-TS. v6.0.4

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2022-11-23, Merge [#3275](https://github.com/ossrs/srs/pull/3275): H265: Support HEVC over HTTP-TS. v6.0.4
 * v6.0, 2022-11-23, Merge [#3274](https://github.com/ossrs/srs/pull/3274): H265: Support parse multiple NALUs in a frame. v6.0.3
 * v6.0, 2022-11-22, Merge [#3272](https://github.com/ossrs/srs/pull/3272): H265: Support HEVC over RTMP or HTTP-FLV. v6.0.2
 * v6.0, 2022-11-22, Merge [#3268](https://github.com/ossrs/srs/pull/3268): H265: Update mpegts.js to play HEVC over HTTP-TS/FLV. v6.0.1

--- a/trunk/src/app/srs_app_hls.hpp
+++ b/trunk/src/app/srs_app_hls.hpp
@@ -193,7 +193,7 @@ public:
     // Whether current hls muxer is pure audio mode.
     virtual bool pure_audio();
     virtual srs_error_t flush_audio(SrsTsMessageCache* cache);
-    virtual srs_error_t flush_video(SrsTsMessageCache* cache);
+    virtual srs_error_t flush_video(SrsTsMessageCache* cache, SrsVideoFrame* frame);
     // Close segment(ts).
     virtual srs_error_t segment_close();
 private:

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    3
+#define VERSION_REVISION    4
 
 #endif

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -468,6 +468,7 @@ enum SrsHevcNaluType {
     SrsHevcNaluType_UNSPECIFIED_63,
     SrsHevcNaluType_INVALID,
 };
+#define SrsHevcNaluTypeParse(code) (SrsHevcNaluType)((code & 0x7E) >> 1)
 
 struct SrsHevcNalData {
     uint16_t nal_unit_length;

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -266,7 +266,8 @@
     XX(ERROR_INOTIFY_OPENFD                , 3094, "InotifyOpenFd", "Failed to open inotify fd for config listener") \
     XX(ERROR_INOTIFY_WATCH                 , 3095, "InotfyWatch", "Failed to watch inotify for config listener") \
     XX(ERROR_HTTP_URL_UNESCAPE             , 3096, "HttpUrlUnescape", "Failed to unescape URL for HTTP") \
-    XX(ERROR_HTTP_WITH_BODY                , 3097, "HttpWithBody", "Failed for HTTP body")
+    XX(ERROR_HTTP_WITH_BODY                , 3097, "HttpWithBody", "Failed for HTTP body") \
+    XX(ERROR_HEVC_DISABLED                 , 3098, "HevcDisabled", "HEVC is disabled")
 
 /**************************************************/
 /* HTTP/StreamConverter protocol error. */

--- a/trunk/src/kernel/srs_kernel_ts.hpp
+++ b/trunk/src/kernel/srs_kernel_ts.hpp
@@ -131,6 +131,10 @@ enum SrsTsStream
     // ITU-T Rec. H.222.0 | ISO/IEC 13818-1 Reserved
     // 0x15-0x7F
     SrsTsStreamVideoH264 = 0x1b,
+#ifdef SRS_H265
+    // For HEVC(H.265).
+    SrsTsStreamVideoHEVC = 0x24,
+#endif
     // User Private
     // 0x80-0xFF
     SrsTsStreamAudioAC3 = 0x81,
@@ -1272,8 +1276,9 @@ public:
     // Write a video frame to ts,
     virtual srs_error_t write_video(SrsTsMessage* video);
 public:
-    // get the video codec of ts muxer.
+    // Get or update the video codec of ts muxer.
     virtual SrsVideoCodecId video_codec();
+    virtual void update_video_codec(SrsVideoCodecId v);
 };
 
 // Used for HLS Encryption
@@ -1315,6 +1320,9 @@ private:
     virtual srs_error_t do_cache_mp3(SrsAudioFrame* frame);
     virtual srs_error_t do_cache_aac(SrsAudioFrame* frame);
     virtual srs_error_t do_cache_avc(SrsVideoFrame* frame);
+#ifdef SRS_H265
+    virtual srs_error_t do_cache_hevc(SrsVideoFrame* frame);
+#endif
 };
 
 // Transmux the RTMP stream to HTTP-TS stream.

--- a/trunk/src/utest/srs_utest_kernel.cpp
+++ b/trunk/src/utest/srs_utest_kernel.cpp
@@ -4921,9 +4921,6 @@ VOID TEST(KernelTSTest, CoverContextEncode)
         
         srs_error_t err = ctx.encode(&f, &m, SrsVideoCodecIdDisabled, SrsAudioCodecIdDisabled);
         HELPER_EXPECT_FAILED(err);
-        
-        err = ctx.encode(&f, &m, SrsVideoCodecIdHEVC, SrsAudioCodecIdOpus);
-        HELPER_EXPECT_FAILED(err);
 
         err = ctx.encode(&f, &m, SrsVideoCodecIdAV1, SrsAudioCodecIdOpus);
         HELPER_EXPECT_FAILED(err);
@@ -4951,6 +4948,34 @@ VOID TEST(KernelTSTest, CoverContextEncode)
         m.payload->append("Hello, world!", 13);
         HELPER_EXPECT_SUCCESS(ctx.encode(&f, &m, SrsVideoCodecIdAVC, SrsAudioCodecIdAAC));
     }
+}
+
+VOID TEST(KernelTSTest, CoverContextEncodeHEVC)
+{
+    srs_error_t err;
+
+    SrsTsContext ctx;
+    MockTsHandler h;
+
+#ifndef SRS_H265
+    if (true) {
+        MockSrsFileWriter f;
+        SrsTsMessage m;
+
+        err = ctx.encode(&f, &m, SrsVideoCodecIdHEVC, SrsAudioCodecIdOpus);
+        HELPER_EXPECT_FAILED(err);
+    }
+#endif
+
+#ifdef SRS_H265
+    if (true) {
+        MockSrsFileWriter f;
+        SrsTsMessage m;
+
+        err = ctx.encode(&f, &m, SrsVideoCodecIdHEVC, SrsAudioCodecIdOpus);
+        HELPER_EXPECT_SUCCESS(err);
+    }
+#endif
 }
 
 VOID TEST(KernelTSTest, CoverContextDecode)


### PR DESCRIPTION
1. Update TS video codec to HEVC during streaming.
2. Return error when HEVC is disabled.
3. Parse HEVC NALU type by SrsHevcNaluTypeParse.
4. Show message when codec change for TS.
