### PR TITLE
GB28181: Fix memory overlap for small packets.

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-12-15, For [#3300](https://github.com/ossrs/srs/issues/3300): GB28181: Fix memory overlap for small packets. v5.0.111
 * v5.0, 2022-12-14, For [#939](https://github.com/ossrs/srs/issues/939): FLV: Support set default has_av and disable guessing. v5.0.110
 * v5.0, 2022-12-13, For [#939](https://github.com/ossrs/srs/issues/939): FLV: Drop packet if header flag is not matched. v5.0.109
 * v5.0, 2022-12-13, For [#939](https://github.com/ossrs/srs/issues/939): FLV: Reset has_audio or has_video if only sequence header.

--- a/trunk/src/app/srs_app_gb28181.cpp
+++ b/trunk/src/app/srs_app_gb28181.cpp
@@ -1444,8 +1444,9 @@ srs_error_t SrsLazyGbMediaTcpConn::do_cycle()
             string bytes = srs_string_dumps_hex(b.head(), reserved, 16);
             srs_trace("PS: Reserved bytes for next loop, pos=%d, left=%d, total=%d, bytes=[%s]",
                 b.pos(), b.left(), b.size(), bytes.c_str());
-            // Copy the bytes left to the start of buffer.
-            b.read_bytes((char*)buffer_, reserved);
+            // Copy the bytes left to the start of buffer. Note that the left(reserved) bytes might be overlapped with
+            // buffer, so we must use memmove not memcpy, see https://github.com/ossrs/srs/issues/3300#issuecomment-1352907075
+            memmove(buffer_, b.head(), reserved);
             pack_->media_reserved_++;
         }
     }

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    110
+#define VERSION_REVISION    111
 
 #endif


### PR DESCRIPTION
In a certain scenario, when the package is relatively small and there is overlapping in the reserved area, memcpy should not be used, but memmove should be used instead.

```cpp
srs_error_t SrsLazyGbMediaTcpConn::do_cycle() {
    uint32_t reserved = 0;
    for (;;) {
        uint16_t length = 0; // If it's 30
        if ((err = conn_->read_fully(buffer_ + reserved, length, NULL)) != srs_success) {

        reserved = b.left(); // If it's 20
        if (reserved) {
            b.read_bytes((char*)buffer_, reserved); // Crash here.
            pack_->media_reserved_++;
        }
```

When this situation occurs, `b.read_bytes` is actually equivalent to `memcpy`, which copies the last 20 bytes of b (30 bytes) to the beginning, resulting in overlap. It is equivalent to the following situation:

```cpp
int length = 30;
char buffer[length];

char* p = buffer + 10;
int reserved = 20;
memcpy(buffer, p, reserved);
```

Solution: Changing it to `memmove` will solve the issue and support overlap.

Once again, thanks to @chen-guanghua for introducing the asan tool, which helped uncover many potential issues.

---------

`TRANS_BY_GPT3`