### PR TITLE
H265: Support HEVC over HLS. v6.0.11 (#465)

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-01-02, For [#465](https://github.com/ossrs/srs/issues/465): HLS: Support HEVC over HLS. v6.0.11
 * v6.0, 2022-12-30, Support first SRS6 version. v6.0.10
 * v6.0, 2022-12-26, For [#465](https://github.com/ossrs/srs/issues/465): TS: Support disable audio or video to make mpegts.js happy. v6.0.9
 * v6.0, 2022-12-26, For [#465](https://github.com/ossrs/srs/issues/465): TS: Fix bug for codec detecting for HTTP-TS. v6.0.8

--- a/trunk/src/app/srs_app_hls.hpp
+++ b/trunk/src/app/srs_app_hls.hpp
@@ -159,6 +159,8 @@ private:
 private:
     // Latest audio codec, parsed from stream.
     SrsAudioCodecId latest_acodec_;
+    // Latest audio codec, parsed from stream.
+    SrsVideoCodecId latest_vcodec_;
 public:
     SrsHlsMuxer();
     virtual ~SrsHlsMuxer();
@@ -172,6 +174,8 @@ public:
 public:
     SrsAudioCodecId latest_acodec();
     void set_latest_acodec(SrsAudioCodecId v);
+    SrsVideoCodecId latest_vcodec();
+    void set_latest_vcodec(SrsVideoCodecId v);
 public:
     // Initialize the hls muxer.
     virtual srs_error_t initialize();
@@ -199,7 +203,7 @@ public:
     // Whether current hls muxer is pure audio mode.
     virtual bool pure_audio();
     virtual srs_error_t flush_audio(SrsTsMessageCache* cache);
-    virtual srs_error_t flush_video(SrsTsMessageCache* cache, SrsVideoFrame* frame);
+    virtual srs_error_t flush_video(SrsTsMessageCache* cache);
     // Close segment(ts).
     virtual srs_error_t segment_close();
 private:

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    10
+#define VERSION_REVISION    11
 
 #endif

--- a/trunk/src/kernel/srs_kernel_ts.cpp
+++ b/trunk/src/kernel/srs_kernel_ts.cpp
@@ -2678,7 +2678,7 @@ SrsTsContextWriter::SrsTsContextWriter(ISrsStreamWriter* w, SrsTsContext* c, Srs
     context = c;
 
     acodec_ = ac;
-    vcodec = vc;
+    vcodec_ = vc;
 }
 
 SrsTsContextWriter::~SrsTsContextWriter()
@@ -2692,8 +2692,8 @@ srs_error_t SrsTsContextWriter::write_audio(SrsTsMessage* audio)
     srs_info("hls: write audio codec=%d/%d, pts=%" PRId64 ", dts=%" PRId64 ", size=%d",
         acodec_, vcodec_, audio->pts, audio->dts, audio->PES_packet_length);
     
-    if ((err = context->encode(writer, audio, vcodec, acodec_)) != srs_success) {
-        return srs_error_wrap(err, "ts: write audio acodec=%d, vcodec=%d", acodec_, vcodec);
+    if ((err = context->encode(writer, audio, vcodec_, acodec_)) != srs_success) {
+        return srs_error_wrap(err, "ts: write audio");
     }
     srs_info("hls encode audio ok");
     
@@ -2707,22 +2707,22 @@ srs_error_t SrsTsContextWriter::write_video(SrsTsMessage* video)
     srs_info("hls: write video codec=%d/%d, pts=%" PRId64 ", dts=%" PRId64 ", size=%d",
         acodec_, vcodec_, video->pts, video->dts, video->PES_packet_length);
     
-    if ((err = context->encode(writer, video, vcodec, acodec_)) != srs_success) {
-        return srs_error_wrap(err, "ts: write video acodec=%d, vcodec=%d", acodec_, vcodec);
+    if ((err = context->encode(writer, video, vcodec_, acodec_)) != srs_success) {
+        return srs_error_wrap(err, "ts: write video");
     }
     srs_info("hls encode video ok");
     
     return err;
 }
 
-SrsVideoCodecId SrsTsContextWriter::video_codec()
+SrsVideoCodecId SrsTsContextWriter::vcodec()
 {
-    return vcodec;
+    return vcodec_;
 }
 
-void SrsTsContextWriter::update_video_codec(SrsVideoCodecId v)
+void SrsTsContextWriter::set_vcodec(SrsVideoCodecId v)
 {
-    vcodec = v;
+    vcodec_ = v;
 }
 
 SrsAudioCodecId SrsTsContextWriter::acodec()
@@ -3293,7 +3293,7 @@ srs_error_t SrsTsTransmuxer::write_video(int64_t timestamp, char* data, int size
     }
 
     // The video codec might change during streaming.
-    tscw->update_video_codec(format->vcodec->id);
+    tscw->set_vcodec(format->vcodec->id);
     
     // ignore sequence header
     if (format->video->frame_type == SrsVideoAvcFrameTypeKeyFrame && format->video->avc_packet_type == SrsVideoAvcFrameTraitSequenceHeader) {

--- a/trunk/src/kernel/srs_kernel_ts.hpp
+++ b/trunk/src/kernel/srs_kernel_ts.hpp
@@ -1259,7 +1259,7 @@ class SrsTsContextWriter
 private:
     // User must config the codec in right way.
     // @see https://github.com/ossrs/srs/issues/301
-    SrsVideoCodecId vcodec;
+    SrsVideoCodecId vcodec_;
     SrsAudioCodecId acodec_;
 private:
     SrsTsContext* context;
@@ -1275,8 +1275,8 @@ public:
     virtual srs_error_t write_video(SrsTsMessage* video);
 public:
     // Get or update the video codec of ts muxer.
-    virtual SrsVideoCodecId video_codec();
-    virtual void update_video_codec(SrsVideoCodecId v);
+    virtual SrsVideoCodecId vcodec();
+    virtual void set_vcodec(SrsVideoCodecId v);
 public:
     // Get and set the audio codec.
     SrsAudioCodecId acodec();


### PR DESCRIPTION
1. compile by `./configure --h265=on`, run by `./objs/srs -c conf/hls.conf`
2. Support HEVC/H.265 in HLS.