### PR TITLE
HTTP: Add CORS Header for private network access

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-01-06, Merge [#3363](https://github.com/ossrs/srs/issues/3363): HTTP: Add CORS Header for private network access. v6.0.13
 * v6.0, 2023-01-04, Merge [#3362](https://github.com/ossrs/srs/issues/3362): SRT: Upgrade libsrt from 1.4.1 to 1.5.1. v6.0.12
 * v6.0, 2023-01-02, For [#465](https://github.com/ossrs/srs/issues/465): HLS: Support HEVC over HLS. v6.0.11
 * v6.0, 2022-12-30, Support first SRS6 version. v6.0.10

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    12
+#define VERSION_REVISION    13
 
 #endif

--- a/trunk/src/protocol/srs_protocol_http_stack.cpp
+++ b/trunk/src/protocol/srs_protocol_http_stack.cpp
@@ -895,6 +895,8 @@ srs_error_t SrsHttpCorsMux::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessag
         h->set("Access-Control-Allow-Methods", "GET, POST, HEAD, PUT, DELETE, OPTIONS");
         h->set("Access-Control-Expose-Headers", "Server,range,Content-Length,Content-Range");
         h->set("Access-Control-Allow-Headers", "origin,range,accept-encoding,referer,Cache-Control,X-Proxy-Authorization,X-Requested-With,Content-Type");
+        // CORS header for private network access, starting in Chrome 104
+        h->set("Access-Control-Request-Private-Network", "true");
     }
     
     // handle the http options.


### PR DESCRIPTION
Chrome will start sending a CORS preflight request ahead of any [private network request](https://developer.chrome.com/blog/private-network-access-preflight/#what-is-private-network-access-pna) for a subresource, which asks for explicit permission from the target server. This preflight request will carry a new header, `Access-Control-Request-Private-Network: true`, and the response to it must carry a corresponding header, `Access-Control-Allow-Private-Network: true`.

The aim is to protect users from [cross-site request forgery (CSRF) attacks](https://portswigger.net/web-security/csrf) targeting routers and other devices on private networks. These [attacks have affected hundreds of thousands of users](https://securityaffairs.co/wordpress/22743/cyber-crime/soho-pharming-attack.html), allowing attackers to redirect them to malicious servers.

Reference content: 
Make sure to maintain the markdown structure.
https://developer.chrome.com/blog/private-network-access-preflight/
#2787 RTC: Ensure private network requests are made from secure contexts

---------

`TRANS_BY_GPT3`