### PR TITLE
SRT: Fix srt to rtmp crash when sps or pps empty. v5.0.112

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2022-12-17, Merge [#3323](https://github.com/ossrs/srs/pull/3323): SRT: Fix srt to rtmp crash when sps or pps empty. v5.0.112
 * v5.0, 2022-12-15, For [#3300](https://github.com/ossrs/srs/issues/3300): GB28181: Fix memory overlap for small packets. v5.0.111
 * v5.0, 2022-12-14, For [#939](https://github.com/ossrs/srs/issues/939): FLV: Support set default has_av and disable guessing. v5.0.110
 * v5.0, 2022-12-13, For [#939](https://github.com/ossrs/srs/issues/939): FLV: Drop packet if header flag is not matched. v5.0.109

--- a/trunk/src/app/srs_app_srt_source.cpp
+++ b/trunk/src/app/srs_app_srt_source.cpp
@@ -377,6 +377,10 @@ srs_error_t SrsRtmpFromSrtBridge::on_ts_video(SrsTsMessage* msg, SrsBuffer* avs)
         if ((err = avc->annexb_demux(avs, &frame, &frame_size)) != srs_success) {
             return srs_error_wrap(err, "demux annexb");
         }
+
+        if (frame == NULL || frame_size == 0) {
+            continue;
+        }
         
         // for sps
         if (avc->is_sps(frame, frame_size)) {
@@ -424,6 +428,10 @@ srs_error_t SrsRtmpFromSrtBridge::check_sps_pps_change(SrsTsMessage* msg)
 
     if (! sps_pps_change_) {
         return err;
+    }
+
+    if (sps_.empty() || pps_.empty()) {
+        return srs_error_new(ERROR_SRT_TO_RTMP_EMPTY_SPS_PPS, "sps or pps empty");
     }
 
     // sps/pps changed, generate new video sh frame and dispatch it.

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    111
+#define VERSION_REVISION    112
 
 #endif

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -370,7 +370,8 @@
     XX(ERROR_SRT_CONN                      , 6006, "SrtConnection", "SRT connectin level error") \
     XX(ERROR_SRT_SOURCE_BUSY               , 6007, "SrtStreamBusy", "SRT stream already exists or busy") \
     XX(ERROR_RTMP_TO_SRT                   , 6008, "SrtFromRtmp", "Covert RTMP to SRT failed") \
-    XX(ERROR_SRT_STATS                     , 6009, "SrtStats", "SRT get statistic data failed")
+    XX(ERROR_SRT_STATS                     , 6009, "SrtStats", "SRT get statistic data failed") \
+    XX(ERROR_SRT_TO_RTMP_EMPTY_SPS_PPS     , 6010, "SrtToRtmpEmptySpsPps", "SRT to rtmp have empty sps or pps")
 
 /**************************************************/
 /* For user-define error. */


### PR DESCRIPTION
Srt to rtmp need to check wether the sps or pps empty.
