### PR TITLE
HttpConn: Check nb_chunk no memory address.

### DIFF
--- a/trunk/src/protocol/srs_protocol_http_conn.cpp
+++ b/trunk/src/protocol/srs_protocol_http_conn.cpp
@@ -1162,7 +1162,9 @@ srs_error_t SrsHttpResponseReader::read_chunked(void* data, size_t nb_data, ssiz
     if (nb_chunk <= 0) {
         // for the last chunk, eof.
         is_eof = true;
-        *nb_read = 0;
+        if (nb_read) {
+            *nb_read = 0;
+        }
     } else {
         // for not the last chunk, there must always exists bytes.
         // left bytes in chunk, read some.


### PR DESCRIPTION
When HTTP request run this function ` io->read`, maybe coredump by `nb_chunk` no address.
```c++
srs_error_t SrsHttpxConn::pop_message(ISrsHttpMessage** preq)
{
    srs_error_t err = srs_success;

    ISrsProtocolReadWriter* io = io_;
    if (ssl) {
        io = ssl;
    }

    // Check user interrupt by interval.
    io->set_recv_timeout(3 * SRS_UTIME_SECONDS);

    // We start a socket to read the stfd, which is writing by conn.
    // It's ok, because conn never read it after processing the HTTP request.
    // drop all request body.
    static char body[SRS_HTTP_READ_CACHE_BYTES];
    while (true) {
        if ((err = conn->pull()) != srs_success) {
            return srs_error_wrap(err, "timeout");
        }

        if ((err = io->read(body, SRS_HTTP_READ_CACHE_BYTES, NULL)) != srs_success) {
            // Because we use timeout to check trd state, so we should ignore any timeout.
            if (srs_error_code(err) == ERROR_SOCKET_TIMEOUT) {
                srs_freep(err);
                continue;
            }

            return srs_error_wrap(err, "read response");
        }
    }
    
    return err;
}
```