### PR TITLE
DASH: fix crash when unpublish

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-12-12, Merge [#3301](https://github.com/ossrs/srs/pull/3301): DASH: Fix dash crash bug when writing file. v5.0.108
 * v5.0, 2022-12-09, Merge [#3296](https://github.com/ossrs/srs/pull/3296): SRT: Support SRT to RTMP to WebRTC. v5.0.107
 * v5.0, 2022-12-08, Merge [#3295](https://github.com/ossrs/srs/pull/3295): API: Parse fragment of URI. v5.0.106
 * v5.0, 2022-12-04, Cygwin: Enable gb28181 for Windows. v5.0.105

--- a/trunk/src/app/srs_app_dash.cpp
+++ b/trunk/src/app/srs_app_dash.cpp
@@ -458,7 +458,7 @@ void SrsDashController::on_unpublish()
         srs_freep(err);
     }
 
-    if (acurrent->duration() > 0) {
+    if (acurrent && acurrent->duration() > 0) {
         afragments->append(acurrent);
         acurrent = NULL;
     }

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    107
+#define VERSION_REVISION    108
 
 #endif


### PR DESCRIPTION
The problem I encountered was that after pushing several video packages, ffmpeg reported an error and exited, and dash coredumped.

Fix the problem here.

---------

`TRANS_BY_GPT3`