### PR TITLE
GB: Fix PSM parsing indicator bug. v6.0.15

### DIFF
--- a/trunk/src/kernel/srs_kernel_ps.cpp
+++ b/trunk/src/kernel/srs_kernel_ps.cpp
@@ -427,15 +427,16 @@ srs_error_t SrsPsPsmPacket::decode(SrsBuffer* stream)
         return srs_error_new(ERROR_GB_PS_HEADER, "requires 4 only %d bytes", stream->left());
     }
 
-    uint16_t r0 = stream->read_2bytes();
-    if ((r0&0x01) != 0x01) {
-        return srs_error_new(ERROR_GB_PS_HEADER, "invalid marker of 0x%#x", r0);
-    }
-
-    program_stream_map_version_ = (uint8_t)(r0&0x1f);
-    current_next_indicator_ = (uint8_t)((r0>>7) & 0x01);
+    uint8_t r0 = stream->read_1bytes();
+    program_stream_map_version_ = (r0&0x1f);
+    current_next_indicator_ = (r0>>7) & 0x01;
     if (!current_next_indicator_) {
         return srs_error_new(ERROR_GB_PS_HEADER, "invalid indicator of 0x%#x", r0);
+    }
+
+    uint8_t r1 = stream->read_1bytes();
+    if ((r1&0x01) != 0x01) {
+        return srs_error_new(ERROR_GB_PS_HEADER, "invalid marker of 0x%#x", r0);
     }
 
     program_stream_info_length_ = stream->read_2bytes();

--- a/trunk/src/kernel/srs_kernel_ps.cpp
+++ b/trunk/src/kernel/srs_kernel_ps.cpp
@@ -428,7 +428,7 @@ srs_error_t SrsPsPsmPacket::decode(SrsBuffer* stream)
     }
 
     uint8_t r0 = stream->read_1bytes();
-    program_stream_map_version_ = (r0&0x1f);
+    program_stream_map_version_ = r0&0x1f;
     current_next_indicator_ = (r0>>7) & 0x01;
     if (!current_next_indicator_) {
         return srs_error_new(ERROR_GB_PS_HEADER, "invalid indicator of 0x%#x", r0);

--- a/trunk/src/kernel/srs_kernel_ps.cpp
+++ b/trunk/src/kernel/srs_kernel_ps.cpp
@@ -436,7 +436,7 @@ srs_error_t SrsPsPsmPacket::decode(SrsBuffer* stream)
 
     uint8_t r1 = stream->read_1bytes();
     if ((r1&0x01) != 0x01) {
-        return srs_error_new(ERROR_GB_PS_HEADER, "invalid marker of 0x%#x", r0);
+        return srs_error_new(ERROR_GB_PS_HEADER, "invalid marker of 0x%#x", r1);
     }
 
     program_stream_info_length_ = stream->read_2bytes();


### PR DESCRIPTION
@see Table 2-35 – Program Stream map
@doc hls-mpeg-ts-iso13818-1.pdf, page 77.
```
    // 2B
    //      1bit current_next_indicator
    //      2bits reserved
    //      5bits program_stream_map_version
    //      7bits reserved
    //      1bit marker_bit '1'
    // This is a 1-bit field, when set to '1' indicates that the Program Stream Map sent is currently applicable. When
    // the bit is set to '0', it indicates that the Program Stream Map sent is not yet applicable and shall be the next
    // table to become valid.
    uint8_t current_next_indicator_;
    // This 5-bit field is the version number of the whole Program Stream Map. The version number shall be incremented
    // by 1 modulo 32 whenever the definition of the Program Stream Map changes. When the current_next_indicator is set
    // to '1', then the program_stream_map_version shall be that of the currently applicable Program Stream Map. When
    // the current_next_indicator is set to '0', then the program_stream_map_version shall be that of the next
    // applicable Program Stream Map.
    uint8_t program_stream_map_version_;
```

---------

`TRANS_BY_GPT3`