### PR TITLE
FLV: Drop packet if header flag is not matched. v5.0.109

### DIFF
--- a/.run/regression-test.run.xml
+++ b/.run/regression-test.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="regression-test" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="-c conf/regression-test-for-clion.conf" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$CMakeCurrentBuildDir$/../../../" PASS_PARENT_ENVS_2="true" PROJECT_NAME="srs" TARGET_NAME="srs" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="srs" RUN_TARGET_NAME="srs">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -1450,6 +1450,12 @@ vhost http.remux.srs.com {
         # Overwrite by env SRS_VHOST_HTTP_REMUX_FAST_CACHE for all vhosts.
         # default: 0
         fast_cache 30;
+        # Whether drop packet if not match header. For example, there is has_audio and has video flag in FLV header, if
+        # this is set to on and has_audio is false, then SRS will drop audio packets when got audio packets. Generally
+        # it should work, but sometimes you might need SRS to keep packets even when FLV header is set to false.
+        # Overwrite by env SRS_VHOST_HTTP_REMUX_DROP_IF_NOT_MATCH for all vhosts.
+        # default: on
+        drop_if_not_match on;
         # the stream mount for rtmp to remux to live streaming.
         # typical mount to [vhost]/[app]/[stream].flv
         # the variables:

--- a/trunk/conf/regression-test-for-clion.conf
+++ b/trunk/conf/regression-test-for-clion.conf
@@ -1,0 +1,67 @@
+
+listen              1935;
+max_connections     1000;
+daemon off; 
+srs_log_tank console;
+
+stream_caster {
+    enabled on;
+    caster gb28181;
+    output rtmp://127.0.0.1/live/[stream];
+    listen 9000;
+    sip {
+        enabled on;
+        listen 5060;
+        timeout 2.1;
+        reinvite 1.2;
+    }
+}
+
+http_server {
+    enabled         on;
+    listen          8080;
+    dir             ./objs/nginx/html;
+}
+
+http_api {
+    enabled         on;
+    listen          1985;
+}
+stats {
+    network         0;
+}
+rtc_server {
+    enabled         on;
+    listen          8000;
+    candidate       $CANDIDATE;
+}
+
+vhost __defaultVhost__ {
+    rtc {
+        enabled     on;
+        rtmp_to_rtc on;
+        keep_bframe off;
+        rtc_to_rtmp on;
+    }
+    play {
+        atc         on;
+    }
+    http_remux {
+        enabled     on;
+        mount       [vhost]/[app]/[stream].flv;
+        drop_if_not_match on;
+    }
+    ingest livestream {
+        enabled on;
+        input {
+            type    file;
+            url     ./doc/source.200kbps.768x320.flv;
+        }
+        ffmpeg      ./objs/ffmpeg/bin/ffmpeg;
+        engine {
+            enabled          off;
+            output          rtmp://127.0.0.1:[port]/live/livestream;
+        }
+    }
+}
+

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-12-13, For [#939](https://github.com/ossrs/srs/issues/939): FLV: Drop packet if header flag is not matched. v5.0.109
 * v5.0, 2022-12-12, Merge [#3301](https://github.com/ossrs/srs/pull/3301): DASH: Fix dash crash bug when writing file. v5.0.108
 * v5.0, 2022-12-09, Merge [#3296](https://github.com/ossrs/srs/pull/3296): SRT: Support SRT to RTMP to WebRTC. v5.0.107
 * v5.0, 2022-12-08, Merge [#3295](https://github.com/ossrs/srs/pull/3295): API: Parse fragment of URI. v5.0.106

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2600,7 +2600,7 @@ srs_error_t SrsConfig::check_normal_config()
             } else if (n == "http_remux") {
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
-                    if (m != "enabled" && m != "mount" && m != "fast_cache") {
+                    if (m != "enabled" && m != "mount" && m != "fast_cache" && m != "drop_if_not_match") {
                         return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal vhost.http_remux.%s of %s", m.c_str(), vhost->arg0().c_str());
                     }
                 }
@@ -8239,6 +8239,30 @@ srs_utime_t SrsConfig::get_vhost_http_remux_fast_cache(string vhost)
     }
     
     return srs_utime_t(::atof(conf->arg0().c_str()) * SRS_UTIME_SECONDS);
+}
+
+bool SrsConfig::get_vhost_http_remux_drop_if_not_match(string vhost)
+{
+    SRS_OVERWRITE_BY_ENV_BOOL2("srs.vhost.http_remux.drop_if_not_match"); // SRS_VHOST_HTTP_REMUX_DROP_IF_NOT_MATCH
+
+    static bool DEFAULT = true;
+
+    SrsConfDirective* conf = get_vhost(vhost);
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("http_remux");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("drop_if_not_match");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
+    return SRS_CONF_PERFER_TRUE(conf->arg0());
 }
 
 string SrsConfig::get_vhost_http_remux_mount(string vhost)

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -1064,6 +1064,8 @@ public:
     virtual bool get_vhost_http_remux_enabled(SrsConfDirective* vhost);
     // Get the fast cache duration for http audio live stream.
     virtual srs_utime_t get_vhost_http_remux_fast_cache(std::string vhost);
+    // Whether drop packet if not match header.
+    bool get_vhost_http_remux_drop_if_not_match(std::string vhost);
     // Get the http flv live stream mount point for vhost.
     // used to generate the flv stream mount path.
     virtual std::string get_vhost_http_remux_mount(std::string vhost);

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -289,6 +289,11 @@ srs_error_t SrsFlvStreamEncoder::write_metadata(int64_t timestamp, char* data, i
     return enc->write_metadata(SrsFrameTypeScript, data, size);
 }
 
+void SrsFlvStreamEncoder::set_drop_if_not_match(bool v)
+{
+    enc->set_drop_if_not_match(v);
+}
+
 bool SrsFlvStreamEncoder::has_cache()
 {
     // for flv stream, use gop cache of SrsLiveSource is ok.
@@ -343,7 +348,7 @@ srs_error_t SrsFlvStreamEncoder::write_header(bool has_video, bool has_audio)
             return srs_error_wrap(err, "write header");
         }
 
-        srs_trace("FLV: write header audio=%d, video=%d", has_audio, has_video);
+        srs_trace("FLV: write header audio=%d, video=%d, dinm=%d", has_audio, has_video, enc->drop_if_not_match());
     }
 
     return err;
@@ -563,12 +568,15 @@ srs_error_t SrsLiveStream::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMess
     
     string enc_desc;
     ISrsBufferEncoder* enc = NULL;
-    
+
     srs_assert(entry);
+    bool drop_if_not_match = _srs_config->get_vhost_http_remux_drop_if_not_match(req->vhost);
+
     if (srs_string_ends_with(entry->pattern, ".flv")) {
         w->header()->set_content_type("video/x-flv");
         enc_desc = "FLV";
         enc = new SrsFlvStreamEncoder();
+        ((SrsFlvStreamEncoder*)enc)->set_drop_if_not_match(drop_if_not_match);
     } else if (srs_string_ends_with(entry->pattern, ".aac")) {
         w->header()->set_content_type("audio/x-aac");
         enc_desc = "AAC";
@@ -638,8 +646,8 @@ srs_error_t SrsLiveStream::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMess
     }
 
     srs_utime_t mw_sleep = _srs_config->get_mw_sleep(req->vhost);
-    srs_trace("FLV %s, encoder=%s, mw_sleep=%dms, cache=%d, msgs=%d", entry->pattern.c_str(), enc_desc.c_str(),
-        srsu2msi(mw_sleep), enc->has_cache(), msgs.max);
+    srs_trace("FLV %s, encoder=%s, mw_sleep=%dms, cache=%d, msgs=%d, dinm=%d", entry->pattern.c_str(), enc_desc.c_str(),
+        srsu2msi(mw_sleep), enc->has_cache(), msgs.max, drop_if_not_match);
 
     // TODO: free and erase the disabled entry after all related connections is closed.
     // TODO: FXIME: Support timeout for player, quit infinite-loop.

--- a/trunk/src/app/srs_app_http_stream.hpp
+++ b/trunk/src/app/srs_app_http_stream.hpp
@@ -77,6 +77,7 @@ public:
     virtual srs_error_t write_video(int64_t timestamp, char* data, int size);
     virtual srs_error_t write_metadata(int64_t timestamp, char* data, int size);
 public:
+    void set_drop_if_not_match(bool v);
     virtual bool has_cache();
     virtual srs_error_t dump_cache(SrsLiveConsumer* consumer, SrsRtmpJitterAlgorithm jitter);
 public:

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    108
+#define VERSION_REVISION    109
 
 #endif

--- a/trunk/src/kernel/srs_kernel_flv.hpp
+++ b/trunk/src/kernel/srs_kernel_flv.hpp
@@ -336,6 +336,9 @@ public:
 class SrsFlvTransmuxer
 {
 private:
+    bool has_audio_;
+    bool has_video_;
+    bool drop_if_not_match_;
     ISrsWriter* writer;
 private:
     char tag_header[SRS_FLV_TAG_HEADER_SIZE];
@@ -347,6 +350,9 @@ public:
     // @remark user can initialize multiple times to encode multiple flv files.
     // @remark, user must free the @param fw, flv encoder never close/free it.
     virtual srs_error_t initialize(ISrsWriter* fw);
+    // Drop packet if not match FLV header.
+    void set_drop_if_not_match(bool v);
+    bool drop_if_not_match();
 public:
     // Write flv header.
     // Write following:

--- a/trunk/src/utest/srs_utest_config.cpp
+++ b/trunk/src/utest/srs_utest_config.cpp
@@ -4666,9 +4666,9 @@ VOID TEST(ConfigEnvTest, CheckEnvValuesHttpRemux)
 {
     srs_error_t err;
 
-    if (true) {
-        MockSrsConfig conf;
+    MockSrsConfig conf;
 
+    if (true) {
         SrsSetEnvConfig(http_remux_enabled, "SRS_VHOST_HTTP_REMUX_ENABLED", "on");
         EXPECT_TRUE(conf.get_vhost_http_remux_enabled("__defaultVhost__"));
 
@@ -4677,6 +4677,16 @@ VOID TEST(ConfigEnvTest, CheckEnvValuesHttpRemux)
 
         SrsSetEnvConfig(http_remux_mount, "SRS_VHOST_HTTP_REMUX_MOUNT", "xxx");
         EXPECT_STREQ("xxx", conf.get_vhost_http_remux_mount("__defaultVhost__").c_str());
+    }
+
+    if (true) {
+        EXPECT_TRUE(conf.get_vhost_http_remux_drop_if_not_match("__defaultVhost__"));
+
+        SrsSetEnvConfig(drop_if_not_match, "SRS_VHOST_HTTP_REMUX_DROP_IF_NOT_MATCH", "off");
+        EXPECT_FALSE(conf.get_vhost_http_remux_drop_if_not_match("__defaultVhost__"));
+
+        SrsSetEnvConfig(drop_if_not_match2, "SRS_VHOST_HTTP_REMUX_DROP_IF_NOT_MATCH", "on");
+        EXPECT_TRUE(conf.get_vhost_http_remux_drop_if_not_match("__defaultVhost__"));
     }
 }
 


### PR DESCRIPTION
1. Ignore audo or video packets if FLV header disable it.
2. Reset has_audio if got some video frames but no audio frames.
3. Reset has_video if got some audio frames but no video frames.
4. Note that audio/video frames are not sequence header.
