### PR TITLE
Build: Fix build warnings

### DIFF
--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -624,7 +624,7 @@ srs_error_t SrsGopCache::cache(SrsSharedPtrMessage* shared_msg)
         // Drop video when not h.264 or h.265.
         bool codec_ok = SrsFlvVideo::h264(msg->payload, msg->size);
 #ifdef SRS_H265
-        codec_ok = codec_ok ? : SrsFlvVideo::hevc(msg->payload, msg->size);
+        codec_ok = codec_ok ? true : SrsFlvVideo::hevc(msg->payload, msg->size);
 #endif
         if (!codec_ok) return err;
 

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -165,7 +165,7 @@ bool SrsFlvVideo::sh(char* data, int size)
     // Check sequence header only for H.264 or H.265
     bool codec_ok = h264(data, size);
 #ifdef SRS_H265
-    codec_ok = codec_ok? : hevc(data, size);
+    codec_ok = codec_ok? true : hevc(data, size);
 #endif
     if (!codec_ok) return false;
 
@@ -778,7 +778,7 @@ srs_error_t SrsFormat::on_video(int64_t timestamp, char* data, int size)
     // Check codec for H.264 and H.265.
     bool codec_ok = (codec_id == SrsVideoCodecIdAVC);
 #ifdef SRS_H265
-    codec_ok = codec_ok ? : (codec_id == SrsVideoCodecIdHEVC);
+    codec_ok = codec_ok ? true : (codec_id == SrsVideoCodecIdHEVC);
 #endif
     if (!codec_ok) return err;
     
@@ -851,7 +851,7 @@ srs_error_t SrsFormat::video_avc_demux(SrsBuffer* stream, int64_t timestamp)
     // Check codec for H.264 and H.265.
     bool codec_ok = (codec_id == SrsVideoCodecIdAVC);
 #ifdef SRS_H265
-    codec_ok = codec_ok ? : (codec_id == SrsVideoCodecIdHEVC);
+    codec_ok = codec_ok ? true : (codec_id == SrsVideoCodecIdHEVC);
 #endif
     if (!codec_ok) {
         return srs_error_new(ERROR_HLS_DECODE_ERROR, "only support video H.264/H.265, actual=%d", codec_id);
@@ -1174,7 +1174,7 @@ srs_error_t SrsFormat::hevc_demux_sps_rbsp(char* rbsp, int nb_rbsp)
 
     // profile tier level...
     SrsHevcSpsProfileTierLevel profile_tier_level;
-    memset(&profile_tier_level, 0, sizeof(SrsHevcSpsProfileTierLevel));
+    memset((void*)&profile_tier_level, 0, sizeof(SrsHevcSpsProfileTierLevel));
 
     if ((err = hevc_demux_sps_rbsp_ptl(&bs, &profile_tier_level, 1, sps_max_sub_layers_minus1)) != srs_success) {
         return srs_error_wrap(err, "sps rbsp ptl sps_max_sub_layers_minus1=%d", sps_max_sub_layers_minus1);

--- a/trunk/src/kernel/srs_kernel_ts.cpp
+++ b/trunk/src/kernel/srs_kernel_ts.cpp
@@ -371,7 +371,7 @@ srs_error_t SrsTsContext::encode_pat_pmt(ISrsStreamWriter* writer, int16_t vpid,
 
     bool codec_ok = (vs == SrsTsStreamVideoH264 || as == SrsTsStreamAudioAAC || as == SrsTsStreamAudioMp3);
 #ifdef SRS_H265
-    codec_ok = codec_ok ? : (vs == SrsTsStreamVideoHEVC);
+    codec_ok = codec_ok ? true : (vs == SrsTsStreamVideoHEVC);
 #endif
     if (!codec_ok) {
         return srs_error_new(ERROR_HLS_NO_STREAM, "ts: no PID, vs=%d, as=%d", vs, as);
@@ -445,7 +445,7 @@ srs_error_t SrsTsContext::encode_pes(ISrsStreamWriter* writer, SrsTsMessage* msg
 
     bool codec_ok = (sid == SrsTsStreamVideoH264 || sid == SrsTsStreamAudioAAC || sid == SrsTsStreamAudioMp3);
 #ifdef SRS_H265
-    codec_ok = codec_ok ? : (sid == SrsTsStreamVideoHEVC);
+    codec_ok = codec_ok ? true : (sid == SrsTsStreamVideoHEVC);
 #endif
     if (!codec_ok) {
         srs_info("ts: ignore the unknown stream, sid=%d", sid);
@@ -775,7 +775,7 @@ SrsTsPacket* SrsTsPacket::create_pmt(SrsTsContext* context,
     // Here we must get the correct codec.
     bool codec_ok = (vs == SrsTsStreamVideoH264 || as == SrsTsStreamAudioAAC || as == SrsTsStreamAudioMp3);
 #ifdef SRS_H265
-    codec_ok = codec_ok ? : (vs == SrsTsStreamVideoHEVC);
+    codec_ok = codec_ok ? true : (vs == SrsTsStreamVideoHEVC);
 #endif
     srs_assert(codec_ok);
 
@@ -790,7 +790,7 @@ SrsTsPacket* SrsTsPacket::create_pmt(SrsTsContext* context,
     // If h.264/h.265 specified, use video to carry pcr.
     codec_ok = (vs == SrsTsStreamVideoH264);
 #ifdef SRS_H265
-    codec_ok = codec_ok ? : (vs == SrsTsStreamVideoHEVC);
+    codec_ok = codec_ok ? true : (vs == SrsTsStreamVideoHEVC);
 #endif
     if (codec_ok) {
         pmt->PCR_PID = vpid;
@@ -3256,7 +3256,7 @@ srs_error_t SrsTsTransmuxer::write_video(int64_t timestamp, char* data, int size
 
     bool codec_ok = (format->vcodec->id != SrsVideoCodecIdAVC);
 #ifdef SRS_H265
-    codec_ok = codec_ok ? : (format->vcodec->id != SrsVideoCodecIdHEVC);
+    codec_ok = codec_ok ? true : (format->vcodec->id != SrsVideoCodecIdHEVC);
 #endif
     if (!codec_ok) {
         return err;


### PR DESCRIPTION
1. Avoid default guess for expression.
2. Force to void* for memset.
