### PR TITLE
GB: Refine lazy object GC. v5.0.114

### DIFF
--- a/.run/gb28181.run.xml
+++ b/.run/gb28181.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="gb28181" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="-c conf/gb28181.conf" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$CMakeCurrentBuildDir$/../../../" PASS_PARENT_ENVS_2="true" PROJECT_NAME="srs" TARGET_NAME="srs" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="srs" RUN_TARGET_NAME="srs">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,7 +8,8 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
-* v5.0, 2022-12-18, Merge [#3324](https://github.com/ossrs/srs/pull/3324): Asan: Support parse asan symbol backtrace log. v5.0.113
+* v5.0, 2022-12-18, Merge [#3324](https://github.com/ossrs/srs/pull/3324): Asan: Support parse asan symbol backtrace log. v5.0.114
+* v5.0, 2022-12-20, Merge [#3321](https://github.com/ossrs/srs/pull/3321): GB: Refine lazy object GC. v5.0.113
 * v5.0, 2022-12-17, Merge [#3323](https://github.com/ossrs/srs/pull/3323): SRT: Fix srt to rtmp crash when sps or pps empty. v5.0.112
 * v5.0, 2022-12-15, For [#3300](https://github.com/ossrs/srs/issues/3300): GB28181: Fix memory overlap for small packets. v5.0.111
 * v5.0, 2022-12-14, For [#939](https://github.com/ossrs/srs/issues/939): FLV: Support set default has_av and disable guessing. v5.0.110

--- a/trunk/src/app/srs_app_conn.hpp
+++ b/trunk/src/app/srs_app_conn.hpp
@@ -139,21 +139,68 @@ extern ISrsLazyGc* _srs_gc;
 
 // A wrapper template for lazy-sweep resource.
 // See https://github.com/ossrs/srs/issues/3176#lazy-sweep
+//
+// Usage for resource which manages itself in coroutine cycle, see SrsLazyGbSession:
+//      class Resource {
+//      private:
+//          SrsLazyObjectWrapper<Resource>* wrapper_;
+//      private:
+//          friend class SrsLazyObjectWrapper<Resource>;
+//          Resource(SrsLazyObjectWrapper<Resource>* wrapper) { wrapper_ = wrapper; }
+//      public:
+//          srs_error_t Resource::cycle() {
+//              srs_error_t err = do_cycle();
+//              _srs_gb_manager->remove(wrapper_);
+//              return err;
+//          }
+//      };
+//      SrsLazyObjectWrapper<Resource>* obj = new SrsLazyObjectWrapper<Resource>*();
+//      _srs_gb_manager->add(obj); // Add wrapper to resource manager.
+//      Start a coroutine to do obj->resource()->cycle().
+//
+// Usage for resource managed by other object:
+//      class Resource {
+//      private:
+//          friend class SrsLazyObjectWrapper<Resource>;
+//          Resource(SrsLazyObjectWrapper<Resource>* /*wrapper*/) {
+//          }
+//      };
+//      class Manager {
+//      private:
+//          SrsLazyObjectWrapper<Resource>* wrapper_;
+//      public:
+//          Manager() { wrapper_ = new SrsLazyObjectWrapper<Resource>(); }
+//          ~Manager() { srs_freep(wrapper_); }
+//      };
+//      Manager* manager = new Manager();
+//      srs_freep(manager);
+//
+// Note that under-layer resource are destroyed by _srs_gc, which is literally equal to srs_freep. However, the root
+// wrapper might be managed by other resource manager, such as _srs_gb_manager for SrsLazyGbSession. Furthermore, other
+// copied out wrappers might be freed by srs_freep. All are ok, because all wrapper and resources are simply normal
+// object, so if you added to manager then you should use manager to remove it, and you can also directly delete it.
 template<typename T>
 class SrsLazyObjectWrapper : public ISrsResource
 {
 private:
     T* resource_;
 public:
-    SrsLazyObjectWrapper(T* resource = NULL) {
-        resource_ = resource ? resource : new T(this);
-        resource_->gc_use();
+    SrsLazyObjectWrapper() {
+        init(new T(this));
     }
     virtual ~SrsLazyObjectWrapper() {
         resource_->gc_dispose();
         if (resource_->gc_ref() == 0) {
             _srs_gc->remove(resource_);
         }
+    }
+private:
+    SrsLazyObjectWrapper(T* resource) {
+        init(resource);
+    }
+    void init(T* resource) {
+        resource_ = resource;
+        resource_->gc_use();
     }
 public:
     SrsLazyObjectWrapper<T>* copy() {

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    113
+#define VERSION_REVISION    114
 
 #endif

--- a/trunk/src/protocol/srs_protocol_conn.cpp
+++ b/trunk/src/protocol/srs_protocol_conn.cpp
@@ -43,38 +43,25 @@ ISrsConnection::~ISrsConnection()
 SrsLazyObject::SrsLazyObject()
 {
     gc_ref_ = 0;
-    gc_creator_wrapper_ = NULL;
 }
 
 SrsLazyObject::~SrsLazyObject()
 {
 }
 
-SrsLazyObject* SrsLazyObject::gc_use()
+void SrsLazyObject::gc_use()
 {
     gc_ref_++;
-    return this;
 }
 
-SrsLazyObject* SrsLazyObject::gc_dispose()
+void SrsLazyObject::gc_dispose()
 {
     gc_ref_--;
-    return this;
 }
 
 int32_t SrsLazyObject::gc_ref()
 {
     return gc_ref_;
-}
-
-void SrsLazyObject::gc_set_creator_wrapper(ISrsResource* wrapper)
-{
-    gc_creator_wrapper_ = wrapper;
-}
-
-ISrsResource* SrsLazyObject::gc_creator_wrapper()
-{
-    return gc_creator_wrapper_;
 }
 
 ISrsLazyGc::ISrsLazyGc()

--- a/trunk/src/protocol/srs_protocol_conn.hpp
+++ b/trunk/src/protocol/srs_protocol_conn.hpp
@@ -55,24 +55,16 @@ class SrsLazyObject
 private:
     // The reference count of resource, 0 is no wrapper and safe to sweep.
     int32_t gc_ref_;
-    // The creator wrapper, which created this resource. Note that it might be disposed and the pointer is NULL, so be
-    // careful and make sure to check it before use it.
-    ISrsResource* gc_creator_wrapper_;
 public:
     SrsLazyObject();
     virtual ~SrsLazyObject();
 public:
     // For wrapper to use this resource.
-    virtual SrsLazyObject* gc_use();
+    virtual void gc_use();
     // For wrapper to dispose this resource.
-    virtual SrsLazyObject* gc_dispose();
+    virtual void gc_dispose();
     // The current reference count of resource.
     virtual int32_t gc_ref();
-public:
-    // Set the creator wrapper, from which resource clone wrapper.
-    virtual void gc_set_creator_wrapper(ISrsResource* wrapper);
-    // Get the first available wrapper. NULL if the creator wrapper disposed.
-    virtual ISrsResource* gc_creator_wrapper();
 };
 
 // The lazy-sweep GC, wait for a long time to dispose resource even when resource is disposable.


### PR DESCRIPTION
1. Remove gc_set_creator_wrapper, pass by resource constructor.
2. Remove SRS_LAZY_WRAPPER_GENERATOR macro, use template directly.
3. Remove interfaces ISrsGbSipConn and ISrsGbSipConnWrapper.
4. Remove ISrsGbMediaConn and ISrsGbMediaConnWrapper.
