### PR TITLE
set max width for rtc_media_player

### DIFF
--- a/trunk/research/players/rtc_player.html
+++ b/trunk/research/players/rtc_player.html
@@ -50,7 +50,7 @@
     </div>
 
     <label></label>
-    <video id="rtc_media_player" controls autoplay></video>
+    <video id="rtc_media_player" controls autoplay style="max-width: 100%;"></video>
 
     <label></label>
     SessionID: <span id='sessionid'></span>


### PR DESCRIPTION
The webrtc player's size is default to that of the video stream, which may often overflow, so we should set its max width as 100% (note that the height is auto so we don't have to set it).