### PR TITLE
Kernel: Fix demux SPS error for NVENC and LARIX. v6.0.22

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-02-08, Merge [#3389](https://github.com/ossrs/srs/pull/3389): Kernel: Fix demux SPS error for NVENC and LARIX. v6.0.22 (#3389)
 * v6.0, 2023-01-29, Merge [#3371](https://github.com/ossrs/srs/pull/3371): HLS: support kick-off hls client. v6.0.21 (#3371)
 * v6.0, 2023-01-19, Merge [#3366](https://github.com/ossrs/srs/pull/3366): H265: Support HEVC over SRT. v6.0.20 (#465) (#3366)
 * v6.0, 2023-01-19, Merge [#3318](https://github.com/ossrs/srs/pull/3318): RTC: fix rtc publisher pli cid. v6.0.19 (#3318)

--- a/trunk/src/app/srs_app_srt_source.cpp
+++ b/trunk/src/app/srs_app_srt_source.cpp
@@ -651,7 +651,7 @@ srs_error_t SrsRtmpFromSrtBridge::check_vps_sps_pps_change(SrsTsMessage* msg)
     }
 
     if ((err = live_source_->on_video(&rtmp)) != srs_success) {
-        return srs_error_wrap(err, "srt to rtmp sps/pps");
+        return srs_error_wrap(err, "srt to rtmp vps/sps/pps");
     }
 
     return err;

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    21
+#define VERSION_REVISION    22
 
 #endif

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -893,7 +893,7 @@ srs_error_t SrsFormat::video_avc_demux(SrsBuffer* stream, int64_t timestamp)
         if (avc_packet_type == SrsVideoAvcFrameTraitSequenceHeader) {
             // TODO: demux vps/sps/pps for hevc
             if ((err = hevc_demux_hvcc(stream)) != srs_success) {
-                return srs_error_wrap(err, "demux hevc SPS/PPS");
+                return srs_error_wrap(err, "demux hevc VPS/SPS/PPS");
             }
         } else if (avc_packet_type == SrsVideoAvcFrameTraitNALU) {
             // TODO: demux nalu for hevc
@@ -1047,7 +1047,7 @@ srs_error_t SrsFormat::hevc_demux_hvcc(SrsBuffer* stream)
 
         // demux nalu
         if ((err = hevc_demux_vps_sps_pps(&hevc_unit)) != srs_success) {
-            return srs_error_wrap(err, "hevc demux vps sps pps failed");
+            return srs_error_wrap(err, "hevc demux vps/sps/pps failed");
         }
     }
 
@@ -1649,7 +1649,7 @@ srs_error_t SrsFormat::hevc_demux_pps_rbsp(char* rbsp, int nb_rbsp)
         pps->deblocking_filter_override_enabled_flag = bs.read_bit();
         // pps_deblocking_filter_disabled_flag  u(1)
         pps->pps_deblocking_filter_disabled_flag = bs.read_bit();
-        if (pps->pps_deblocking_filter_disabled_flag) {
+        if (!pps->pps_deblocking_filter_disabled_flag) {
             // pps_beta_offset_div2  se(v)
             if ((err = bs.read_bits_se(pps->pps_beta_offset_div2)) != srs_success) {
                 return srs_error_wrap(err, "pps_beta_offset_div2");

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -1742,76 +1742,35 @@ srs_error_t SrsFormat::hevc_demux_pps_rbsp(char* rbsp, int nb_rbsp)
     }
 
     if (pps->pps_range_extension_flag) {
-        if (pps->transform_skip_enabled_flag) {
-            if ((err = bs.read_bits_ue(pps->pps_range_extension.log2_max_transform_skip_block_size_minus2)) != srs_success) {
-                return srs_error_wrap(err, "log2_max_transform_skip_block_size_minus2");
-            }
-        }
-
-        if (!bs.require_bits(2)) {
-            return srs_error_new(ERROR_HEVC_DECODE_ERROR, "cross_component_prediction_enabled_flag requires 2 only %d bits", bs.left_bits());
-        }
-
-        // cross_component_prediction_enabled_flag  u(1)
-        pps->pps_range_extension.cross_component_prediction_enabled_flag = bs.read_bit();
-        // chroma_qp_offset_list_enabled_flag  u(1)
-        pps->pps_range_extension.chroma_qp_offset_list_enabled_flag = bs.read_bit();
-        if (pps->pps_range_extension.chroma_qp_offset_list_enabled_flag) {
-            // diff_cu_chroma_qp_offset_depth  ue(v)
-            if ((err = bs.read_bits_ue(pps->pps_range_extension.diff_cu_chroma_qp_offset_depth)) != srs_success) {
-                return srs_error_wrap(err, "diff_cu_chroma_qp_offset_depth");
-            }
-
-            // chroma_qp_offset_list_len_minus1  ue(v)
-            if ((err = bs.read_bits_ue(pps->pps_range_extension.chroma_qp_offset_list_len_minus1)) != srs_success) {
-                return srs_error_wrap(err, "chroma_qp_offset_list_len_minus1");
-            }
-
-            pps->pps_range_extension.cb_qp_offset_list.resize(pps->pps_range_extension.chroma_qp_offset_list_len_minus1);
-            pps->pps_range_extension.cr_qp_offset_list.resize(pps->pps_range_extension.chroma_qp_offset_list_len_minus1);
-
-            for (int i = 0; i < (int)pps->pps_range_extension.chroma_qp_offset_list_len_minus1; i++) {
-                // cb_qp_offset_list[i]  se(v)
-                if ((err = bs.read_bits_se(pps->pps_range_extension.cb_qp_offset_list[i])) != srs_success) {
-                    return srs_error_wrap(err, "cb_qp_offset_list");
-                }
-
-                // cr_qp_offset_list[i] se(v)
-                if ((err = bs.read_bits_se(pps->pps_range_extension.cr_qp_offset_list[i])) != srs_success) {
-                    return srs_error_wrap(err, "cr_qp_offset_list");
-                }
-            }
-        }
-
-        // log2_sao_offset_scale_luma  ue(v)
-        if ((err = bs.read_bits_ue(pps->pps_range_extension.log2_sao_offset_scale_luma)) != srs_success) {
-            return srs_error_wrap(err, "log2_sao_offset_scale_luma");
-        }
-
-        // log2_sao_offset_scale_chroma  ue(v)
-        if ((err = bs.read_bits_ue(pps->pps_range_extension.log2_sao_offset_scale_chroma)) != srs_success) {
-            return srs_error_wrap(err, "log2_sao_offset_scale_chroma");
-        }
+        // TODO: FIXME: add support for pps_range_extension()
+        // @see 7.3.2.3.2 Picture parameter set range extension syntax
+        // @doc ITU-T-H.265-2021.pdf, page 59.
     }
 
     if (pps->pps_multilayer_extension_flag){
         // pps_multilayer_extension, specified in Annex F
         // TODO: FIXME: add support for pps_multilayer_extension()
+        // @see F.7.3.2.3.4 Picture parameter set multilayer extension syntax
+        // @doc ITU-T-H.265-2021.pdf, page 475.
     }
 
     if (pps->pps_3d_extension_flag) {
         // pps_3d_extension, specified in Annex I
         // TODO: FIXME: add support for pps_3d_extension()
+        // @see I.7.3.2.3.7 Picture parameter set 3D extension syntax
+        // @doc ITU-T-H.265-2021.pdf, page 627.
     }
 
     if (pps->pps_scc_extension_flag) {
-        // pps_scc_extension_flag
         // TODO: FIXME: add support for pps_scc_extension()
+        // @see 7.3.2.3.3 Picture parameter set screen content coding extension syntax
+        // @doc ITU-T-H.265-2021.pdf, page 60.
     }
 
     if (pps->pps_extension_4bits) {
-        // more_rbsp_data
         // TODO: FIXME: add support for more_rbsp_data()
+        // @see 7.2 Specification of syntax functions and descriptors
+        // @doc ITU-T-H.265-2021.pdf, page 52.
     }
 
     // TODO: FIXME: rbsp_trailing_bits

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -928,6 +928,132 @@ srs_error_t SrsFormat::video_avc_demux(SrsBuffer* stream, int64_t timestamp)
 // LCOV_EXCL_START
 
 #ifdef SRS_H265
+// struct ptl
+SrsHevcProfileTierLevel::SrsHevcProfileTierLevel()
+{
+    general_profile_space = 0;
+    general_tier_flag = 0;
+    general_profile_idc = 0;
+    memset(general_profile_compatibility_flag, 0, 32);
+    general_progressive_source_flag = 0;
+    general_interlaced_source_flag = 0;
+    general_non_packed_constraint_flag = 0;
+    general_frame_only_constraint_flag = 0;
+    general_max_12bit_constraint_flag = 0;
+    general_max_10bit_constraint_flag = 0;
+    general_max_8bit_constraint_flag = 0;
+    general_max_422chroma_constraint_flag = 0;
+    general_max_420chroma_constraint_flag = 0;
+    general_max_monochrome_constraint_flag = 0;
+    general_intra_constraint_flag = 0;
+    general_one_picture_only_constraint_flag = 0;
+    general_lower_bit_rate_constraint_flag = 0;
+    general_max_14bit_constraint_flag = 0;
+    general_reserved_zero_7bits = 0;
+    general_reserved_zero_33bits = 0;
+    general_reserved_zero_34bits = 0;
+    general_reserved_zero_35bits = 0;
+    general_reserved_zero_43bits = 0;
+    general_inbld_flag = 0;
+    general_reserved_zero_bit = 0;
+    general_level_idc = 0;
+    memset(reserved_zero_2bits, 0, 8);
+}
+
+SrsHevcProfileTierLevel::~SrsHevcProfileTierLevel()
+{
+    sub_layer_profile_present_flag.clear();
+    sub_layer_level_present_flag.clear();
+    sub_layer_profile_space.clear();
+    sub_layer_tier_flag.clear();
+    sub_layer_profile_idc.clear();
+    sub_layer_profile_compatibility_flag.clear();
+    sub_layer_progressive_source_flag.clear();
+    sub_layer_interlaced_source_flag.clear();
+    sub_layer_non_packed_constraint_flag.clear();
+    sub_layer_frame_only_constraint_flag.clear();
+    sub_layer_max_12bit_constraint_flag.clear();
+    sub_layer_max_10bit_constraint_flag.clear();
+    sub_layer_max_8bit_constraint_flag.clear();
+    sub_layer_max_422chroma_constraint_flag.clear();
+    sub_layer_max_420chroma_constraint_flag.clear();
+    sub_layer_max_monochrome_constraint_flag.clear();
+    sub_layer_intra_constraint_flag.clear();
+    sub_layer_one_picture_only_constraint_flag.clear();
+    sub_layer_lower_bit_rate_constraint_flag.clear();
+    sub_layer_reserved_zero_7bits.clear();
+    sub_layer_reserved_zero_33bits.clear();
+    sub_layer_reserved_zero_34bits.clear();
+    sub_layer_reserved_zero_35bits.clear();
+    sub_layer_reserved_zero_43bits.clear();
+    sub_layer_inbld_flag.clear();
+    sub_layer_reserved_zero_bit.clear();
+    sub_layer_level_idc.clear();
+}
+
+srs_error_t SrsHevcProfileTierLevel::dumps(SrsHevcProfileTierLevel* ptl)
+{
+    srs_error_t err = srs_success;
+
+    general_profile_space = ptl->general_profile_space;
+    general_tier_flag = ptl->general_tier_flag;
+    general_profile_idc = ptl->general_profile_idc;
+    memcpy(general_profile_compatibility_flag, ptl->general_profile_compatibility_flag, 32);
+    general_progressive_source_flag = ptl->general_progressive_source_flag;
+    general_interlaced_source_flag = ptl->general_interlaced_source_flag;
+    general_non_packed_constraint_flag = ptl->general_non_packed_constraint_flag;
+    general_frame_only_constraint_flag = ptl->general_frame_only_constraint_flag;
+    general_max_12bit_constraint_flag = ptl->general_max_12bit_constraint_flag;
+    general_max_10bit_constraint_flag = ptl->general_max_10bit_constraint_flag;
+    general_max_8bit_constraint_flag = ptl->general_max_8bit_constraint_flag;
+    general_max_422chroma_constraint_flag = ptl->general_max_422chroma_constraint_flag;
+    general_max_420chroma_constraint_flag = ptl->general_max_420chroma_constraint_flag;
+    general_max_monochrome_constraint_flag = ptl->general_max_monochrome_constraint_flag;
+    general_intra_constraint_flag = ptl->general_intra_constraint_flag;
+    general_one_picture_only_constraint_flag = ptl->general_one_picture_only_constraint_flag;
+    general_lower_bit_rate_constraint_flag = ptl->general_lower_bit_rate_constraint_flag;
+    general_max_14bit_constraint_flag = ptl->general_max_14bit_constraint_flag;
+    general_reserved_zero_7bits = ptl->general_reserved_zero_7bits;
+    general_reserved_zero_33bits = ptl->general_reserved_zero_33bits;
+    general_reserved_zero_34bits = ptl->general_reserved_zero_34bits;
+    general_reserved_zero_35bits = ptl->general_reserved_zero_35bits;
+    general_reserved_zero_43bits = ptl->general_reserved_zero_43bits;
+    general_inbld_flag = ptl->general_inbld_flag;
+    general_reserved_zero_bit = ptl->general_reserved_zero_bit;
+    general_level_idc = ptl->general_level_idc;
+    memcpy(reserved_zero_2bits, ptl->reserved_zero_2bits, 8);
+
+    sub_layer_profile_present_flag.swap(ptl->sub_layer_profile_present_flag);
+    sub_layer_level_present_flag.swap(ptl->sub_layer_level_present_flag);
+    sub_layer_profile_space.swap(ptl->sub_layer_profile_space);
+    sub_layer_tier_flag.swap(ptl->sub_layer_tier_flag);
+    sub_layer_profile_idc.swap(ptl->sub_layer_profile_idc);
+    sub_layer_profile_compatibility_flag.swap(ptl->sub_layer_profile_compatibility_flag);
+    sub_layer_progressive_source_flag.swap(ptl->sub_layer_progressive_source_flag);
+    sub_layer_interlaced_source_flag.swap(ptl->sub_layer_interlaced_source_flag);
+    sub_layer_non_packed_constraint_flag.swap(ptl->sub_layer_non_packed_constraint_flag);
+    sub_layer_frame_only_constraint_flag.swap(ptl->sub_layer_frame_only_constraint_flag);
+    sub_layer_max_12bit_constraint_flag.swap(ptl->sub_layer_max_12bit_constraint_flag);
+    sub_layer_max_10bit_constraint_flag.swap(ptl->sub_layer_max_10bit_constraint_flag);
+    sub_layer_max_8bit_constraint_flag.swap(ptl->sub_layer_max_8bit_constraint_flag);
+    sub_layer_max_422chroma_constraint_flag.swap(ptl->sub_layer_max_422chroma_constraint_flag);
+    sub_layer_max_420chroma_constraint_flag.swap(ptl->sub_layer_max_420chroma_constraint_flag);
+    sub_layer_max_monochrome_constraint_flag.swap(ptl->sub_layer_max_monochrome_constraint_flag);
+    sub_layer_intra_constraint_flag.swap(ptl->sub_layer_intra_constraint_flag);
+    sub_layer_one_picture_only_constraint_flag.swap(ptl->sub_layer_one_picture_only_constraint_flag);
+    sub_layer_lower_bit_rate_constraint_flag.swap(ptl->sub_layer_lower_bit_rate_constraint_flag);
+    sub_layer_reserved_zero_7bits.swap(ptl->sub_layer_reserved_zero_7bits);
+    sub_layer_reserved_zero_33bits.swap(ptl->sub_layer_reserved_zero_33bits);
+    sub_layer_reserved_zero_34bits.swap(ptl->sub_layer_reserved_zero_34bits);
+    sub_layer_reserved_zero_35bits.swap(ptl->sub_layer_reserved_zero_35bits);
+    sub_layer_reserved_zero_43bits.swap(ptl->sub_layer_reserved_zero_43bits);
+    sub_layer_inbld_flag.swap(ptl->sub_layer_inbld_flag);
+    sub_layer_reserved_zero_bit.swap(ptl->sub_layer_reserved_zero_bit);
+    sub_layer_level_idc.swap(ptl->sub_layer_level_idc);
+
+    return err;
+}
+
 // Parse the hevc vps/sps/pps
 srs_error_t SrsFormat::hevc_demux_hvcc(SrsBuffer* stream)
 {
@@ -1339,7 +1465,7 @@ srs_error_t SrsFormat::hevc_demux_sps_rbsp(char* rbsp, int nb_rbsp)
     sps->sps_max_sub_layers_minus1 = sps_max_sub_layers_minus1;
     sps->sps_temporal_id_nesting_flag = sps_temporal_id_nesting_flag;
     sps->sps_seq_parameter_set_id = sps_seq_parameter_set_id;
-    memcpy((void*)&sps->ptl, &profile_tier_level, sizeof(profile_tier_level));
+    sps->ptl.dumps(&profile_tier_level);
 
     // chroma_format_idc  ue(v)
     if ((err = bs.read_bits_ue(sps->chroma_format_idc)) != srs_success) {

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -962,96 +962,6 @@ SrsHevcProfileTierLevel::SrsHevcProfileTierLevel()
 
 SrsHevcProfileTierLevel::~SrsHevcProfileTierLevel()
 {
-    sub_layer_profile_present_flag.clear();
-    sub_layer_level_present_flag.clear();
-    sub_layer_profile_space.clear();
-    sub_layer_tier_flag.clear();
-    sub_layer_profile_idc.clear();
-    sub_layer_profile_compatibility_flag.clear();
-    sub_layer_progressive_source_flag.clear();
-    sub_layer_interlaced_source_flag.clear();
-    sub_layer_non_packed_constraint_flag.clear();
-    sub_layer_frame_only_constraint_flag.clear();
-    sub_layer_max_12bit_constraint_flag.clear();
-    sub_layer_max_10bit_constraint_flag.clear();
-    sub_layer_max_8bit_constraint_flag.clear();
-    sub_layer_max_422chroma_constraint_flag.clear();
-    sub_layer_max_420chroma_constraint_flag.clear();
-    sub_layer_max_monochrome_constraint_flag.clear();
-    sub_layer_intra_constraint_flag.clear();
-    sub_layer_one_picture_only_constraint_flag.clear();
-    sub_layer_lower_bit_rate_constraint_flag.clear();
-    sub_layer_reserved_zero_7bits.clear();
-    sub_layer_reserved_zero_33bits.clear();
-    sub_layer_reserved_zero_34bits.clear();
-    sub_layer_reserved_zero_35bits.clear();
-    sub_layer_reserved_zero_43bits.clear();
-    sub_layer_inbld_flag.clear();
-    sub_layer_reserved_zero_bit.clear();
-    sub_layer_level_idc.clear();
-}
-
-srs_error_t SrsHevcProfileTierLevel::dumps(SrsHevcProfileTierLevel* ptl)
-{
-    srs_error_t err = srs_success;
-
-    general_profile_space = ptl->general_profile_space;
-    general_tier_flag = ptl->general_tier_flag;
-    general_profile_idc = ptl->general_profile_idc;
-    memcpy(general_profile_compatibility_flag, ptl->general_profile_compatibility_flag, 32);
-    general_progressive_source_flag = ptl->general_progressive_source_flag;
-    general_interlaced_source_flag = ptl->general_interlaced_source_flag;
-    general_non_packed_constraint_flag = ptl->general_non_packed_constraint_flag;
-    general_frame_only_constraint_flag = ptl->general_frame_only_constraint_flag;
-    general_max_12bit_constraint_flag = ptl->general_max_12bit_constraint_flag;
-    general_max_10bit_constraint_flag = ptl->general_max_10bit_constraint_flag;
-    general_max_8bit_constraint_flag = ptl->general_max_8bit_constraint_flag;
-    general_max_422chroma_constraint_flag = ptl->general_max_422chroma_constraint_flag;
-    general_max_420chroma_constraint_flag = ptl->general_max_420chroma_constraint_flag;
-    general_max_monochrome_constraint_flag = ptl->general_max_monochrome_constraint_flag;
-    general_intra_constraint_flag = ptl->general_intra_constraint_flag;
-    general_one_picture_only_constraint_flag = ptl->general_one_picture_only_constraint_flag;
-    general_lower_bit_rate_constraint_flag = ptl->general_lower_bit_rate_constraint_flag;
-    general_max_14bit_constraint_flag = ptl->general_max_14bit_constraint_flag;
-    general_reserved_zero_7bits = ptl->general_reserved_zero_7bits;
-    general_reserved_zero_33bits = ptl->general_reserved_zero_33bits;
-    general_reserved_zero_34bits = ptl->general_reserved_zero_34bits;
-    general_reserved_zero_35bits = ptl->general_reserved_zero_35bits;
-    general_reserved_zero_43bits = ptl->general_reserved_zero_43bits;
-    general_inbld_flag = ptl->general_inbld_flag;
-    general_reserved_zero_bit = ptl->general_reserved_zero_bit;
-    general_level_idc = ptl->general_level_idc;
-    memcpy(reserved_zero_2bits, ptl->reserved_zero_2bits, 8);
-
-    sub_layer_profile_present_flag.swap(ptl->sub_layer_profile_present_flag);
-    sub_layer_level_present_flag.swap(ptl->sub_layer_level_present_flag);
-    sub_layer_profile_space.swap(ptl->sub_layer_profile_space);
-    sub_layer_tier_flag.swap(ptl->sub_layer_tier_flag);
-    sub_layer_profile_idc.swap(ptl->sub_layer_profile_idc);
-    sub_layer_profile_compatibility_flag.swap(ptl->sub_layer_profile_compatibility_flag);
-    sub_layer_progressive_source_flag.swap(ptl->sub_layer_progressive_source_flag);
-    sub_layer_interlaced_source_flag.swap(ptl->sub_layer_interlaced_source_flag);
-    sub_layer_non_packed_constraint_flag.swap(ptl->sub_layer_non_packed_constraint_flag);
-    sub_layer_frame_only_constraint_flag.swap(ptl->sub_layer_frame_only_constraint_flag);
-    sub_layer_max_12bit_constraint_flag.swap(ptl->sub_layer_max_12bit_constraint_flag);
-    sub_layer_max_10bit_constraint_flag.swap(ptl->sub_layer_max_10bit_constraint_flag);
-    sub_layer_max_8bit_constraint_flag.swap(ptl->sub_layer_max_8bit_constraint_flag);
-    sub_layer_max_422chroma_constraint_flag.swap(ptl->sub_layer_max_422chroma_constraint_flag);
-    sub_layer_max_420chroma_constraint_flag.swap(ptl->sub_layer_max_420chroma_constraint_flag);
-    sub_layer_max_monochrome_constraint_flag.swap(ptl->sub_layer_max_monochrome_constraint_flag);
-    sub_layer_intra_constraint_flag.swap(ptl->sub_layer_intra_constraint_flag);
-    sub_layer_one_picture_only_constraint_flag.swap(ptl->sub_layer_one_picture_only_constraint_flag);
-    sub_layer_lower_bit_rate_constraint_flag.swap(ptl->sub_layer_lower_bit_rate_constraint_flag);
-    sub_layer_reserved_zero_7bits.swap(ptl->sub_layer_reserved_zero_7bits);
-    sub_layer_reserved_zero_33bits.swap(ptl->sub_layer_reserved_zero_33bits);
-    sub_layer_reserved_zero_34bits.swap(ptl->sub_layer_reserved_zero_34bits);
-    sub_layer_reserved_zero_35bits.swap(ptl->sub_layer_reserved_zero_35bits);
-    sub_layer_reserved_zero_43bits.swap(ptl->sub_layer_reserved_zero_43bits);
-    sub_layer_inbld_flag.swap(ptl->sub_layer_inbld_flag);
-    sub_layer_reserved_zero_bit.swap(ptl->sub_layer_reserved_zero_bit);
-    sub_layer_level_idc.swap(ptl->sub_layer_level_idc);
-
-    return err;
 }
 
 // Parse the hevc vps/sps/pps
@@ -1465,7 +1375,7 @@ srs_error_t SrsFormat::hevc_demux_sps_rbsp(char* rbsp, int nb_rbsp)
     sps->sps_max_sub_layers_minus1 = sps_max_sub_layers_minus1;
     sps->sps_temporal_id_nesting_flag = sps_temporal_id_nesting_flag;
     sps->sps_seq_parameter_set_id = sps_seq_parameter_set_id;
-    sps->ptl.dumps(&profile_tier_level);
+    sps->ptl = profile_tier_level;
 
     // chroma_format_idc  ue(v)
     if ((err = bs.read_bits_ue(sps->chroma_format_idc)) != srs_success) {
@@ -1866,37 +1776,9 @@ srs_error_t SrsFormat::hevc_demux_pps_rbsp(char* rbsp, int nb_rbsp)
         pps->pps_extension_4bits = bs.read_bits(4);
     }
 
-    if (pps->pps_range_extension_flag) {
-        // TODO: FIXME: add support for pps_range_extension()
-        // @see 7.3.2.3.2 Picture parameter set range extension syntax
-        // @doc ITU-T-H.265-2021.pdf, page 59.
-    }
-
-    if (pps->pps_multilayer_extension_flag){
-        // pps_multilayer_extension, specified in Annex F
-        // TODO: FIXME: add support for pps_multilayer_extension()
-        // @see F.7.3.2.3.4 Picture parameter set multilayer extension syntax
-        // @doc ITU-T-H.265-2021.pdf, page 475.
-    }
-
-    if (pps->pps_3d_extension_flag) {
-        // pps_3d_extension, specified in Annex I
-        // TODO: FIXME: add support for pps_3d_extension()
-        // @see I.7.3.2.3.7 Picture parameter set 3D extension syntax
-        // @doc ITU-T-H.265-2021.pdf, page 627.
-    }
-
-    if (pps->pps_scc_extension_flag) {
-        // TODO: FIXME: add support for pps_scc_extension()
-        // @see 7.3.2.3.3 Picture parameter set screen content coding extension syntax
-        // @doc ITU-T-H.265-2021.pdf, page 60.
-    }
-
-    if (pps->pps_extension_4bits) {
-        // TODO: FIXME: add support for more_rbsp_data()
-        // @see 7.2 Specification of syntax functions and descriptors
-        // @doc ITU-T-H.265-2021.pdf, page 52.
-    }
+    // TODO: FIXME: Implements it, you might parse remain bits for pic_parameter_set_rbsp.
+    // @see 7.3.2.3 Picture parameter set RBSP syntax
+    // @doc ITU-T-H.265-2021.pdf, page 59.
 
     // TODO: FIXME: rbsp_trailing_bits
 

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -1317,7 +1317,6 @@ srs_error_t SrsFormat::hevc_demux_sps_rbsp(char* rbsp, int nb_rbsp)
 
     // profile tier level...
     SrsHevcProfileTierLevel profile_tier_level;
-    memset((void*)&profile_tier_level, 0, sizeof(profile_tier_level));
     // profile_tier_level(1, sps_max_sub_layers_minus1)
     if ((err = hevc_demux_rbsp_ptl(&bs, &profile_tier_level, 1, sps_max_sub_layers_minus1)) != srs_success) {
         return srs_error_wrap(err, "sps rbsp ptl sps_max_sub_layers_minus1=%d", sps_max_sub_layers_minus1);

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -1317,7 +1317,7 @@ srs_error_t SrsFormat::hevc_demux_sps_rbsp(char* rbsp, int nb_rbsp)
 
     // profile tier level...
     SrsHevcProfileTierLevel profile_tier_level;
-    memset((void*)&profile_tier_level, 0, sizeof(SrsHevcProfileTierLevel));
+    memset((void*)&profile_tier_level, 0, sizeof(profile_tier_level));
     // profile_tier_level(1, sps_max_sub_layers_minus1)
     if ((err = hevc_demux_rbsp_ptl(&bs, &profile_tier_level, 1, sps_max_sub_layers_minus1)) != srs_success) {
         return srs_error_wrap(err, "sps rbsp ptl sps_max_sub_layers_minus1=%d", sps_max_sub_layers_minus1);
@@ -1340,7 +1340,7 @@ srs_error_t SrsFormat::hevc_demux_sps_rbsp(char* rbsp, int nb_rbsp)
     sps->sps_max_sub_layers_minus1 = sps_max_sub_layers_minus1;
     sps->sps_temporal_id_nesting_flag = sps_temporal_id_nesting_flag;
     sps->sps_seq_parameter_set_id = sps_seq_parameter_set_id;
-    memcpy(&(sps->ptl), &profile_tier_level, sizeof(SrsHevcProfileTierLevel));
+    memcpy((void*)&sps->ptl, &profile_tier_level, sizeof(profile_tier_level));
 
     // chroma_format_idc  ue(v)
     if ((err = bs.read_bits_ue(sps->chroma_format_idc)) != srs_success) {

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -551,6 +551,36 @@ struct SrsHevcProfileTierLevel
     std::vector<uint8_t> sub_layer_inbld_flag;
     std::vector<uint8_t> sub_layer_reserved_zero_bit;
     std::vector<uint8_t> sub_layer_level_idc;
+
+    SrsHevcProfileTierLevel() {
+        general_profile_space = 0;
+        general_tier_flag = 0;
+        general_profile_idc = 0;
+        memset(general_profile_compatibility_flag, 0, 32);
+        general_progressive_source_flag = 0;
+        general_interlaced_source_flag = 0;
+        general_non_packed_constraint_flag = 0;
+        general_frame_only_constraint_flag = 0;
+        general_max_12bit_constraint_flag = 0;
+        general_max_10bit_constraint_flag = 0;
+        general_max_8bit_constraint_flag = 0;
+        general_max_422chroma_constraint_flag = 0;
+        general_max_420chroma_constraint_flag = 0;
+        general_max_monochrome_constraint_flag = 0;
+        general_intra_constraint_flag = 0;
+        general_one_picture_only_constraint_flag = 0;
+        general_lower_bit_rate_constraint_flag = 0;
+        general_max_14bit_constraint_flag = 0;
+        general_reserved_zero_7bits = 0;
+        general_reserved_zero_33bits = 0;
+        general_reserved_zero_34bits = 0;
+        general_reserved_zero_35bits = 0;
+        general_reserved_zero_43bits = 0;
+        general_inbld_flag = 0;
+        general_reserved_zero_bit = 0;
+        general_level_idc = 0;
+        memset(reserved_zero_2bits, 0, 8);
+    }
 };
 
 /**

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -497,6 +497,7 @@ struct SrsHevcHvccNalu {
  */
 struct SrsHevcProfileTierLevel
 {
+public:
     uint8_t general_profile_space;
     uint8_t general_tier_flag;
     uint8_t general_profile_idc;
@@ -552,35 +553,12 @@ struct SrsHevcProfileTierLevel
     std::vector<uint8_t> sub_layer_reserved_zero_bit;
     std::vector<uint8_t> sub_layer_level_idc;
 
-    SrsHevcProfileTierLevel() {
-        general_profile_space = 0;
-        general_tier_flag = 0;
-        general_profile_idc = 0;
-        memset(general_profile_compatibility_flag, 0, 32);
-        general_progressive_source_flag = 0;
-        general_interlaced_source_flag = 0;
-        general_non_packed_constraint_flag = 0;
-        general_frame_only_constraint_flag = 0;
-        general_max_12bit_constraint_flag = 0;
-        general_max_10bit_constraint_flag = 0;
-        general_max_8bit_constraint_flag = 0;
-        general_max_422chroma_constraint_flag = 0;
-        general_max_420chroma_constraint_flag = 0;
-        general_max_monochrome_constraint_flag = 0;
-        general_intra_constraint_flag = 0;
-        general_one_picture_only_constraint_flag = 0;
-        general_lower_bit_rate_constraint_flag = 0;
-        general_max_14bit_constraint_flag = 0;
-        general_reserved_zero_7bits = 0;
-        general_reserved_zero_33bits = 0;
-        general_reserved_zero_34bits = 0;
-        general_reserved_zero_35bits = 0;
-        general_reserved_zero_43bits = 0;
-        general_inbld_flag = 0;
-        general_reserved_zero_bit = 0;
-        general_level_idc = 0;
-        memset(reserved_zero_2bits, 0, 8);
-    }
+public:
+    SrsHevcProfileTierLevel();
+    virtual ~SrsHevcProfileTierLevel();
+
+public:
+    virtual srs_error_t dumps(SrsHevcProfileTierLevel* ptl);
 };
 
 /**

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -556,9 +556,6 @@ public:
 public:
     SrsHevcProfileTierLevel();
     virtual ~SrsHevcProfileTierLevel();
-
-public:
-    virtual srs_error_t dumps(SrsHevcProfileTierLevel* ptl);
 };
 
 /**


### PR DESCRIPTION
When publish stream with  NVENC and LARIX by SRT or RTMP, maybe demux pps failed. Likely,
```
[2023-01-27 15:14:46.881][WARN][2338][81rhc7z9][22] parse ts packet err=code=4054(CasterTsHevcVps)(Invalid ts HEVC VPS for stream caster) : ts: handle ts message : ts: consume hevc video : check vps sps pps : srt to rtmp vps/sps/pps : format consume video : demux hevc VPS/SPS/PPS : hevc demux vps/sps/pps failed : scaling_list_delta_coef : read uev : no bytes for leadingZeroBits=1
thread [2338][81rhc7z9]: decode() [./src/kernel/srs_kernel_ts.cpp:273][errno=22]
thread [2338][81rhc7z9]: on_ts_message() [./src/app/srs_app_srt_source.cpp:364][errno=22]
thread [2338][81rhc7z9]: on_ts_video_hevc() [./src/app/srs_app_srt_source.cpp:607][errno=22]
thread [2338][81rhc7z9]: check_vps_sps_pps_change() [./src/app/srs_app_srt_source.cpp:654][errno=22]
thread [2338][81rhc7z9]: on_video_imp() [./src/app/srs_app_source.cpp:2437][errno=22]
thread [2338][81rhc7z9]: video_avc_demux() [./src/kernel/srs_kernel_codec.cpp:896][errno=22]
thread [2338][81rhc7z9]: hevc_demux_hvcc() [./src/kernel/srs_kernel_codec.cpp:1050][errno=22]
thread [2338][81rhc7z9]: hevc_demux_pps_rbsp() [./src/kernel/srs_kernel_codec.cpp:1698][errno=22]
thread [2338][81rhc7z9]: read_bits_se() [./src/kernel/srs_kernel_buffer.cpp:511][errno=22]
thread [2338][81rhc7z9]: read_bits_ue() [./src/kernel/srs_kernel_buffer.cpp:489][errno=22]
[2023-01-27 15:14:46.881][WARN][2338][81rhc7z9][22] parse ts packet err=code=4019(CasterTsPse)(Invalid ts PSE payload for stream caster) : ts: ts packet decode : ts: demux payload : ts: PES fresh packet length=0, us=0, cc=5
thread [2338][81rhc7z9]: decode() [./src/kernel/srs_kernel_ts.cpp:264][errno=22]
thread [2338][81rhc7z9]: decode() [./src/kernel/srs_kernel_ts.cpp:629][errno=22]
thread [2338][81rhc7z9]: decode() [./src/kernel/srs_kernel_ts.cpp:1955][errno=22]
```