### PR TITLE
Player: Support nginx-http-flv-module stream url.

### DIFF
--- a/trunk/research/players/srs_player.html
+++ b/trunk/research/players/srs_player.html
@@ -188,22 +188,6 @@
             return;
         }
 
-        // Start play HTTP-FLV.
-        if (r.stream.indexOf('.flv') > 0) {
-            if (!mpegts.getFeatureList().mseLivePlayback) {
-                hide_for_error();
-                return;
-            }
-
-            show_for_ok();
-
-            flvPlayer = mpegts.createPlayer({type: 'flv', url: r.url, isLive: true});
-            flvPlayer.attachMediaElement(document.getElementById('video_player'));
-            flvPlayer.load();
-            flvPlayer.play();
-            return;
-        }
-
         // Start play HTTP-TS.
         if (r.stream.indexOf('.ts') > 0) {
             if (!mpegts.getFeatureList().mseLivePlayback) {
@@ -241,6 +225,27 @@
 
             dashPlayer = dashjs.MediaPlayer().create();
             dashPlayer.initialize(document.querySelector("#video_player"), r.url, true);
+            return;
+        }
+
+        // Start play HTTP-FLV.
+        let isFlv = r.stream.indexOf('.flv') > 0;
+        // Compatible with NGINX-HTTP-FLV module, see https://github.com/winshining/nginx-http-flv-module and the stream
+        // url without .flv, such as:
+        //          http://localhost:8080/live?app=live&stream=livestream
+        isFlv = isFlv || r.stream && r.url.indexOf('http') === 0;
+        if (isFlv) {
+            if (!mpegts.getFeatureList().mseLivePlayback) {
+                hide_for_error();
+                return;
+            }
+
+            show_for_ok();
+
+            flvPlayer = mpegts.createPlayer({type: 'flv', url: r.url, isLive: true});
+            flvPlayer.attachMediaElement(document.getElementById('video_player'));
+            flvPlayer.load();
+            flvPlayer.play();
             return;
         }
 


### PR DESCRIPTION
## Usage

Clone nginx-http-flv-module

```bash
cd ~/git && git clone https://github.com/nginx/nginx.git
cd ~/git/nginx && git clone https://github.com/winshining/nginx-http-flv-module.git
cd ~/git/nginx && cp -R ~/git/srs/trunk/3rdparty/openssl-1.1-fit .
```

Build:

```bash
./auto/configure --prefix=$(pwd)/_release --with-openssl=$(pwd)/openssl-1.1-fit \
    --without-http_rewrite_module --without-http_gzip_module \
    --add-module=$(pwd)/nginx-http-flv-module

if [[ $(uname -s) == Darwin ]]; then
    sed -i '' 's/ -O / -O0 /g' objs/Makefile
else
    sed -i 's/ -O / -O0 /g' objs/Makefile
fi

make -j10
make install
```

Config `nginx.conf`:

```nginx
worker_processes  1;
daemon off;
events {
    worker_connections  1024;
}
rtmp_auto_push on;
rtmp_auto_push_reconnect 1s;
rtmp_socket_dir /tmp;
rtmp {
    server {
        listen 1935;
        # HLS
        # For HLS to work please create a directory in tmpfs (/tmp/hls here)
        # for the fragments. The directory contents is served via HTTP (see
        # http{} section in config)
        #
        # Incoming stream must be in H264/AAC. For iPhones use baseline H264
        # profile (see ffmpeg example).
        # This example creates RTMP stream from movie ready for HLS:
        #
        # ffmpeg -loglevel verbose -re -i movie.avi  -vcodec libx264
        #    -vprofile baseline -acodec libmp3lame -ar 44100 -ac 1
        #    -f flv rtmp://localhost:1935/hls/movie
        #
        # If you need to transcode live stream use 'exec' feature.
        #
        application live {
            live on;
            hls on;
            hls_path /tmp/hls;
        }
    }
}
http {
    server {
        listen      8080;
        location /live {
            flv_live on; #open flv live streaming (subscribe)
            chunked_transfer_encoding  on; #open 'Transfer-Encoding: chunked' response

            add_header 'Access-Control-Allow-Origin' '*'; #add additional HTTP header
            add_header 'Access-Control-Allow-Credentials' 'true'; #add additional HTTP header
        }
        location /hls {
            # Serve HLS fragments
            types {
                application/vnd.apple.mpegurl m3u8;
                video/mp2t ts;
            }
            root /tmp;
            add_header Cache-Control no-cache;

            add_header 'Access-Control-Allow-Origin' '*'; #add additional HTTP header
            add_header 'Access-Control-Allow-Credentials' 'true'; #add additional HTTP header
        }
    }
}
```

Publish stream:

```bash
ffmpeg -stream_loop -1 -re -i ~/git/srs/doc/source.flv -c copy \
    -f flv rtmp://localhost/live/livestream
```

Play stream:

- RTMP: `rtmp://localhost/live/livestream`
- HLS: `http://localhost:8080/hls/livestream.m3u8`
- HTTP-FLV: `http://localhost:8080/live?app=live&stream=livestream`

Open srs-player to play the HTTP-FLV stream.