### PR TITLE
Live: Fix bug for gop cache limits. v5.0.99

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-12-01, Live: Fix bug for gop cache limits. v5.0.99
 * v5.0, 2022-11-25, SRT: Support transform tlpkdrop to tlpktdrop. 5.0.98
 * v5.0, 2022-11-25, Config: Add ENV tips for config. 5.0.97
 * v5.0, 2022-11-24, For [#299](https://github.com/ossrs/srs/issues/299), DASH: Fix number mode bug to make it run. 5.0.96

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -1065,6 +1065,11 @@ srs_error_t SrsHttpStreamServer::hijack(ISrsHttpMessage* request, ISrsHttpHandle
     }
     srs_assert(s != NULL);
     
+    bool enabled_cache = _srs_config->get_gop_cache(r->vhost);
+    int gcmf = _srs_config->get_gop_cache_max_frames(r->vhost);
+    s->set_cache(enabled_cache);
+    s->set_gop_cache_max_frames(gcmf);
+
     // create http streaming handler.
     if ((err = http_mount(s, r)) != srs_success) {
         return srs_error_wrap(err, "http mount");

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -659,7 +659,7 @@ srs_error_t SrsGopCache::cache(SrsSharedPtrMessage* shared_msg)
     gop_cache.push_back(msg->copy());
 
     // Clear gop cache if exceed the max frames.
-    if (gop_cache.size() > (size_t)gop_cache_max_frames_) {
+    if (gop_cache_max_frames_ > 0 && gop_cache.size() > (size_t)gop_cache_max_frames_) {
         srs_warn("Gop cache exceed max frames=%d, total=%d, videos=%d, aalvc=%d",
             gop_cache_max_frames_, (int)gop_cache.size(), cached_video_count, audio_after_last_video_count);
         clear();

--- a/trunk/src/app/srs_app_srt_conn.cpp
+++ b/trunk/src/app/srs_app_srt_conn.cpp
@@ -367,6 +367,13 @@ srs_error_t SrsMpegtsSrtConn::acquire_publish()
             return srs_error_wrap(err, "create source");
         }
 
+        srs_assert(live_source != NULL);
+        
+        bool enabled_cache = _srs_config->get_gop_cache(req_->vhost);
+        int gcmf = _srs_config->get_gop_cache_max_frames(req_->vhost);
+        live_source->set_cache(enabled_cache);
+        live_source->set_gop_cache_max_frames(gcmf);
+
         SrsRtmpFromSrtBridge *bridger = new SrsRtmpFromSrtBridge(live_source);
         if ((err = bridger->initialize(req_)) != srs_success) {
             srs_freep(bridger);

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    98
+#define VERSION_REVISION    99
 
 #endif


### PR DESCRIPTION
1. set rtmp gop cache limit while using srt to push stream & bridge to rtmp source.
2. set rtmp gop cache limit while http_stream playing the live stream.