### PR TITLE
Config: Support better env name for prefixed with srs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,7 @@ jobs:
       ##################################################################################################################
       # Create main images for Docker
       - name: Login to docker hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: "${{ secrets.DOCKER_USERNAME }}"
           password: "${{ secrets.DOCKER_PASSWORD }}"
@@ -267,7 +267,7 @@ jobs:
       # Docker alias images
       # TODO: FIXME: If stable, please set the latest from 4.0 to 5.0
       - name: Docker alias images for ossrs/srs
-        uses: akhilerm/tag-push-action@v2.0.0
+        uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ossrs/srs:${{ env.SRS_TAG }}
           dst: |
@@ -291,13 +291,13 @@ jobs:
       # Aliyun ACR
       # TODO: FIXME: If stable, please set the latest from 4.0 to 5.0
       - name: Login aliyun hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: "${{ secrets.ACR_USERNAME }}"
           password: "${{ secrets.ACR_PASSWORD }}"
       - name: Push to Aliyun registry for ossrs/srs
-        uses: akhilerm/tag-push-action@v2.0.0
+        uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ossrs/srs:${{ env.SRS_TAG }}
           dst: |

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -36,7 +36,7 @@ ff_log_level info;
 # if console, print log to console.
 # if file, write log to file. requires srs_log_file if log to file.
 # Note: Do not support reloading, for SRS5+
-# Overwrite by env SRS_SRS_LOG_TANK
+# Overwrite by env SRS_LOG_TANK or SRS_SRS_LOG_TANK
 # default: file.
 srs_log_tank console;
 # The log level for logging to console or file. It can be:
@@ -46,7 +46,7 @@ srs_log_tank console;
 # If configure --log-level_v2=on, use SRS 5.0 level specs which is v2, the level text is:
 #       TRACE, DEBUG, INFO, WARN, ERROR
 # Note: Do not support reloading, for SRS5+
-# Overwrite by env SRS_SRS_LOG_LEVEL
+# Overwrite by env SRS_LOG_LEVEL or SRS_SRS_LOG_LEVEL
 # default: trace
 srs_log_level trace;
 # The log level v2, rewrite the config srs_log_level if not empty, it can be:
@@ -55,11 +55,11 @@ srs_log_level trace;
 #       Verb, Info, Trace, Warn, Error
 # If configure --log-level_v2=on, use SRS 5.0 level specs which is v2, the level text is:
 #       TRACE, DEBUG, INFO, WARN, ERROR
-# Overwrite by env SRS_SRS_LOG_LEVEL_V2
+# Overwrite by env SRS_LOG_LEVEL_V2 or SRS_SRS_LOG_LEVEL_V2
 srs_log_level_v2 info;
 # when srs_log_tank is file, specifies the log file.
 # Note: Do not support reloading, for SRS5+
-# Overwrite by env SRS_SRS_LOG_FILE
+# Overwrite by env SRS_LOG_FILE or SRS_SRS_LOG_FILE
 # default: ./objs/srs.log
 srs_log_file ./objs/srs.log;
 # the max connections.

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -1919,7 +1919,7 @@ srs_error_t SrsConfig::parse_options(int argc, char** argv)
     // If use env only, we set change to daemon(off) and console log.
     if (env_only_) {
         if (!getenv("SRS_DAEMON")) setenv("SRS_DAEMON", "off", 1);
-        if (!getenv("SRS_SRS_LOG_TANK")) setenv("SRS_SRS_LOG_TANK", "console", 1);
+        if (!getenv("SRS_SRS_LOG_TANK") && !getenv("SRS_LOG_TANK")) setenv("SRS_SRS_LOG_TANK", "console", 1);
         if (root->directives.empty()) root->get_or_create("vhost", "__defaultVhost__");
     }
 
@@ -6340,8 +6340,11 @@ extern bool _srs_in_docker;
 
 bool SrsConfig::get_log_tank_file()
 {
-    if (!srs_getenv("srs.srs_log_tank").empty()) { // SRS_
+    if (!srs_getenv("srs.srs_log_tank").empty()) { // SRS_SRS_LOG_TANK
         return srs_getenv("srs.srs_log_tank") != "console";
+    }
+    if (!srs_getenv("srs.log_tank").empty()) { // SRS_LOG_TANK
+        return srs_getenv("srs.log_tank") != "console";
     }
 
     static bool DEFAULT = true;
@@ -6361,6 +6364,7 @@ bool SrsConfig::get_log_tank_file()
 string SrsConfig::get_log_level()
 {
     SRS_OVERWRITE_BY_ENV_STRING("srs.srs_log_level"); // SRS_SRS_LOG_LEVEL
+    SRS_OVERWRITE_BY_ENV_STRING("srs.log_level"); // SRS_LOG_LEVEL
 
     static string DEFAULT = "trace";
 
@@ -6375,6 +6379,7 @@ string SrsConfig::get_log_level()
 string SrsConfig::get_log_level_v2()
 {
     SRS_OVERWRITE_BY_ENV_STRING("srs.srs_log_level_v2"); // SRS_SRS_LOG_LEVEL_V2
+    SRS_OVERWRITE_BY_ENV_STRING("srs.log_level_v2"); // SRS_LOG_LEVEL_V2
 
     static string DEFAULT = "";
 
@@ -6389,6 +6394,7 @@ string SrsConfig::get_log_level_v2()
 string SrsConfig::get_log_file()
 {
     SRS_OVERWRITE_BY_ENV_STRING("srs.srs_log_file"); // SRS_SRS_LOG_FILE
+    SRS_OVERWRITE_BY_ENV_STRING("srs.log_file"); // SRS_LOG_FILE
 
     static string DEFAULT = "./objs/srs.log";
     

--- a/trunk/src/app/srs_app_forward.cpp
+++ b/trunk/src/app/srs_app_forward.cpp
@@ -66,6 +66,9 @@ srs_error_t SrsForwarder::initialize(SrsRequest* r, string ep)
     
     // the ep(endpoint) to forward to
     ep_forward = ep;
+
+    // Remember the source context id.
+    source_cid_ = _srs_context->get_id();
     
     return err;
 }
@@ -164,7 +167,10 @@ srs_error_t SrsForwarder::on_video(SrsSharedPtrMessage* shared_video)
 srs_error_t SrsForwarder::cycle()
 {
     srs_error_t err = srs_success;
-    
+
+    srs_trace("Forwarder: Start forward %s of source=[%s] to %s",
+        req->get_stream_url().c_str(), source_cid_.c_str(), ep_forward.c_str());
+
     while (true) {
         // We always check status first.
         // @see https://github.com/ossrs/srs/issues/1634#issuecomment-597571561

--- a/trunk/src/app/srs_app_forward.hpp
+++ b/trunk/src/app/srs_app_forward.hpp
@@ -33,6 +33,9 @@ private:
     std::string ep_forward;
     SrsRequest* req;
 private:
+    // The source or stream context id to bind to.
+    SrsContextId source_cid_;
+private:
     SrsCoroutine* trd;
 private:
     SrsOriginHub* hub;

--- a/trunk/src/utest/srs_utest_config.cpp
+++ b/trunk/src/utest/srs_utest_config.cpp
@@ -3943,6 +3943,9 @@ VOID TEST(ConfigEnvTest, CheckEnvValuesGlobal)
         SrsSetEnvConfig(pid, "SRS_PID", "xxx");
         EXPECT_STREQ("xxx", conf.get_pid_file().c_str());
 
+        SrsSetEnvConfig(log_tank, "SRS_SRS_LOG_TANK", "console");
+        EXPECT_FALSE(conf.get_log_tank_file());
+
         SrsSetEnvConfig(log_file, "SRS_SRS_LOG_FILE", "xxx2");
         EXPECT_STREQ("xxx2", conf.get_log_file().c_str());
 
@@ -3950,6 +3953,28 @@ VOID TEST(ConfigEnvTest, CheckEnvValuesGlobal)
         EXPECT_STREQ("xxx3", conf.get_log_level().c_str());
 
         SrsSetEnvConfig(log_level_v2, "SRS_SRS_LOG_LEVEL_V2", "xxx4");
+        EXPECT_STREQ("xxx4", conf.get_log_level_v2().c_str());
+
+        SrsSetEnvConfig(work_dir, "SRS_WORK_DIR", "xxx5");
+        EXPECT_STREQ("xxx5", conf.get_work_dir().c_str());
+    }
+
+    if (true) {
+        MockSrsConfig conf;
+
+        SrsSetEnvConfig(pid, "SRS_PID", "xxx");
+        EXPECT_STREQ("xxx", conf.get_pid_file().c_str());
+
+        SrsSetEnvConfig(log_tank, "SRS_LOG_TANK", "console");
+        EXPECT_FALSE(conf.get_log_tank_file());
+
+        SrsSetEnvConfig(log_file, "SRS_LOG_FILE", "xxx2");
+        EXPECT_STREQ("xxx2", conf.get_log_file().c_str());
+
+        SrsSetEnvConfig(log_level, "SRS_LOG_LEVEL", "xxx3");
+        EXPECT_STREQ("xxx3", conf.get_log_level().c_str());
+
+        SrsSetEnvConfig(log_level_v2, "SRS_LOG_LEVEL_V2", "xxx4");
         EXPECT_STREQ("xxx4", conf.get_log_level_v2().c_str());
 
         SrsSetEnvConfig(work_dir, "SRS_WORK_DIR", "xxx5");

--- a/trunk/src/utest/srs_utest_kernel2.cpp
+++ b/trunk/src/utest/srs_utest_kernel2.cpp
@@ -356,7 +356,7 @@ VOID TEST(KernelFileWriterTest, RealfileTest)
 {
     srs_error_t err;
 
-    string filename = "./test-realfile.log";
+    string filename = _srs_tmp_file_prefix + "test-realfile.log";
     MockFileRemover disposer(filename);
 
     if (true) {


### PR DESCRIPTION
Some config items are prefixed with `srs_`, for example:

```
srs_log_tank
srs_log_level
srs_log_file
```

So when configured with env, the key is:

```
SRS_SRS_LOG_TANK is parsed as srs.srs_log_tank
SRS_SRS_LOG_LEVEL is parsed as srs.srs_log_level
SRS_SRS_LOG_FILE is parsed as srs.srs_log_file
```

It confuses people, so I add some configs as alias:

```
SRS_LOG_LEVEL is equal to SRS_SRS_LOG_TANK
SRS_LOG_LEVEL is equal to SRS_SRS_LOG_LEVEL
SRS_LOG_FILE is equal to SRS_SRS_LOG_FILE
SRS_LOG_LEVEL_V2 is equal to SRS_SRS_LOG_LEVEL_V2
```

Both are available.