### PR TITLE
[deprecated]API: add basic auth for http api

### DIFF
--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -203,6 +203,19 @@ http_api {
         # Always off by https://github.com/ossrs/srs/issues/2653
         #allow_update off;
     }
+    # the auth is authentication for http api
+    auth {
+        # whether enable the HTTP AUTH.
+        # Overwrite by env SRS_HTTP_API_AUTH_ENABLED
+        # default: off
+        enabled         on;
+        # The username of Basic authentication:
+        # Overwrite by env SRS_HTTP_API_AUTH_USERNAME
+        username        admin;
+        # The password of Basic authentication:
+        # Overwrite by env SRS_HTTP_API_AUTH_PASSWORD
+        password        admin;
+    }
     # For https_api or HTTPS API.
     https {
         # Whether enable HTTPS API.

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -1021,6 +1021,12 @@ public:
     virtual bool get_raw_api_allow_query();
     // Whether allow rpc update.
     virtual bool get_raw_api_allow_update();
+    // Whether http api auth enabled.
+    virtual bool get_http_api_auth_enabled();
+    // Get the http api auth username.
+    virtual std::string get_http_api_auth_username();
+    // Get the http api auth password.
+    virtual std::string get_http_api_auth_password();
 // https api section
 private:
     SrsConfDirective* get_https_api();

--- a/trunk/src/app/srs_app_http_conn.cpp
+++ b/trunk/src/app/srs_app_http_conn.cpp
@@ -230,11 +230,9 @@ srs_error_t SrsHttpConn::process_request(ISrsHttpResponseWriter* w, ISrsHttpMess
     srs_trace("HTTP #%d %s:%d %s %s, content-length=%" PRId64 "", rid, ip.c_str(), port,
         r->method_str().c_str(), r->url().c_str(), r->content_length());
 
-    if (_srs_config->get_http_api_auth_enabled()) {
-        if ((err = do_auth(w, r)) != srs_success) {
-            w->write_header(SRS_CONSTS_HTTP_Unauthorized);
-            return w->final_request();
-        }
+    if ((err = do_auth(w, r)) != srs_success) {
+        w->write_header(SRS_CONSTS_HTTP_Unauthorized);
+        return w->final_request();
     }
 
     // use cors server mux to serve http request, which will proxy to http_remux.
@@ -253,36 +251,47 @@ srs_error_t SrsHttpConn::on_disconnect(SrsRequest* req)
 
 srs_error_t SrsHttpConn::do_auth(ISrsHttpResponseWriter* w, ISrsHttpMessage* r)
 {
+    // there are 2 class type of http_mux:
+    //      SrsHttpServer for http_server, listen on 8080 by default;
+    //      ISrsHttpServeMux for http_api, listen on 1985 by default;
+    // 'do_auth' only for http_api
+    SrsHttpServer* mux = dynamic_cast<SrsHttpServer*>(http_mux);
+    if (mux) {
+        return srs_success;
+    }
+
+    if (!_srs_config->get_http_api_auth_enabled()) {
+        return srs_success;
+    }
+
     std::string path = r->path();
-    // For /api/, /rtc/, Basic Auth
-    if (path.find("/api/") != std::string::npos || 
-        path.find("/rtc/") != std::string::npos) {
-        std::string auth = r->header()->get("Authorization");
-        if (auth.empty()) {
-            w->header()->set("WWW-Authenticate", SRS_HTTP_AUTH_PREFIX_BASIC);
-            return srs_error_new(SRS_CONSTS_HTTP_Unauthorized, "empty Authorization");
-        }
+    std::string auth = r->header()->get("Authorization");
+    if (auth.empty()) {
+        w->header()->set("WWW-Authenticate", SRS_HTTP_AUTH_PREFIX_BASIC);
+        return srs_error_new(SRS_CONSTS_HTTP_Unauthorized, "empty Authorization");
+    }
 
-        if (!srs_string_contains(auth, SRS_HTTP_AUTH_PREFIX_BASIC)) {
-            return srs_error_new(SRS_CONSTS_HTTP_Unauthorized, 
-                "invalid authorization header. Must start with %s", SRS_HTTP_AUTH_PREFIX_BASIC);
-        }
+    if (!srs_string_contains(auth, SRS_HTTP_AUTH_PREFIX_BASIC)) {
+        return srs_error_new(SRS_CONSTS_HTTP_Unauthorized, 
+            "invalid authorization header. Must start with %s", SRS_HTTP_AUTH_PREFIX_BASIC);
+    }
 
-        std::string token = srs_string_trim_start(auth, SRS_HTTP_AUTH_PREFIX_BASIC);
-        if (token.empty()) {
-            return srs_error_new(SRS_CONSTS_HTTP_Unauthorized, "empty token");
-        }
+    std::string token = srs_string_trim_start(auth, SRS_HTTP_AUTH_PREFIX_BASIC);
+    if (token.empty()) {
+        return srs_error_new(SRS_CONSTS_HTTP_Unauthorized, "empty token");
+    }
 
-        std::string base64 = base64_decode(token);
-        std::vector<std::string> user_pwd = srs_string_split(base64, ":");
-        if (user_pwd.size() != 2) {
-            return srs_error_new(SRS_CONSTS_HTTP_Unauthorized, "invalid token");
-        }
+    std::string base64 = base64_decode(token);
 
-        srs_warn("Get Authorization: %s, username: %s, password: %s", auth.c_str(), user_pwd[0].c_str(), user_pwd[1].c_str());
-        if (_srs_config->get_http_api_auth_username() != user_pwd[0] || _srs_config->get_http_api_auth_password() != user_pwd[1]) {
-            return srs_error_new(SRS_CONSTS_HTTP_Unauthorized, "match token");
-        }
+    // should be 'username:password'
+    std::vector<std::string> user_pwd = srs_string_split(base64, ":");
+    if (user_pwd.size() != 2) {
+        return srs_error_new(SRS_CONSTS_HTTP_Unauthorized, "invalid token");
+    }
+
+    srs_warn("Get Authorization: %s, username: %s, password: %s", auth.c_str(), user_pwd[0].c_str(), user_pwd[1].c_str());
+    if (_srs_config->get_http_api_auth_username() != user_pwd[0] || _srs_config->get_http_api_auth_password() != user_pwd[1]) {
+        return srs_error_new(SRS_CONSTS_HTTP_Unauthorized, "match token");
     }
 
     return srs_success;

--- a/trunk/src/app/srs_app_http_conn.hpp
+++ b/trunk/src/app/srs_app_http_conn.hpp
@@ -104,6 +104,7 @@ private:
     // e.g. log msg of connection and report to other system.
     // @param request: request which is converted by the last http message.
     virtual srs_error_t on_disconnect(SrsRequest* req);
+    virtual srs_error_t do_auth(ISrsHttpResponseWriter* w, ISrsHttpMessage* r);
 public:
     // Get the HTTP message handler.
     virtual ISrsHttpConnOwner* handler();

--- a/trunk/src/kernel/srs_kernel_utility.cpp
+++ b/trunk/src/kernel/srs_kernel_utility.cpp
@@ -1303,3 +1303,54 @@ int srs_chunk_header_c3(int perfer_cid, uint32_t timestamp, char* cache, int nb_
     return (int)(p - cache);
 }
 
+
+inline bool is_base64(unsigned char c)
+{
+    return (std::isalnum(c) || (c == '+') || (c == '/'));
+}
+
+std::string base64_decode(const std::string &encoded_string)
+{
+    static const std::string base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    int in_len = encoded_string.size();
+    int i = 0;
+    int j = 0;
+    int in_ = 0;
+    unsigned char char_array_4[4], char_array_3[3];
+    std::string ret;
+
+    while (in_len-- && (encoded_string[in_] != '=') && is_base64(encoded_string[in_])) {
+        char_array_4[i++] = encoded_string[in_];
+        in_++;
+        if (i == 4) {
+            for (i = 0; i < 4; i++)
+                char_array_4[i] = base64_chars.find(char_array_4[i]);
+
+            char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+            char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+            char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+            for (i = 0; (i < 3); i++)
+                ret += char_array_3[i];
+            i = 0;
+        }
+    }
+
+    if (i) {
+        for (j = i; j < 4; j++)
+            char_array_4[j] = 0;
+
+        for (j = 0; j < 4; j++)
+            char_array_4[j] = base64_chars.find(char_array_4[j]);
+
+        char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+        char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+        char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+        for (j = 0; (j < i - 1); j++)
+            ret += char_array_3[j];
+    }
+
+    return ret;
+}

--- a/trunk/src/kernel/srs_kernel_utility.hpp
+++ b/trunk/src/kernel/srs_kernel_utility.hpp
@@ -167,5 +167,8 @@ extern int srs_chunk_header_c3(int perfer_cid, uint32_t timestamp, char* cache, 
     typedef int (*srs_gettimeofday_t) (struct timeval* tv, struct timezone* tz);
 #endif
 
+// 
+extern std::string base64_decode(const std::string &encoded_string);
+
 #endif
 

--- a/trunk/src/utest/srs_utest_config.cpp
+++ b/trunk/src/utest/srs_utest_config.cpp
@@ -3639,7 +3639,7 @@ VOID TEST(ConfigMainTest, CheckVhostConfig5)
 
     if (true) {
         MockSrsConfig conf;
-        HELPER_ASSERT_SUCCESS(conf.parse(_MIN_OK_CONF "http_api{enabled on;listen xxx;crossdomain off;raw_api {enabled on;allow_reload on;allow_query on;allow_update on;}}"));
+        HELPER_ASSERT_SUCCESS(conf.parse(_MIN_OK_CONF "http_api{enabled on;listen xxx;crossdomain off;auth {enabled on;username admin;password 123456;}raw_api {enabled on;allow_reload on;allow_query on;allow_update on;}}"));
         EXPECT_TRUE(conf.get_http_api_enabled());
         EXPECT_STREQ("xxx", conf.get_http_api_listen().c_str());
         EXPECT_FALSE(conf.get_http_api_crossdomain());
@@ -3647,6 +3647,9 @@ VOID TEST(ConfigMainTest, CheckVhostConfig5)
         EXPECT_TRUE(conf.get_raw_api_allow_reload());
         EXPECT_FALSE(conf.get_raw_api_allow_query()); // Always disabled
         EXPECT_FALSE(conf.get_raw_api_allow_update()); // Always disabled
+        EXPECT_TRUE(conf.get_http_api_auth_enabled());
+        EXPECT_STREQ("admin", conf.get_http_api_auth_username().c_str());
+        EXPECT_STREQ("123456", conf.get_http_api_auth_password().c_str());
     }
 
     if (true) {
@@ -4112,6 +4115,15 @@ VOID TEST(ConfigEnvTest, CheckEnvValuesHttpApi)
 
         SrsSetEnvConfig(http_api_crossdomain, "SRS_HTTP_API_CROSSDOMAIN", "off");
         EXPECT_FALSE(conf.get_http_api_crossdomain());
+
+        SrsSetEnvConfig(http_api_auth_enabled, "SRS_HTTP_API_AUTH_ENABLED", "on");
+        EXPECT_TRUE(conf.get_http_api_auth_enabled());
+
+        SrsSetEnvConfig(http_api_auth_username, "SRS_HTTP_API_AUTH_USERNAME", "admin");
+        EXPECT_STREQ("admin", conf.get_http_api_auth_username().c_str());
+
+        SrsSetEnvConfig(http_api_auth_password, "SRS_HTTP_API_AUTH_PASSWORD", "123456");
+        EXPECT_STREQ("123456", conf.get_http_api_auth_password().c_str());
     }
 
     if (true) {


### PR DESCRIPTION
Usage: 
Make sure to maintain the markdown structure.
```
curl http://admin:admin@ip:1985/api/v1/clients/
```
Alternatively, if you access it directly through a browser, it will prompt you to enter a username and password.
![image](https://user-images.githubusercontent.com/4254164/223633086-40a20359-1ae7-4bf2-9f7a-b226f993072f.png)


---------

`TRANS_BY_GPT3`