### PR TITLE
SRT: Support SRT to RTMP to WebRTC. v5.0.107

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-12-09, Merge [#3296](https://github.com/ossrs/srs/pull/3296): SRT: Support SRT to RTMP to WebRTC. v5.0.107
 * v5.0, 2022-12-08, Merge [#3295](https://github.com/ossrs/srs/pull/3295): API: Parse fragment of URI. v5.0.106
 * v5.0, 2022-12-04, Cygwin: Enable gb28181 for Windows. v5.0.105
 * v5.0, 2022-12-04, Asan: Set asan loging callback. v5.0.104

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    106
+#define VERSION_REVISION    107
 
 #endif


### PR DESCRIPTION
SRT to RTC conversion, first convert SRT to RTMP, then convert RTMP to RTC.
There is no issue with version 4.0 because in version 4.0, SRT is pushed to 127.0.0.1 using an RTMP client.
However, in version 5.0 after the SRT code is refactored, a manual creation of the RTC from RTMP bridge is required.

Version 6.0 needs to address the complex relationship issues between different sources and bridges (problems with mutual conversion).

---------

`TRANS_BY_GPT3`