### PR TITLE
WebRTC: Support configure CANDIDATE by env

### DIFF
--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -549,7 +549,8 @@ if [[ $SRS_RTC == YES && $SRS_FFMPEG_OPUS != YES ]]; then
         rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/opus ${SRS_OBJS}/opus &&
         tar xf ${SRS_WORKDIR}/3rdparty/opus-1.3.1.tar.gz -C ${SRS_OBJS}/${SRS_PLATFORM} &&
         (
-            cd ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 &&
+            # Opus requires automake 1.15, and fails for automake 1.16+, so we run autoreconf to fix it.
+            cd ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 && autoreconf &&
             ./configure --prefix=${SRS_DEPENDS_LIBS}/${SRS_PLATFORM}/3rdpatry/opus --enable-static $OPUS_OPTIONS
         ) &&
         make -C ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 ${SRS_JOBS} &&

--- a/trunk/conf/hevc.flv.conf
+++ b/trunk/conf/hevc.flv.conf
@@ -2,6 +2,10 @@ listen              1935;
 max_connections     1000;
 daemon              off;
 srs_log_tank        console;
+srt_server {
+    enabled on;
+    listen 10080;
+}
 http_api {
     enabled         on;
     listen          1985;
@@ -11,6 +15,10 @@ http_server {
     listen          8080;
 }
 vhost __defaultVhost__ {
+    srt {
+        enabled     on;
+        srt_to_rtmp on;
+    }
     http_remux {
         enabled     on;
         mount       [vhost]/[app]/[stream].flv;

--- a/trunk/conf/hevc.ts.conf
+++ b/trunk/conf/hevc.ts.conf
@@ -2,6 +2,10 @@ listen              1935;
 max_connections     1000;
 daemon              off;
 srs_log_tank        console;
+srt_server {
+    enabled on;
+    listen 10080;
+}
 http_api {
     enabled         on;
     listen          1985;
@@ -11,6 +15,10 @@ http_server {
     listen          8080;
 }
 vhost __defaultVhost__ {
+    srt {
+        enabled     on;
+        srt_to_rtmp on;
+    }
     http_remux {
         enabled     on;
         mount       [vhost]/[app]/[stream].ts;

--- a/trunk/conf/realtime.conf
+++ b/trunk/conf/realtime.conf
@@ -7,7 +7,7 @@ max_connections     1000;
 daemon              off;
 srs_log_tank        console;
 vhost __defaultVhost__ {
-    tcp_nodelay     on
+    tcp_nodelay     on;
     min_latency     on;
     
     play {

--- a/trunk/conf/realtime.flv.conf
+++ b/trunk/conf/realtime.flv.conf
@@ -17,7 +17,7 @@ vhost __defaultVhost__ {
         mount       [vhost]/[app]/[stream].flv;
     }
 
-    tcp_nodelay     on
+    tcp_nodelay     on;
     min_latency     on;
     
     play {

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -4030,7 +4030,12 @@ int SrsConfig::get_rtc_server_listen()
 
 std::string SrsConfig::get_rtc_server_candidates()
 {
-    SRS_OVERWRITE_BY_ENV_STRING("srs.rtc_server.candidate"); // SRS_RTC_SERVER_CANDIDATE
+    // Note that the value content might be an environment variable.
+    std::string eval = srs_getenv("srs.rtc_server.candidate"); // SRS_RTC_SERVER_CANDIDATE
+    if (!eval.empty()) {
+        if (!srs_string_starts_with(eval, "$")) return eval;
+        SRS_OVERWRITE_BY_ENV_STRING(eval);
+    }
 
     static string DEFAULT = "*";
 

--- a/trunk/src/utest/srs_utest_config.cpp
+++ b/trunk/src/utest/srs_utest_config.cpp
@@ -4311,6 +4311,23 @@ VOID TEST(ConfigEnvTest, CheckEnvValuesRtcServer)
         SrsSetEnvConfig(rtc_server_black_hole_addr, "SRS_RTC_SERVER_BLACK_HOLE_ADDR", "xxx");
         EXPECT_STREQ("xxx", conf.get_rtc_server_black_hole_addr().c_str());
     }
+
+    if (true) {
+        MockSrsConfig conf;
+
+        SrsSetEnvConfig(rtc_server_candidates, "SRS_RTC_SERVER_CANDIDATE", "192.168.0.1");
+        EXPECT_STREQ("192.168.0.1", conf.get_rtc_server_candidates().c_str());
+
+        SrsSetEnvConfig(rtc_server_candidates2, "SRS_RTC_SERVER_CANDIDATE", "MY_CANDIDATE");
+        EXPECT_STREQ("MY_CANDIDATE", conf.get_rtc_server_candidates().c_str());
+
+        SrsSetEnvConfig(rtc_server_candidates3, "SRS_RTC_SERVER_CANDIDATE", "$MY_CANDIDATE");
+        EXPECT_STREQ("*", conf.get_rtc_server_candidates().c_str());
+
+        SrsSetEnvConfig(candidates, "MY_CANDIDATE", "192.168.0.11");
+        SrsSetEnvConfig(rtc_server_candidates4, "SRS_RTC_SERVER_CANDIDATE", "$MY_CANDIDATE");
+        EXPECT_STREQ("192.168.0.11", conf.get_rtc_server_candidates().c_str());
+    }
 }
 
 VOID TEST(ConfigEnvTest, CheckEnvValuesVhostRtc)


### PR DESCRIPTION
In dockerfile, we can set the default RTC candidate to env:

```
ENV SRS_RTC_SERVER_CANDIDATE=\$CANDIDATE
CMD ["./objs/srs", "-e"]
```

When starts a docker container, user can setup the candidate by env:

```
docker run --rm -it --env CANDIDATE=1.2.3.4 ossrs/srs:5
```

We should parse the content of SRS_RTC_SERVER_CANDIDATE as env variable name and parse it again.
