### PR TITLE
WebRTC: Add error tips when coverting HEVC to RTC.

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -974,13 +974,6 @@ srs_error_t SrsRtcFromRtmpBridge::on_video(SrsSharedPtrMessage* msg)
         return err;
     }
 
-    // WebRTC NOT support HEVC.
-#ifdef SRS_H265
-    if (format->vcodec->id == SrsVideoCodecIdHEVC) {
-        return err;
-    }
-#endif
-
     // cache the sequence header if h264
     bool is_sequence_header = SrsFlvVideo::sh(msg->payload, msg->size);
     if (is_sequence_header && (err = meta->update_vsh(msg)) != srs_success) {
@@ -995,6 +988,11 @@ srs_error_t SrsRtcFromRtmpBridge::on_video(SrsSharedPtrMessage* msg)
     // such as H.263 codec
     if (!format->vcodec) {
         return err;
+    }
+
+    // WebRTC NOT support HEVC, RTMP NOT support VP8/VP9.
+    if (format->vcodec->id != SrsVideoCodecIdAVC && format->vcodec->id != SrsVideoCodecIdAV1) {
+        return srs_error_new(ERROR_RTC_CODEC_ERROR, "WebRTC not support %s", srs_video_codec_id2str(format->vcodec->id).c_str());
     }
 
     bool has_idr = false;

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -372,7 +372,8 @@
     XX(ERROR_RTC_TCP_SIZE                  , 5032, "RtcTcpSize", "RTC TCP packet size is invalid") \
     XX(ERROR_RTC_TCP_PACKET                , 5033, "RtcTcpStun", "RTC TCP first packet must be STUN") \
     XX(ERROR_RTC_TCP_STUN                  , 5034, "RtcTcpSession", "RTC TCP packet is invalid for session not found") \
-    XX(ERROR_RTC_TCP_UNIQUE                , 5035, "RtcUnique", "RTC only support one UDP or TCP network")
+    XX(ERROR_RTC_TCP_UNIQUE                , 5035, "RtcUnique", "RTC only support one UDP or TCP network") \
+    XX(ERROR_RTC_CODEC_ERROR               , 5036, "RtcCodec", "RTC not support codec type")
 
 /**************************************************/
 /* SRT protocol error. */


### PR DESCRIPTION
When you push hevc stream by opening `rtmp_to_rtc on`, we'll return error tips for `WebRTC not support HEVC`.
### Publish RTMP HEVC
```log
[2023-02-15 17:33:40.292][ERROR][26356][5e93kr4y][4] serve error code=5036(RtcCodec)(RTC not support codec type) : service cycle : rtmp: stream service : rtmp: receive thread : handle publish message : rtmp: consume message : rtmp: consume video : bridge consume video : WebRTC not support HEVC
thread [26356][5e93kr4y]: do_cycle() [./src/app/srs_app_rtmp_conn.cpp:262][errno=4]
thread [26356][5e93kr4y]: service_cycle() [./src/app/srs_app_rtmp_conn.cpp:456][errno=4]
thread [26356][5e93kr4y]: do_publishing() [./src/app/srs_app_rtmp_conn.cpp:1024][errno=22]
thread [26356][5e93kr4y]: consume() [./src/app/srs_app_recv_thread.cpp:380][errno=22]
thread [26356][5e93kr4y]: handle_publish_message() [./src/app/srs_app_rtmp_conn.cpp:1161][errno=22]
thread [26356][5e93kr4y]: process_publish_message() [./src/app/srs_app_rtmp_conn.cpp:1189][errno=22]
thread [26356][5e93kr4y]: on_video_imp() [./src/app/srs_app_source.cpp:2468][errno=22]
thread [26356][5e93kr4y]: on_video() [./src/app/srs_app_rtc_source.cpp:996][errno=22](Interrupted system call)
```
### Publish SRT HEVC
```log
[2023-02-15 17:38:44.437][WARN][26356][749051kk][4] parse ts packet err=code=4019(CasterTsPse)(Invalid ts PSE payload for stream caster) : ts: ts packet decode : ts: demux payload : ts: PES fresh packet length=0, us=0, cc=5
thread [26356][749051kk]: decode() [./src/kernel/srs_kernel_ts.cpp:265][errno=4]
thread [26356][749051kk]: decode() [./src/kernel/srs_kernel_ts.cpp:630][errno=4]
thread [26356][749051kk]: decode() [./src/kernel/srs_kernel_ts.cpp:1956][errno=4]
```
### Publish GB HEVC
```log
```