### PR TITLE
Compatible with legacy RTMP URL. v5.0.142. v6.0.27

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-02-22, Compatible with legacy RTMP URL. v6.0.27
 * v6.0, 2023-02-16, Merge [#3411](https://github.com/ossrs/srs/pull/3411): HEVC: Fix nalu vec duplicate when h265 vps/sps/pps demux. v6.0.26 (#3411)
 * v6.0, 2023-02-14, Merge [#3408](https://github.com/ossrs/srs/pull/3408): GB: Support H.265 for GB28181. v6.0.25 (#3408)
 * v6.0, 2023-02-12, Merge [#3409](https://github.com/ossrs/srs/pull/3409): SRT: Reduce latency to 200ms of srt2rtc.conf. v6.0.24 (#3409)
@@ -40,6 +41,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-02-22, Compatible with legacy RTMP URL. v5.0.142
 * v5.0, 2023-02-12, Merge [#3409](https://github.com/ossrs/srs/pull/3409): SRT: Reduce latency to 200ms of srt2rtc.conf. v5.0.141 (#3409)
 * v5.0, 2023-02-08, Merge [#3391](https://github.com/ossrs/srs/pull/3391): Config: Error when both HLS and HTTP-TS enabled. v5.0.140 (#3391)
 * v5.0, 2023-01-29, Merge [#3371](https://github.com/ossrs/srs/pull/3371): HLS: support kick-off hls client. v5.0.139 (#3371)

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    141
+#define VERSION_REVISION    142
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    26
+#define VERSION_REVISION    27
 
 #endif

--- a/trunk/src/protocol/srs_protocol_rtmp_stack.hpp
+++ b/trunk/src/protocol/srs_protocol_rtmp_stack.hpp
@@ -397,11 +397,14 @@ public:
     // The client ip.
     std::string ip;
 public:
-    // The tcUrl: rtmp://request_vhost:port/app/stream
-    // support pass vhost in query string, such as:
-    //    rtmp://ip:port/app?vhost=request_vhost/stream
-    //    rtmp://ip:port/app...vhost...request_vhost/stream
+    // Support pass vhost in RTMP URL, such as:
+    //    rtmp://VHOST:port/app/stream
+    //    rtmp://ip:port/app/stream?vhost=VHOST
+    //    rtmp://ip:port/app?vhost=VHOST/stream
+    //    rtmp://ip:port/app...vhost...VHOST/stream
+    // While tcUrl is url without stream.
     std::string tcUrl;
+public:
     std::string pageUrl;
     std::string swfUrl;
     double objectEncoding;

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -45,13 +45,11 @@ using namespace std;
 
 void srs_discovery_tc_url(string tcUrl, string& schema, string& host, string& vhost, string& app, string& stream, int& port, string& param)
 {
-    string fullUrl = tcUrl;
-
     // For compatibility, transform
     //      rtmp://ip/app...vhost...VHOST/stream
     // to typical format:
     //      rtmp://ip/app?vhost=VHOST/stream
-    fullUrl = srs_string_replace(fullUrl, "...vhost...", "?vhost=");
+    string fullUrl = srs_string_replace(tcUrl, "...vhost...", "?vhost=");
 
     // Standard URL is:
     //      rtmp://ip/app/app2/stream?k=v

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -45,10 +45,17 @@ using namespace std;
 
 void srs_discovery_tc_url(string tcUrl, string& schema, string& host, string& vhost, string& app, string& stream, int& port, string& param)
 {
+    string fullUrl = tcUrl;
+
+    // For compatibility, transform
+    //      rtmp://ip/app...vhost...VHOST/stream
+    // to typical format:
+    //      rtmp://ip/app?vhost=VHOST/stream
+    fullUrl = srs_string_replace(fullUrl, "...vhost...", "?vhost=");
+
     // Standard URL is:
     //      rtmp://ip/app/app2/stream?k=v
     // Where after last slash is stream.
-    string fullUrl = tcUrl;
     fullUrl += stream.empty() ? "/" : (stream.at(0) == '/' ? stream : "/" + stream);
     fullUrl += param.empty() ? "" : (param.at(0) == '?' ? param : "?" + param);
 

--- a/trunk/src/utest/srs_utest_rtmp.cpp
+++ b/trunk/src/utest/srs_utest_rtmp.cpp
@@ -3049,6 +3049,35 @@ VOID TEST(ProtocolRTMPTest, GenerateURL)
     }
 }
 
+VOID TEST(ProtocolRTMPTest, DiscoveryTcUrlLegacy)
+{
+    if (true) {
+        int port; std::string tcUrl, schema, ip, vhost, app, stream, param;
+
+        tcUrl = "rtmp://127.0.0.1:19351/live...vhost...demo"; stream= "show";
+        srs_discovery_tc_url(tcUrl, schema, ip, vhost, app, stream, port, param);
+        EXPECT_STREQ("rtmp", schema.c_str());
+        EXPECT_STREQ("127.0.0.1", ip.c_str());
+        EXPECT_STREQ("demo", vhost.c_str());
+        EXPECT_STREQ("live", app.c_str());
+        EXPECT_STREQ("show", stream.c_str());
+        EXPECT_EQ(19351, port);
+    }
+
+    if (true) {
+        int port; std::string tcUrl, schema, ip, vhost, app, stream, param;
+
+        tcUrl = "rtmp://127.0.0.1:19351/live...vhost...demo&token=abc"; stream= "show";
+        srs_discovery_tc_url(tcUrl, schema, ip, vhost, app, stream, port, param);
+        EXPECT_STREQ("rtmp", schema.c_str());
+        EXPECT_STREQ("127.0.0.1", ip.c_str());
+        EXPECT_STREQ("demo", vhost.c_str());
+        EXPECT_STREQ("live", app.c_str());
+        EXPECT_STREQ("show", stream.c_str());
+        EXPECT_EQ(19351, port);
+    }
+}
+
 /**
 * discovery tcUrl to schema/vhost/host/port/app
 */


### PR DESCRIPTION
For compatibility, transform
  rtmp://ip/app...vhost...VHOST/stream
to typical format:
  rtmp://ip/app/stream?vhost=VHOST

This is used for some legacy devices, which does not support standard HTTP url query string.

