### PR TITLE
For #3176: GB28181: Error and logging for HEVC. v5.0.95

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-11-23, For [#3176](https://github.com/ossrs/srs/pull/3176): GB28181: Error and logging for HEVC. v5.0.95
 * v5.0, 2022-11-22, Merge [#3236](https://github.com/ossrs/srs/pull/3236): Live: Limit cached max frames by gop_cache_max_frames. v5.0.93
 * v5.0, 2022-11-22, Asan: Check libasan and show tips. v5.0.92
 * v5.0, 2022-11-21, Merge [#3264](https://github.com/ossrs/srs/pull/3264): Asan: Try to fix st_memory_leak for asan check. (#3264). v5.0.91

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    94
+#define VERSION_REVISION    95
 
 #endif

--- a/trunk/src/kernel/srs_kernel_ps.hpp
+++ b/trunk/src/kernel/srs_kernel_ps.hpp
@@ -67,6 +67,10 @@ private:
     // Whether detect PS packet header integrity.
     bool detect_ps_integrity_;
 public:
+    // The stream type parsed from latest PSM packet.
+    SrsTsStream video_stream_type_;
+    SrsTsStream audio_stream_type_;
+public:
     SrsPsContext();
     virtual ~SrsPsContext();
 public:

--- a/trunk/src/kernel/srs_kernel_ts.hpp
+++ b/trunk/src/kernel/srs_kernel_ts.hpp
@@ -131,6 +131,7 @@ enum SrsTsStream
     // ITU-T Rec. H.222.0 | ISO/IEC 13818-1 Reserved
     // 0x15-0x7F
     SrsTsStreamVideoH264 = 0x1b,
+    SrsTsStreamVideoHEVC = 0x24,
     // User Private
     // 0x80-0xFF
     SrsTsStreamAudioAC3 = 0x81,


### PR DESCRIPTION
1. Parse video codec from PSM packet.
2. Return error and logging if HEVC packet.
3. Ignore invalid AVC NALUs, drop AVC AUD and SEI.
4. Disconnect TCP connection if HEVC.