### PR TITLE
Improve file writer performance by fwrite with cache.  v5.0.133

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-01-08, Merge [#3308](https://github.com/ossrs/srs/pull/3308): DVR: Improve file write performance by fwrite with cache. v5.0.133
 * v5.0, 2023-01-06, DVR: Support blackbox test based on hooks. v5.0.132
 * v5.0, 2023-01-06, FFmpeg: Support build with FFmpeg native opus. v5.0.131 (#3140)
 * v5.0, 2023-01-05, CORS: Refine HTTP CORS headers. v5.0.130

--- a/trunk/src/app/srs_app_dvr.cpp
+++ b/trunk/src/app/srs_app_dvr.cpp
@@ -95,6 +95,11 @@ srs_error_t SrsDvrSegmenter::open()
         return srs_error_wrap(err, "open file %s", path.c_str());
     }
     
+    // set libc file write cache buffer size
+    if ((err = fs->srs_set_iobuf_size(65536)) != srs_success) {
+        return srs_error_wrap(err, "set iobuf size for file %s", path.c_str());
+    }
+
     // initialize the encoder.
     if ((err = open_encoder()) != srs_success) {
         return srs_error_wrap(err, "open encoder");

--- a/trunk/src/app/srs_app_dvr.cpp
+++ b/trunk/src/app/srs_app_dvr.cpp
@@ -26,6 +26,8 @@ using namespace std;
 #include <srs_kernel_mp4.hpp>
 #include <srs_app_fragment.hpp>
 
+#define SRS_FWRITE_CACHE_SIZE 65536
+
 SrsDvrSegmenter::SrsDvrSegmenter()
 {
     req = NULL;
@@ -95,8 +97,8 @@ srs_error_t SrsDvrSegmenter::open()
         return srs_error_wrap(err, "open file %s", path.c_str());
     }
     
-    // set libc file write cache buffer size
-    if ((err = fs->set_iobuf_size(65536)) != srs_success) {
+    // Set libc file write cache buffer size
+    if ((err = fs->set_iobuf_size(SRS_FWRITE_CACHE_SIZE)) != srs_success) {
         return srs_error_wrap(err, "set iobuf size for file %s", path.c_str());
     }
 

--- a/trunk/src/app/srs_app_dvr.cpp
+++ b/trunk/src/app/srs_app_dvr.cpp
@@ -96,7 +96,7 @@ srs_error_t SrsDvrSegmenter::open()
     }
     
     // set libc file write cache buffer size
-    if ((err = fs->srs_set_iobuf_size(65536)) != srs_success) {
+    if ((err = fs->set_iobuf_size(65536)) != srs_success) {
         return srs_error_wrap(err, "set iobuf size for file %s", path.c_str());
     }
 

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    132
+#define VERSION_REVISION    133
 
 #endif

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -105,6 +105,8 @@
     XX(ERROR_BACKTRACE_PARSE_NOT_SUPPORT   , 1092, "BacktraceParseNotSupport", "Backtrace parse not supported") \
     XX(ERROR_BACKTRACE_PARSE_OFFSET        , 1093, "BacktraceParseOffset", "Parse backtrace offset failed") \
     XX(ERROR_BACKTRACE_ADDR2LINE           , 1094, "BacktraceAddr2Line", "Backtrace addr2line failed") \
+    XX(ERROR_SYSTEM_FILE_NOT_OPEN          , 1095, "FileNotOpen", "File is not opened") \
+    XX(ERROR_SYSTEM_FILE_SETVBUF           , 1096, "FileSetVBuf", "Failed to set file vbuf") \
 
 /**************************************************/
 /* RTMP protocol error. */

--- a/trunk/src/kernel/srs_kernel_file.cpp
+++ b/trunk/src/kernel/srs_kernel_file.cpp
@@ -46,7 +46,6 @@ SrsFileWriter::~SrsFileWriter()
     srs_freepa(buf_);
 }
 
-
 srs_error_t SrsFileWriter::set_iobuf_size(int size)
 {
     srs_error_t err = srs_success;
@@ -56,24 +55,14 @@ srs_error_t SrsFileWriter::set_iobuf_size(int size)
     }
 
     srs_freepa(buf_);
-
-    int ret;
-
-    if (size > 0) {
-        buf_ = new char[size];
-        ret = _srs_setvbuf_fn(fp_, buf_, _IOFBF, size);
-    }
-    else {
-        ret = _srs_setvbuf_fn(fp_, NULL, _IONBF, size);
-    }
-
-    if (ret != 0) {
-        return srs_error_new(ERROR_SYSTEM_FILE_SETVBUF, "file %s set vbuf error", path_.c_str());
+    buf_ = size > 0 ? new char[size] : NULL;
+    int r0 = _srs_setvbuf_fn(fp_, buf_, _IOFBF, size);
+    if (r0) {
+        return srs_error_new(ERROR_SYSTEM_FILE_SETVBUF, "setvbuf err, file=%s, r0=%d", path_.c_str(), r0);
     }
 
     return err;
 }
-
 
 srs_error_t SrsFileWriter::open(string p)
 {

--- a/trunk/src/kernel/srs_kernel_file.cpp
+++ b/trunk/src/kernel/srs_kernel_file.cpp
@@ -121,16 +121,17 @@ bool SrsFileWriter::is_open()
 
 void SrsFileWriter::seek2(int64_t offset)
 {
+    srs_assert(is_open());
+
     int r0 = fseek(fd_, (long)offset, SEEK_SET);
     srs_assert(r0 != -1);
 }
 
 int64_t SrsFileWriter::tellg()
 {
-    fpos_t pos;
-    srs_assert(fgetpos(fd_, &pos) == 0);
-        
-    return (int64_t)pos.__pos;
+    srs_assert(is_open());
+
+    return ftell(fd_);
 }
 
 srs_error_t SrsFileWriter::write(void* buf, size_t count, ssize_t* pnwrite)
@@ -176,16 +177,14 @@ srs_error_t SrsFileWriter::writev(const iovec* iov, int iovcnt, ssize_t* pnwrite
 
 srs_error_t SrsFileWriter::lseek(off_t offset, int whence, off_t* seeked)
 {
+    srs_assert(is_open());
+
     if (fseek(fd_, (long)offset, whence) == -1) {
         return srs_error_new(ERROR_SYSTEM_FILE_SEEK, "seek file");
     }
 
     if (seeked) {
-        fpos_t pos;
-        if (fgetpos(fd_, &pos)){
-            return srs_error_new(ERROR_SYSTEM_FILE_SEEK, "get pos");
-        }
-        *seeked = pos.__pos;
+        *seeked = ftell(fd_);
     }
 
     return srs_success;

--- a/trunk/src/kernel/srs_kernel_file.cpp
+++ b/trunk/src/kernel/srs_kernel_file.cpp
@@ -28,30 +28,57 @@ srs_close_t _srs_close_fn = ::close;
 
 SrsFileWriter::SrsFileWriter()
 {
-    fd = -1;
+    fd_  = NULL;
+    buf_ = NULL;
 }
 
 SrsFileWriter::~SrsFileWriter()
 {
     close();
+    srs_freepa(buf_);
 }
+
+
+srs_error_t SrsFileWriter::srs_set_iobuf_size(int size)
+{
+    srs_error_t err = srs_success;
+
+    if (fd_ == NULL){
+        return srs_error_new(ERROR_SYSTEM_FILE_NOT_OPEN, "file %s is not opened", path_.c_str());
+    }
+
+    srs_freepa(buf_);
+
+    int ret;
+
+    if (size > 0){
+        buf_ = new char[size];
+        ret = setvbuf(fd_, buf_, _IOFBF, size);
+    }else{
+        ret = setvbuf(fd_, NULL, _IONBF, size);
+    }
+
+    if (ret != 0){
+        return srs_error_new(ERROR_SYSTEM_FILE_SETVBUF, "file %s set vbuf error", path_.c_str());
+    }
+
+    return err;
+}
+
 
 srs_error_t SrsFileWriter::open(string p)
 {
     srs_error_t err = srs_success;
     
-    if (fd > 0) {
+    if (fd_ != NULL) {
         return srs_error_new(ERROR_SYSTEM_FILE_ALREADY_OPENED, "file %s already opened", p.c_str());
     }
     
-    int flags = O_CREAT|O_WRONLY|O_TRUNC;
-    mode_t mode = S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH;
-    
-    if ((fd = _srs_open_fn(p.c_str(), flags, mode)) < 0) {
+    if ((fd_ = fopen(p.c_str(), "wb")) == NULL) {
         return srs_error_new(ERROR_SYSTEM_FILE_OPENE, "open file %s failed", p.c_str());
     }
     
-    path = p;
+    path_ = p;
     
     return err;
 }
@@ -60,70 +87,69 @@ srs_error_t SrsFileWriter::open_append(string p)
 {
     srs_error_t err = srs_success;
     
-    if (fd > 0) {
-        return srs_error_new(ERROR_SYSTEM_FILE_ALREADY_OPENED, "file %s already opened", path.c_str());
+    if (fd_ != NULL) {
+        return srs_error_new(ERROR_SYSTEM_FILE_ALREADY_OPENED, "file %s already opened", p.c_str());
     }
     
-    int flags = O_CREAT|O_APPEND|O_WRONLY;
-    mode_t mode = S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH;
-    
-    if ((fd = _srs_open_fn(p.c_str(), flags, mode)) < 0) {
+    if ((fd_ = fopen(p.c_str(), "ab")) == NULL) {
         return srs_error_new(ERROR_SYSTEM_FILE_OPENE, "open file %s failed", p.c_str());
     }
     
-    path = p;
+    path_ = p;
     
     return err;
 }
 
 void SrsFileWriter::close()
 {
-    if (fd < 0) {
+    if (fd_ ==  NULL) {
         return;
     }
     
-    if (_srs_close_fn(fd) < 0) {
-        srs_warn("close file %s failed", path.c_str());
+    if (fclose(fd_) < 0) {
+        srs_warn("close file %s failed", path_.c_str());
     }
-    fd = -1;
+    fd_ = NULL;
     
     return;
 }
 
 bool SrsFileWriter::is_open()
 {
-    return fd > 0;
+    return fd_ != NULL;
 }
 
 void SrsFileWriter::seek2(int64_t offset)
 {
-    off_t r0 = _srs_lseek_fn(fd, (off_t)offset, SEEK_SET);
+    int r0 = fseek(fd_, (long)offset, SEEK_SET);
     srs_assert(r0 != -1);
 }
 
 int64_t SrsFileWriter::tellg()
 {
-    return (int64_t)_srs_lseek_fn(fd, 0, SEEK_CUR);
+    fpos_t pos;
+    srs_assert(fgetpos(fd_, &pos) == 0);
+        
+    return (int64_t)pos.__pos;
 }
 
 srs_error_t SrsFileWriter::write(void* buf, size_t count, ssize_t* pnwrite)
 {
     srs_error_t err = srs_success;
-    
-    ssize_t nwrite;
-    // TODO: FIXME: use st_write.
-#ifdef _WIN32
-    if ((nwrite = ::_write(fd, buf, (unsigned int)count)) < 0) {
-#else
-    if ((nwrite = _srs_write_fn(fd, buf, count)) < 0) {
-#endif
-        return srs_error_new(ERROR_SYSTEM_FILE_WRITE, "write to file %s failed", path.c_str());
+
+    if (fd_ == NULL) {
+        return srs_error_new(ERROR_SYSTEM_FILE_NOT_OPEN, "file %s is not opened", path_.c_str());
     }
     
-    if (pnwrite != NULL) {
-        *pnwrite = nwrite;
+    size_t n = fwrite(buf, 1, count, fd_);
+    if (n != count){
+        return srs_error_new(ERROR_SYSTEM_FILE_WRITE, "write to file %s failed", path_.c_str());
     }
-    
+
+    if (pnwrite != NULL){
+        *pnwrite = (ssize_t)n;
+    }
+
     return err;
 }
 
@@ -135,30 +161,33 @@ srs_error_t SrsFileWriter::writev(const iovec* iov, int iovcnt, ssize_t* pnwrite
     for (int i = 0; i < iovcnt; i++) {
         const iovec* piov = iov + i;
         ssize_t this_nwrite = 0;
-        if ((err = write(piov->iov_base, piov->iov_len, &this_nwrite)) != srs_success) {
-            return srs_error_wrap(err, "write file");
+        if ((err = write(piov->iov_base, piov->iov_len, &this_nwrite)) != NULL) {
+            return srs_error_wrap(err, "writev");
         }
         nwrite += this_nwrite;
     }
-    
+
     if (pnwrite) {
         *pnwrite = nwrite;
     }
-    
+
     return err;
 }
 
 srs_error_t SrsFileWriter::lseek(off_t offset, int whence, off_t* seeked)
 {
-    off_t sk = _srs_lseek_fn(fd, offset, whence);
-    if (sk < 0) {
+    if (fseek(fd_, (long)offset, whence) == -1) {
         return srs_error_new(ERROR_SYSTEM_FILE_SEEK, "seek file");
     }
-    
+
     if (seeked) {
-        *seeked = sk;
+        fpos_t pos;
+        if (fgetpos(fd_, &pos)){
+            return srs_error_new(ERROR_SYSTEM_FILE_SEEK, "get pos");
+        }
+        *seeked = pos.__pos;
     }
-    
+
     return srs_success;
 }
 

--- a/trunk/src/kernel/srs_kernel_file.hpp
+++ b/trunk/src/kernel/srs_kernel_file.hpp
@@ -26,12 +26,18 @@ class SrsFileReader;
 class SrsFileWriter : public ISrsWriteSeeker
 {
 private:
-    std::string path;
-    int fd;
+    std::string path_;
+    FILE *fd_;
+    char *buf_;
 public:
     SrsFileWriter();
     virtual ~SrsFileWriter();
 public:
+    /**
+     * set io buf size
+    */
+   virtual srs_error_t srs_set_iobuf_size(int size);
+
     /**
      * open file writer, in truncate mode.
      * @param p a string indicates the path of file to open.

--- a/trunk/src/kernel/srs_kernel_file.hpp
+++ b/trunk/src/kernel/srs_kernel_file.hpp
@@ -116,5 +116,16 @@ typedef ssize_t (*srs_read_t)(int fildes, void* buf, size_t nbyte);
 typedef off_t (*srs_lseek_t)(int fildes, off_t offset, int whence);
 typedef int (*srs_close_t)(int fildes);
 
+
+typedef FILE* (*srs_fopen_t)(const char* path, const char* mode);
+typedef size_t (*srs_fwrite_t)(const void* ptr, size_t size, size_t nitems, 
+                             FILE* stream);
+typedef size_t (*srs_fread_t)(void* ptr, size_t size, size_t nitems, 
+                            FILE* stream);                             
+typedef int (*srs_fseek_t)(FILE* stream, long offset, int whence);
+typedef int (*srs_fclose_t)(FILE* stream);
+typedef long (*srs_ftell_t)(FILE* stream);
+typedef int (*srs_setvbuf_t)(FILE* stream, char* buf, int type, size_t size);
+
 #endif
 

--- a/trunk/src/kernel/srs_kernel_file.hpp
+++ b/trunk/src/kernel/srs_kernel_file.hpp
@@ -27,7 +27,7 @@ class SrsFileWriter : public ISrsWriteSeeker
 {
 private:
     std::string path_;
-    FILE *fd_;
+    FILE *fp_;
     char *buf_;
 public:
     SrsFileWriter();
@@ -36,7 +36,7 @@ public:
     /**
      * set io buf size
     */
-   virtual srs_error_t srs_set_iobuf_size(int size);
+   virtual srs_error_t set_iobuf_size(int size);
 
     /**
      * open file writer, in truncate mode.

--- a/trunk/src/utest/srs_utest_kernel.cpp
+++ b/trunk/src/utest/srs_utest_kernel.cpp
@@ -4260,7 +4260,7 @@ VOID TEST(KernelFileTest, SeekCase)
 	SrsFileWriter w;
 	HELPER_EXPECT_SUCCESS(w.open(filepath.c_str()));
 
-    HELPER_EXPECT_SUCCESS(w.srs_set_iobuf_size(65536));
+	HELPER_EXPECT_SUCCESS(w.set_iobuf_size(65536));
 
 	SrsFileReader r;
 	HELPER_EXPECT_SUCCESS(r.open(filepath.c_str()));
@@ -4269,11 +4269,11 @@ VOID TEST(KernelFileTest, SeekCase)
 	HELPER_EXPECT_SUCCESS(w.write((void*)"Hello", 5, &nn));
 	EXPECT_EQ(5, nn);
 
-    // over 4g file test
-    long seek_pos = 0x100000002l;
-    off_t pos;  
-    HELPER_EXPECT_SUCCESS(w.lseek(seek_pos, SEEK_SET, &pos));
-    EXPECT_EQ(seek_pos, pos);
+	// over 4g file test
+	long seek_pos = 0x100000002l;
+	off_t pos;  
+	HELPER_EXPECT_SUCCESS(w.lseek(seek_pos, SEEK_SET, &pos));
+	EXPECT_EQ(seek_pos, pos);
 
 	HELPER_EXPECT_SUCCESS(w.write((void*)"World", 5, &nn));
 	EXPECT_EQ(5, nn);

--- a/trunk/src/utest/srs_utest_kernel.cpp
+++ b/trunk/src/utest/srs_utest_kernel.cpp
@@ -4328,7 +4328,6 @@ VOID TEST(KernelFileWriterTest, WriteSpecialCase)
 
 		EXPECT_EQ(f.tellg(), -1);
 	}
-
 }
 
 VOID TEST(KernelFileReaderTest, WriteSpecialCase)
@@ -4385,26 +4384,24 @@ VOID TEST(KernelFileReaderTest, WriteSpecialCase)
 	}
 }
 
-class MockFileRemover
+MockFileRemover::MockFileRemover(string p)
 {
-private:
-	string f;
-public:
-	MockFileRemover(string p) {
-		f = p;
-	}
-	virtual ~MockFileRemover() {
-		if (f != "") {
-			::unlink(f.c_str());
-		}
-	}
-};
+    path_ = p;
+}
+
+MockFileRemover::~MockFileRemover()
+{
+    // Only remove {_srs_tmp_file_prefix}*.log file.
+    if (path_.find(_srs_tmp_file_prefix) != 0) return;
+    if (path_.find(".log") == string::npos) return;
+    ::unlink(path_.c_str());
+}
 
 VOID TEST(KernelFileTest, ReadWriteCase)
 {
 	srs_error_t err;
 
-	string filepath = _srs_tmp_file_prefix + "kernel-file-read-write-case";
+	string filepath = _srs_tmp_file_prefix + "kernel-file-read-write-case.log";
 	MockFileRemover _mfr(filepath);
 
 	SrsFileWriter w;
@@ -4431,7 +4428,7 @@ VOID TEST(KernelFileTest, SeekCase)
 {
 	srs_error_t err;
 
-	string filepath = _srs_tmp_file_prefix + "kernel-file-read-write-case";
+	string filepath = _srs_tmp_file_prefix + "kernel-file-read-write-case.log";
 	MockFileRemover _mfr(filepath);
 
 	SrsFileWriter w;
@@ -4468,7 +4465,6 @@ VOID TEST(KernelFileTest, SeekCase)
 	EXPECT_EQ(5, nn);
 
 	EXPECT_STREQ("World", buf);
-
 }
 
 VOID TEST(KernelFLVTest, CoverAll)

--- a/trunk/src/utest/srs_utest_kernel.hpp
+++ b/trunk/src/utest/srs_utest_kernel.hpp
@@ -39,6 +39,15 @@ public:
     virtual srs_error_t lseek(off_t offset, int whence, off_t* seeked);
 };
 
+class MockFileRemover
+{
+private:
+    std::string path_;
+public:
+    MockFileRemover(std::string p);
+    virtual ~MockFileRemover();
+};
+
 class MockSrsFileWriter : public SrsFileWriter
 {
 public:


### PR DESCRIPTION
I found srs dvr bottleneck while doing dvr stress test with many concurrent streams pushing to srs.
with perf flame graph's help, I found there are so many file write ops which consumed so many cpu time.
And I tracked the dvr module code, and found the SrsFileWriter use unix system file operation functions including open/write/lseek/close, it has no buffer mechanism in it, and every write op will lead to a new system call.
With this analysis, I used corresponding libc  file operation functions to implement the SrsFileWriter, and use setvbuf with 65536 bytes buffer to enable the libc buffer mechanism, as i wished, the cpu usage rate drop down very obviously.

the following is the graph before and after the performance tuning.
before tuning:
![before_tuning](https://user-images.githubusercontent.com/9344676/207499485-3a30d660-7625-4a32-8bef-0e2cdc311936.png)

after tuning:

![after_tuning](https://user-images.githubusercontent.com/9344676/207499499-22d88a7c-d695-4e1c-853e-39e5ac7c6f61.png)
