### PR TITLE
Closes #3326: apihost for sdk.js

### DIFF
--- a/trunk/research/players/js/srs.sdk.js
+++ b/trunk/research/players/js/srs.sdk.js
@@ -157,6 +157,11 @@ function SrsRtcPublisherAsync() {
                 .replace("webrtc://", "http://")
                 .replace("rtc://", "http://");
 
+            var apihost = new URL(url).searchParams.get("apihost");
+            if (apihost) {
+                a.hostname = apihost;
+            }
+
             var vhost = a.hostname;
             var app = a.pathname.substring(1, a.pathname.lastIndexOf("/"));
             var stream = a.pathname.slice(a.pathname.lastIndexOf("/") + 1);
@@ -391,6 +396,11 @@ function SrsRtcPlayerAsync() {
             a.href = url.replace("rtmp://", "http://")
                 .replace("webrtc://", "http://")
                 .replace("rtc://", "http://");
+
+            var apihost = new URL(url).searchParams.get("apihost");
+            if (apihost) {
+                a.hostname = apihost;
+            }
 
             var vhost = a.hostname;
             var app = a.pathname.substring(1, a.pathname.lastIndexOf("/"));


### PR DESCRIPTION
in  play or publish webpage(rtc), uses:

`webrtc://localhost/live/livestream?apihost=47.92.231.11`
