### PR TITLE
Config: Error when both HLS and HTTP-TS enabled.

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-02-08, Merge [#3391](https://github.com/ossrs/srs/pull/3391): Config: Error when both HLS and HTTP-TS enabled. v6.0.23 (#3391)
 * v6.0, 2023-02-08, Merge [#3389](https://github.com/ossrs/srs/pull/3389): Kernel: Fix demux SPS error for NVENC and LARIX. v6.0.22 (#3389)
 * v6.0, 2023-01-29, Merge [#3371](https://github.com/ossrs/srs/pull/3371): HLS: support kick-off hls client. v6.0.21 (#3371)
 * v6.0, 2023-01-19, Merge [#3366](https://github.com/ossrs/srs/pull/3366): H265: Support HEVC over SRT. v6.0.20 (#465) (#3366)
@@ -36,6 +37,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-02-08, Merge [#3391](https://github.com/ossrs/srs/pull/3391): Config: Error when both HLS and HTTP-TS enabled. v5.0.140 (#3391)
 * v5.0, 2023-01-29, Merge [#3371](https://github.com/ossrs/srs/pull/3371): HLS: support kick-off hls client. v5.0.139 (#3371)
 * v5.0, 2023-01-19, Merge [#3318](https://github.com/ossrs/srs/pull/3318): RTC: fix rtc publisher pli cid. v5.0.138 (#3318)
 * v5.0, 2023-01-18, Merge [#3382](https://github.com/ossrs/srs/pull/3382): Rewrite research/api-server code by Go, remove Python. v5.0.137 (#3382)

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2503,9 +2503,6 @@ srs_error_t SrsConfig::check_normal_config()
     for (int n = 0; n < (int)vhosts.size(); n++) {
         SrsConfDirective* vhost = vhosts[n];
 
-        bool hls_enabled = false;
-        bool http_remux_ts = false;
-        int http_remux_cnt = 0;
         for (int i = 0; vhost && i < (int)vhost->directives.size(); i++) {
             SrsConfDirective* conf = vhost->at(i);
             string n = conf->name;
@@ -2581,25 +2578,13 @@ srs_error_t SrsConfig::check_normal_config()
                     }
                 }
             } else if (n == "http_remux") {
-                bool http_remux_enabled = false;
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
                     if (m != "enabled" && m != "mount" && m != "fast_cache" && m != "drop_if_not_match"
                         && m != "has_audio" && m != "has_video" && m != "guess_has_av") {
                         return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal vhost.http_remux.%s of %s", m.c_str(), vhost->arg0().c_str());
                     }
-
-                    // http_remux enabled
-                    if (m == "enabled" && conf->at(j)->arg0() == "on") {
-                        http_remux_enabled = true;
-                    }
-
-                    // check mount suffix '.ts'
-                    if (http_remux_enabled && m == "mount" && srs_string_ends_with(conf->at(j)->arg0(), ".ts")) {
-                        http_remux_ts = true;
-                    }
                 }
-                http_remux_cnt++;
             } else if (n == "dash") {
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
@@ -2622,10 +2607,6 @@ srs_error_t SrsConfig::check_normal_config()
                     // TODO: FIXME: remove it in future.
                     if (m == "hls_storage" || m == "hls_mount") {
                         srs_warn("HLS RAM is removed in SRS3+");
-                    }
-
-                    if (m == "enabled" && conf->at(j)->arg0() == "on") {
-                        hls_enabled = true;
                     }
                 }
             } else if (n == "http_hooks") {
@@ -2692,20 +2673,10 @@ srs_error_t SrsConfig::check_normal_config()
                 }
             }
         }
-
-        // check valid http-remux count
-        if (http_remux_cnt > 1) {
-            return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "vhost.http_remux only one but count=%d of %s", http_remux_cnt, vhost->arg0().c_str());
-        }
-
-        // check hls conflict with http-ts
-        if (hls_enabled && http_remux_ts) {
-            return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "vhost.hls conflict with vhost.http-ts of %s", vhost->arg0().c_str());
-        }
     }
 
     ////////////////////////////////////////////////////////////////////////
-    // check HLS with HTTP-FLV
+    // check HLS with HTTP-TS
     ////////////////////////////////////////////////////////////////////////
     for (int n = 0; n < (int)vhosts.size(); n++) {
         SrsConfDirective* vhost = vhosts[n];

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2503,9 +2503,6 @@ srs_error_t SrsConfig::check_normal_config()
     for (int n = 0; n < (int)vhosts.size(); n++) {
         SrsConfDirective* vhost = vhosts[n];
 
-        bool hls_enabled = false;
-        bool http_remux_ts = false;
-        int http_remux_cnt = 0;
         for (int i = 0; vhost && i < (int)vhost->directives.size(); i++) {
             SrsConfDirective* conf = vhost->at(i);
             string n = conf->name;
@@ -2581,25 +2578,13 @@ srs_error_t SrsConfig::check_normal_config()
                     }
                 }
             } else if (n == "http_remux") {
-                bool http_remux_enabled = false;
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
                     if (m != "enabled" && m != "mount" && m != "fast_cache" && m != "drop_if_not_match"
                         && m != "has_audio" && m != "has_video" && m != "guess_has_av") {
                         return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal vhost.http_remux.%s of %s", m.c_str(), vhost->arg0().c_str());
                     }
-
-                    // http_remux enabled
-                    if (m == "enabled" && conf->at(j)->arg0() == "on") {
-                        http_remux_enabled = true;
-                    }
-
-                    // check mount suffix '.ts'
-                    if (http_remux_enabled && m == "mount" && srs_string_ends_with(conf->at(j)->arg0(), ".ts")) {
-                        http_remux_ts = true;
-                    }
                 }
-                http_remux_cnt++;
             } else if (n == "dash") {
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
@@ -2622,10 +2607,6 @@ srs_error_t SrsConfig::check_normal_config()
                     // TODO: FIXME: remove it in future.
                     if (m == "hls_storage" || m == "hls_mount") {
                         srs_warn("HLS RAM is removed in SRS3+");
-                    }
-
-                    if (m == "enabled" && conf->at(j)->arg0() == "on") {
-                        hls_enabled = true;
                     }
                 }
             } else if (n == "http_hooks") {
@@ -2692,6 +2673,48 @@ srs_error_t SrsConfig::check_normal_config()
                 }
             }
         }
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // check HLS with HTTP-FLV
+    ////////////////////////////////////////////////////////////////////////
+    for (int n = 0; n < (int)vhosts.size(); n++) {
+        SrsConfDirective* vhost = vhosts[n];
+
+        bool hls_enabled = false;
+        bool http_remux_ts = false;
+        int http_remux_cnt = 0;
+
+        for (int i = 0; vhost && i < (int)vhost->directives.size(); i++) {
+            SrsConfDirective* conf = vhost->at(i);
+            string n = conf->name;
+            if (n == "http_remux") {
+                bool http_remux_enabled = false;
+                for (int j = 0; j < (int)conf->directives.size(); j++) {
+                    string m = conf->at(j)->name;
+
+                    // http_remux enabled
+                    if (m == "enabled" && conf->at(j)->arg0() == "on") {
+                        http_remux_enabled = true;
+                    }
+
+                    // check mount suffix '.ts'
+                    if (http_remux_enabled && m == "mount" && srs_string_ends_with(conf->at(j)->arg0(), ".ts")) {
+                        http_remux_ts = true;
+                    }
+                }
+                http_remux_cnt++;
+            } else if (n == "hls") {
+                for (int j = 0; j < (int)conf->directives.size(); j++) {
+                    string m = conf->at(j)->name;
+
+                    // hls enabled
+                    if (m == "enabled" && conf->at(j)->arg0() == "on") {
+                        hls_enabled = true;
+                    }
+                }
+            }
+        }
 
         // check valid http-remux count
         if (http_remux_cnt > 1) {
@@ -2703,6 +2726,7 @@ srs_error_t SrsConfig::check_normal_config()
             return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "vhost.hls conflict with vhost.http-ts of %s", vhost->arg0().c_str());
         }
     }
+
     // check ingest id unique.
     for (int i = 0; i < (int)vhosts.size(); i++) {
         SrsConfDirective* vhost = vhosts[i];

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2503,6 +2503,9 @@ srs_error_t SrsConfig::check_normal_config()
     for (int n = 0; n < (int)vhosts.size(); n++) {
         SrsConfDirective* vhost = vhosts[n];
 
+        bool hls_enabled = false;
+        bool http_remux_ts = false;
+        int http_remux_cnt = 0;
         for (int i = 0; vhost && i < (int)vhost->directives.size(); i++) {
             SrsConfDirective* conf = vhost->at(i);
             string n = conf->name;
@@ -2578,13 +2581,25 @@ srs_error_t SrsConfig::check_normal_config()
                     }
                 }
             } else if (n == "http_remux") {
+                bool http_remux_enabled = false;
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
                     if (m != "enabled" && m != "mount" && m != "fast_cache" && m != "drop_if_not_match"
                         && m != "has_audio" && m != "has_video" && m != "guess_has_av") {
                         return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal vhost.http_remux.%s of %s", m.c_str(), vhost->arg0().c_str());
                     }
+
+                    // http_remux enabled
+                    if (m == "enabled" && conf->at(j)->arg0() == "on") {
+                        http_remux_enabled = true;
+                    }
+
+                    // check mount suffix '.ts'
+                    if (http_remux_enabled && m == "mount" && srs_string_ends_with(conf->at(j)->arg0(), ".ts")) {
+                        http_remux_ts = true;
+                    }
                 }
+                http_remux_cnt++;
             } else if (n == "dash") {
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
@@ -2607,6 +2622,10 @@ srs_error_t SrsConfig::check_normal_config()
                     // TODO: FIXME: remove it in future.
                     if (m == "hls_storage" || m == "hls_mount") {
                         srs_warn("HLS RAM is removed in SRS3+");
+                    }
+
+                    if (m == "enabled" && conf->at(j)->arg0() == "on") {
+                        hls_enabled = true;
                     }
                 }
             } else if (n == "http_hooks") {
@@ -2672,6 +2691,16 @@ srs_error_t SrsConfig::check_normal_config()
                     }
                 }
             }
+        }
+
+        // check valid http-remux count
+        if (http_remux_cnt > 1) {
+            return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "vhost.http_remux only one but count=%d of %s", http_remux_cnt, vhost->arg0().c_str());
+        }
+
+        // check hls conflict with http-ts
+        if (hls_enabled && http_remux_ts) {
+            return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "vhost.hls conflict with vhost.http-ts of %s", vhost->arg0().c_str());
         }
     }
     // check ingest id unique.

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    139
+#define VERSION_REVISION    140
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    22
+#define VERSION_REVISION    23
 
 #endif


### PR DESCRIPTION
If enable HLS and HTTP-TS, SRS can't identify the protocol(HLS or HTTP-TS). So when SRS start, we detect the conflict for HLS and HTTP-TS.
### Test1
```config
vhost __defaultVhost__ {
    http_remux {
        enabled     on;
        mount       [vhost]/[app]/[stream].ts;
    }
    hls {
        enabled         on;
        hls_path        ./objs/nginx/html;
        hls_fragment    10;
        hls_window      60;
    }
}
```
### Test2
```config
vhost __defaultVhost__ {
    http_remux {
        enabled     off;
        mount       [vhost]/[app]/[stream].ts;
    }
    hls {
        enabled         on;
        hls_path        ./objs/nginx/html;
        hls_fragment    10;
        hls_window      60;
    }
}
```
### Test3
```config
vhost __defaultVhost__ {
    http_remux {
        enabled     on;
        mount       [vhost]/[app]/[stream].ts;
    }
    hls {
        enabled         off;
        hls_path        ./objs/nginx/html;
        hls_fragment    10;
        hls_window      60;
    }
}
```
### Test4
```config
vhost __defaultVhost__ {
    http_remux {
        enabled     on;
        mount       [vhost]/[app]/[stream].ts;
    }
    http_remux {
        enabled     on;
        mount       [vhost]/[app]/[stream].flv;
    }
}
```
### Test5
```config
vhost __defaultVhost__ {
    http_remux {
        enabled     off;
        mount       [vhost]/[app]/[stream].ts;
    }
    http_remux {
        enabled     on;
        mount       [vhost]/[app]/[stream].flv;
    }
}
```