### PR TITLE
Docker: Remove CentOS 6 support.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,22 +82,6 @@ jobs:
     outputs:
       SRS_BUILD_CENTOS7_DONE: ok
 
-  build-centos6:
-    name: build-centos6
-    runs-on: ubuntu-20.04
-    needs:
-      - utest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      # Build for CentOS 6
-      - name: Build on CentOS6, baseline
-        run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target centos6-baseline .
-      - name: Build on CentOS6, with all features
-        run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target centos6-all .
-    outputs:
-      SRS_BUILD_CENTOS6_DONE: ok
-
   build-ubuntu16:
     name: build-ubuntu16
     runs-on: ubuntu-20.04
@@ -176,7 +160,6 @@ jobs:
     name: build
     needs:
       - build-centos7
-      - build-centos6
       - build-ubuntu16
       - build-ubuntu18
       - build-ubuntu20

--- a/trunk/Dockerfile
+++ b/trunk/Dockerfile
@@ -34,12 +34,6 @@ RUN cp -R conf /usr/local/srs/conf && \
     cp -R research/players /usr/local/srs/objs/nginx/html/ && \
     cp -R 3rdparty/signaling/www/demos /usr/local/srs/objs/nginx/html/
 
-# Copy the shared libraries for FFmpeg.
-RUN mkdir -p /usr/local/shared && \
-    cp $(ldd /usr/local/bin/ffmpeg |grep libxml2 |awk '{print $3}') /usr/local/shared/ && \
-    cp $(ldd /usr/local/bin/ffmpeg |grep libicuuc |awk '{print $3}') /usr/local/shared/ && \
-    cp $(ldd /usr/local/bin/ffmpeg |grep libicudata |awk '{print $3}') /usr/local/shared/
-
 ############################################################
 # dist
 ############################################################
@@ -53,7 +47,6 @@ RUN echo "BUILDPLATFORM: $BUILDPLATFORM, TARGETPLATFORM: $TARGETPLATFORM"
 EXPOSE 1935 1985 8080 8000/udp 10080/udp
 
 # FFMPEG 4.1
-COPY --from=build /usr/local/shared/* /lib/
 COPY --from=build /usr/local/bin/ffmpeg /usr/local/srs/objs/ffmpeg/bin/ffmpeg
 # SRS binary, config files and srs-console.
 COPY --from=build /usr/local/srs /usr/local/srs

--- a/trunk/Dockerfile.builds
+++ b/trunk/Dockerfile.builds
@@ -20,15 +20,6 @@ COPY . /srs
 RUN cd /srs/trunk && ./configure --srt=off --gb28181=off --cxx11=off --cxx14=off --ffmpeg-fit=off && make
 
 ########################################################
-FROM ossrs/srs:dev6-cache AS centos6-baseline
-COPY . /srs
-RUN cd /srs/trunk && ./configure --srt=off --gb28181=off --cxx11=off --cxx14=off --sanitizer=off && make
-
-FROM ossrs/srs:dev6-cache AS centos6-all
-COPY . /srs
-RUN cd /srs/trunk && ./configure --srt=on --gb28181=on --cxx11=off --cxx14=off --sanitizer=off && make
-
-########################################################
 FROM ossrs/srs:ubuntu16-cache AS ubuntu16-baseline
 COPY . /srs
 RUN cd /srs/trunk && ./configure --srt=off --gb28181=off && make


### PR DESCRIPTION
1. Remove CentOS 6 for test and utest.
2. Statically build FFmpeg, no so depends.
