### PR TITLE
HEVC: webrtc support hevc on safari. v6.0.34

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-03-07, Merge [#3441](https://github.com/ossrs/srs/pull/3441): HEVC: webrtc support hevc on safari. v6.0.34 (#3441)
 * v6.0, 2023-03-07, Merge [#3446](https://github.com/ossrs/srs/pull/3446): WebRTC: Warning if no ideal profile. v6.0.33 (#3446)
 * v6.0, 2023-03-06, Merge [#3445](https://github.com/ossrs/srs/pull/3445): Support configure for generic linux. v6.0.32 (#3445)
 * v6.0, 2023-03-04, Merge [#3105](https://github.com/ossrs/srs/pull/3105): Kickoff publisher when stream is idle, which means no players. v6.0.31 (#3105)

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -2675,7 +2675,6 @@ srs_error_t SrsRtcConnection::negotiate_publish_capability(SrsRtcUserConfig* ruc
                 break;
             }
         } else if (remote_media_desc.is_video() && ruc->codec_ == "hevc") {
-            srs_trace("remote_media_desc.is_video");
             std::vector<SrsMediaPayloadType> payloads = remote_media_desc.find_media_with_encoding_name("H265");
             if (payloads.empty()) {
                 return srs_error_new(ERROR_RTC_SDP_EXCHANGE, "no found valid H.265 payload type");

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    33
+#define VERSION_REVISION    34
 
 #endif


### PR DESCRIPTION
This PR is for HEVC over WebRTC, right now only Safari.

> Note that Chrome/Firefox/Edge does not support HEVC over WebRTC, for detail, please see #465

First, please build SRS with HEVC support:

```bash
./configure --h265=on
make
./objs/srs -c conf/rtc.conf
```

Then, please enable HEVC for WebRTC in Safari, `Develop > Experimental Features > WebRTC H265 codec`

<img width="480" alt="image" src="https://user-images.githubusercontent.com/2777660/222900991-fe160b90-eaa6-4b9f-b123-4bd10767a350.png">

Next, open [webrtc://127.0.0.1/live/livestream?codec=hevc](http://127.0.0.1:8080/players/rtc_publisher.html?codec=hevc) in Safari to push WebRTC stream to SRS:

<img width="480" alt="image" src="https://user-images.githubusercontent.com/2777660/222900734-b79f1536-793b-4716-a15e-d379b2b3c4bd.png">

Now, open [webrtc://127.0.0.1/live/livestream?codec=hevc](http://127.0.0.1:8080/players/rtc_player.html?codec=hevc) in Safari to pull the WebRTC stream.

<img width="480" alt="image" src="https://user-images.githubusercontent.com/2777660/222901160-94b5fdb5-6528-4fc0-994a-50154b965cfb.png">

If want to view the log for Safari WebRTC:

<img width="480" alt="image" src="https://user-images.githubusercontent.com/13824813/222022259-53f62615-90b7-4ba5-a089-821524b22e2e.png">

<img width="480" alt="image" src="https://user-images.githubusercontent.com/13824813/222022407-0e03eb17-4693-4f7a-b706-4b6d4615953d.png">
