### PR TITLE
Exporter: Filter normal read and write errors.(#3364)

### DIFF
--- a/trunk/src/app/srs_app_statistic.cpp
+++ b/trunk/src/app/srs_app_statistic.cpp
@@ -445,7 +445,10 @@ void SrsStatistic::on_disconnect(std::string id, srs_error_t err)
     stream->nb_clients--;
     vhost->nb_clients--;
 
-    if (srs_error_code(err) != ERROR_SUCCESS) {
+    // TODO: FIXME: Should filter the err.
+    int err_code = srs_error_code(err);
+    if (err_code != ERROR_SUCCESS && err_code != ERROR_SOCKET_READ && err_code != ERROR_SOCKET_WRITE
+        && err_code != ERROR_SRT_IO) {
         nb_errs_++;
     }
 


### PR DESCRIPTION
Filter normal read and write errors, for ignore or reduce `srs_clients_errs_total` some disconnect events.
```bash
curl http://127.0.0.1:9972/metrics
```
```bash
# HELP srs_node_uname_info Labeled system information as provided by the uname system call.
# TYPE srs_node_uname_info gauge
srs_node_uname_info{sysname="Linux",nodename="7cd605a15218",release="5.10.104-linuxkit",version="#1 SMP Thu Mar 17 17:08:06 UTC 2022",machine="x86_64"} 1
# HELP srs_build_info A metric with a constant '1' value labeled by build_date, version from which SRS was built.
# TYPE srs_build_info gauge
srs_build_info{build_date="2023-01-06 17:17:09",major="6",version="6.0.13",code="Bee",label="cn-beijing",tag="cn-edge"} 1
# HELP srs_cpu_percent SRS cpu used percent.
# TYPE srs_cpu_percent gauge
srs_cpu_percent 3.003
# HELP srs_memory SRS memory used.
# TYPE srs_memory gauge
srs_memory 22280
# HELP srs_send_bytes_total SRS total sent bytes.
# TYPE srs_send_bytes_total counter
srs_send_bytes_total 5789
# HELP srs_receive_bytes_total SRS total received bytes.
# TYPE srs_receive_bytes_total counter
srs_receive_bytes_total 203862
# HELP srs_streams The number of SRS concurrent streams.
# TYPE srs_streams gauge
srs_streams 0
# HELP srs_clients The number of SRS concurrent clients.
# TYPE srs_clients gauge
srs_clients 0
# HELP srs_clients_total The total counts of SRS clients.
# TYPE srs_clients_total counter
srs_clients_total 1
# HELP srs_clients_errs_total The total errors of SRS clients.
# TYPE srs_clients_errs_total counter
srs_clients_errs_total 0
```