### PR TITLE
support webrtc-datachannel sdp exchange

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,9 @@ on:
     tags:
       - v6*
 
-# Declare default permissions as read only.
-permissions: read-all
+# For draft, need write permission.
+permissions:
+  contents: write
 
 jobs:
   envs:
@@ -284,6 +285,7 @@ jobs:
     needs:
       - envs
       - docker-srs
+      - test
     steps:
       ##################################################################################################################
       - name: Covert output to env

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -549,7 +549,8 @@ if [[ $SRS_RTC == YES && $SRS_FFMPEG_OPUS != YES ]]; then
         rm -rf ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 ${SRS_OBJS}/${SRS_PLATFORM}/3rdpatry/opus ${SRS_OBJS}/opus &&
         tar xf ${SRS_WORKDIR}/3rdparty/opus-1.3.1.tar.gz -C ${SRS_OBJS}/${SRS_PLATFORM} &&
         (
-            cd ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 &&
+            # Opus requires automake 1.15, and fails for automake 1.16+, so we run autoreconf to fix it.
+            cd ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 && autoreconf &&
             ./configure --prefix=${SRS_DEPENDS_LIBS}/${SRS_PLATFORM}/3rdpatry/opus --enable-static $OPUS_OPTIONS
         ) &&
         make -C ${SRS_OBJS}/${SRS_PLATFORM}/opus-1.3.1 ${SRS_JOBS} &&

--- a/trunk/conf/hevc.flv.conf
+++ b/trunk/conf/hevc.flv.conf
@@ -2,6 +2,10 @@ listen              1935;
 max_connections     1000;
 daemon              off;
 srs_log_tank        console;
+srt_server {
+    enabled on;
+    listen 10080;
+}
 http_api {
     enabled         on;
     listen          1985;
@@ -11,6 +15,10 @@ http_server {
     listen          8080;
 }
 vhost __defaultVhost__ {
+    srt {
+        enabled     on;
+        srt_to_rtmp on;
+    }
     http_remux {
         enabled     on;
         mount       [vhost]/[app]/[stream].flv;

--- a/trunk/conf/hevc.ts.conf
+++ b/trunk/conf/hevc.ts.conf
@@ -2,6 +2,10 @@ listen              1935;
 max_connections     1000;
 daemon              off;
 srs_log_tank        console;
+srt_server {
+    enabled on;
+    listen 10080;
+}
 http_api {
     enabled         on;
     listen          1985;
@@ -11,6 +15,10 @@ http_server {
     listen          8080;
 }
 vhost __defaultVhost__ {
+    srt {
+        enabled     on;
+        srt_to_rtmp on;
+    }
     http_remux {
         enabled     on;
         mount       [vhost]/[app]/[stream].ts;

--- a/trunk/conf/realtime.conf
+++ b/trunk/conf/realtime.conf
@@ -7,7 +7,7 @@ max_connections     1000;
 daemon              off;
 srs_log_tank        console;
 vhost __defaultVhost__ {
-    tcp_nodelay     on
+    tcp_nodelay     on;
     min_latency     on;
     
     play {

--- a/trunk/conf/realtime.flv.conf
+++ b/trunk/conf/realtime.flv.conf
@@ -17,7 +17,7 @@ vhost __defaultVhost__ {
         mount       [vhost]/[app]/[stream].flv;
     }
 
-    tcp_nodelay     on
+    tcp_nodelay     on;
     min_latency     on;
     
     play {

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-03-22, Merge [#3427](https://github.com/ossrs/srs/pull/3427): WHIP: Support DELETE resource for Larix Broadcaster. v6.0.36 (#3427)
 * v6.0, 2023-03-20, Merge [#3460](https://github.com/ossrs/srs/pull/3460): WebRTC: Support WHIP/WHEP players. v6.0.35 (#3460)
 * v6.0, 2023-03-07, Merge [#3441](https://github.com/ossrs/srs/pull/3441): HEVC: webrtc support hevc on safari. v6.0.34 (#3441)
 * v6.0, 2023-03-07, Merge [#3446](https://github.com/ossrs/srs/pull/3446): WebRTC: Warning if no ideal profile. v6.0.33 (#3446)
@@ -49,6 +50,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-03-22, Merge [#3427](https://github.com/ossrs/srs/pull/3427): WHIP: Support DELETE resource for Larix Broadcaster. v5.0.148 (#3427)
 * v5.0, 2023-03-20, Merge [#3460](https://github.com/ossrs/srs/pull/3460): WebRTC: Support WHIP/WHEP players. v5.0.147 (#3460)
 * v5.0, 2023-03-07, Merge [#3446](https://github.com/ossrs/srs/pull/3446): WebRTC: Warning if no ideal profile. v5.0.146 (#3446)
 * v5.0, 2023-03-06, Merge [#3445](https://github.com/ossrs/srs/pull/3445): Support configure for generic linux. v5.0.145 (#3445)

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-03-25, Merge [#3477](https://github.com/ossrs/srs/pull/3477): Remove unneccessary NULL check in srs_freep. v6.0.38 (#3477)
 * v6.0, 2023-03-25, Merge [#3455](https://github.com/ossrs/srs/pull/3455): RTC: Call on_play before create session, for it might be freed for timeout. v6.0.37 (#3455)
 * v6.0, 2023-03-22, Merge [#3427](https://github.com/ossrs/srs/pull/3427): WHIP: Support DELETE resource for Larix Broadcaster. v6.0.36 (#3427)
 * v6.0, 2023-03-20, Merge [#3460](https://github.com/ossrs/srs/pull/3460): WebRTC: Support WHIP/WHEP players. v6.0.35 (#3460)
@@ -51,6 +52,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-03-25, Merge [#3477](https://github.com/ossrs/srs/pull/3477): Remove unneccessary NULL check in srs_freep. v5.0.150 (#3477)
 * v5.0, 2023-03-25, Merge [#3455](https://github.com/ossrs/srs/pull/3455): RTC: Call on_play before create session, for it might be freed for timeout. v5.0.149 (#3455)
 * v5.0, 2023-03-22, Merge [#3427](https://github.com/ossrs/srs/pull/3427): WHIP: Support DELETE resource for Larix Broadcaster. v5.0.148 (#3427)
 * v5.0, 2023-03-20, Merge [#3460](https://github.com/ossrs/srs/pull/3460): WebRTC: Support WHIP/WHEP players. v5.0.147 (#3460)

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-03-25, Merge [#3455](https://github.com/ossrs/srs/pull/3455): RTC: Call on_play before create session, for it might be freed for timeout. v6.0.37 (#3455)
 * v6.0, 2023-03-22, Merge [#3427](https://github.com/ossrs/srs/pull/3427): WHIP: Support DELETE resource for Larix Broadcaster. v6.0.36 (#3427)
 * v6.0, 2023-03-20, Merge [#3460](https://github.com/ossrs/srs/pull/3460): WebRTC: Support WHIP/WHEP players. v6.0.35 (#3460)
 * v6.0, 2023-03-07, Merge [#3441](https://github.com/ossrs/srs/pull/3441): HEVC: webrtc support hevc on safari. v6.0.34 (#3441)
@@ -50,6 +51,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-03-25, Merge [#3455](https://github.com/ossrs/srs/pull/3455): RTC: Call on_play before create session, for it might be freed for timeout. v5.0.149 (#3455)
 * v5.0, 2023-03-22, Merge [#3427](https://github.com/ossrs/srs/pull/3427): WHIP: Support DELETE resource for Larix Broadcaster. v5.0.148 (#3427)
 * v5.0, 2023-03-20, Merge [#3460](https://github.com/ossrs/srs/pull/3460): WebRTC: Support WHIP/WHEP players. v5.0.147 (#3460)
 * v5.0, 2023-03-07, Merge [#3446](https://github.com/ossrs/srs/pull/3446): WebRTC: Warning if no ideal profile. v5.0.146 (#3446)

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-03-27, Merge [#3450](https://github.com/ossrs/srs/pull/3450): WebRTC: Error message carries the SDP when failed. v6.0.39 (#3450)
 * v6.0, 2023-03-25, Merge [#3477](https://github.com/ossrs/srs/pull/3477): Remove unneccessary NULL check in srs_freep. v6.0.38 (#3477)
 * v6.0, 2023-03-25, Merge [#3455](https://github.com/ossrs/srs/pull/3455): RTC: Call on_play before create session, for it might be freed for timeout. v6.0.37 (#3455)
 * v6.0, 2023-03-22, Merge [#3427](https://github.com/ossrs/srs/pull/3427): WHIP: Support DELETE resource for Larix Broadcaster. v6.0.36 (#3427)
@@ -52,6 +53,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-03-27, Merge [#3450](https://github.com/ossrs/srs/pull/3450): WebRTC: Error message carries the SDP when failed. v5.0.151 (#3450)
 * v5.0, 2023-03-25, Merge [#3477](https://github.com/ossrs/srs/pull/3477): Remove unneccessary NULL check in srs_freep. v5.0.150 (#3477)
 * v5.0, 2023-03-25, Merge [#3455](https://github.com/ossrs/srs/pull/3455): RTC: Call on_play before create session, for it might be freed for timeout. v5.0.149 (#3455)
 * v5.0, 2023-03-22, Merge [#3427](https://github.com/ossrs/srs/pull/3427): WHIP: Support DELETE resource for Larix Broadcaster. v5.0.148 (#3427)

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-03-20, Merge [#3460](https://github.com/ossrs/srs/pull/3460): WebRTC: Support WHIP/WHEP players. v6.0.35 (#3460)
 * v6.0, 2023-03-07, Merge [#3441](https://github.com/ossrs/srs/pull/3441): HEVC: webrtc support hevc on safari. v6.0.34 (#3441)
 * v6.0, 2023-03-07, Merge [#3446](https://github.com/ossrs/srs/pull/3446): WebRTC: Warning if no ideal profile. v6.0.33 (#3446)
 * v6.0, 2023-03-06, Merge [#3445](https://github.com/ossrs/srs/pull/3445): Support configure for generic linux. v6.0.32 (#3445)
@@ -48,6 +49,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-03-20, Merge [#3460](https://github.com/ossrs/srs/pull/3460): WebRTC: Support WHIP/WHEP players. v5.0.147 (#3460)
 * v5.0, 2023-03-07, Merge [#3446](https://github.com/ossrs/srs/pull/3446): WebRTC: Warning if no ideal profile. v5.0.146 (#3446)
 * v5.0, 2023-03-06, Merge [#3445](https://github.com/ossrs/srs/pull/3445): Support configure for generic linux. v5.0.145 (#3445)
 * v5.0, 2023-03-04, Merge [#3105](https://github.com/ossrs/srs/pull/3105): Kickoff publisher when stream is idle, which means no players. v5.0.144 (#3105)

--- a/trunk/doc/Features.md
+++ b/trunk/doc/Features.md
@@ -61,6 +61,7 @@ The features of SRS.
 - [x] RTC: [Experimental] Support transmux RTC to RTMP, [#2093](https://github.com/ossrs/srs/issues/2093). v4.0.95
 - [x] RTC: [Experimental] Support WebRTC over TCP directly, [#2852](https://github.com/ossrs/srs/issues/2852). v5.0.60+
 - [x] RTC: [Experimental] Support WHIP(WebRTC-HTTP ingestion protocol), [#3170](https://github.com/ossrs/srs/issues/3170). v5.0.61+
+- [x] RTC: [Experimental] Support [Larix Broadcaster](https://softvelum.com/larix/), [#3476](https://github.com/ossrs/srs/issues/3476). v5.0.148+
 - [x] Other: Support ingesting([CN](https://ossrs.net/lts/zh-cn/docs/v4/doc/ingest), [EN](https://ossrs.io/lts/en-us/docs/v4/doc/ingest)) other protocols to SRS by FFMPEG. v1.0.0+
 - [x] Other: Support forwarding([CN](https://ossrs.net/lts/zh-cn/docs/v4/doc/forward), [EN](https://ossrs.io/lts/en-us/docs/v4/doc/forward)) to other RTMP servers. v1.0.0+
 - [x] Other: Support transcoding([CN](https://ossrs.net/lts/zh-cn/docs/v4/doc/ffmpeg), [EN](https://ossrs.io/lts/en-us/docs/v4/doc/ffmpeg)) by FFMPEG. v1.0.0+

--- a/trunk/doc/Features.md
+++ b/trunk/doc/Features.md
@@ -74,6 +74,7 @@ The features of SRS.
 - [x] Other: [Experimental] Support pushing MPEG-TS over UDP, please read [bug #250](https://github.com/ossrs/srs/issues/250). v2.0.111+
 - [x] Other: [Experimental] Support pushing FLV over HTTP POST, please read wiki([CN](https://ossrs.net/lts/zh-cn/docs/v4/doc/streamer#push-http-flv-to-srs), [EN](https://ossrs.io/lts/en-us/docs/v4/doc/streamer#push-http-flv-to-srs)). v2.0.163+
 - [x] Other: [Experimental] Support push stream by GB28181, [#3176](https://github.com/ossrs/srs/issues/3176). v5.0.74+
+- [x] Other: Support WHIP/WHEP player, [#3460](https://github.com/ossrs/srs/pull/3460). v5.0.147+
 - [ ] System: Proxy to extend origin servers, [#3138](https://github.com/ossrs/srs/issues/3138).
 - [ ] System: Support source cleanup for idle streams, [#413](https://github.com/ossrs/srs/issues/413).
 - [ ] System: Support JT808 and JT1708 for transport, [#3420](https://github.com/ossrs/srs/issues/3420).

--- a/trunk/research/players/js/srs.page.js
+++ b/trunk/research/players/js/srs.page.js
@@ -17,6 +17,8 @@ function update_nav() {
     $("#nav_srs_player").attr("href", "srs_player.html" + window.location.search);
     $("#nav_rtc_player").attr("href", "rtc_player.html" + window.location.search);
     $("#nav_rtc_publisher").attr("href", "rtc_publisher.html" + window.location.search);
+    $("#nav_whip").attr("href", "whip.html" + window.location.search);
+    $("#nav_whep").attr("href", "whep.html" + window.location.search);
     $("#nav_srs_publisher").attr("href", "srs_publisher.html" + window.location.search);
     $("#nav_srs_chat").attr("href", "srs_chat.html" + window.location.search);
     $("#nav_srs_bwt").attr("href", "srs_bwt.html" + window.location.search);
@@ -116,6 +118,38 @@ function build_default_rtc_url(query) {
     return uri;
 };
 
+function build_default_whip_whep_url(query, apiPath) {
+    // The format for query string to overwrite configs of server.
+    console.log('?eip=x.x.x.x to overwrite candidate. 覆盖服务器candidate(外网IP)配置');
+    console.log('?api=x to overwrite WebRTC API(1985).');
+    console.log('?schema=http|https to overwrite WebRTC API protocol.');
+
+    var server = (!query.server)? window.location.hostname:query.server;
+    var vhost = (!query.vhost)? window.location.hostname:query.vhost;
+    var app = (!query.app)? "live":query.app;
+    var stream = (!query.stream)? "livestream":query.stream;
+    var api = ':' + (query.api || (window.location.protocol === 'http:' ? '1985' : '1990'));
+
+    var queries = [];
+    if (server !== vhost && vhost !== "__defaultVhost__") {
+        queries.push("vhost=" + vhost);
+    }
+    if (query.schema && window.location.protocol !== query.schema + ':') {
+        queries.push('schema=' + query.schema);
+    }
+    queries = user_extra_params(query, queries, true);
+
+    var uri = window.location.protocol + "//" + server + api + apiPath + "?app=" + app + "&stream=" + stream + "&" + queries.join('&');
+    while (uri.lastIndexOf("?") === uri.length - 1) {
+        uri = uri.slice(0, uri.length - 1);
+    }
+    while (uri.lastIndexOf("&") === uri.length - 1) {
+        uri = uri.slice(0, uri.length - 1);
+    }
+
+    return uri;
+}
+
 /**
 * initialize the page.
 * @param flv_url the div id contains the flv stream url to play
@@ -135,4 +169,12 @@ function srs_init_flv(flv_url, modal_player) {
 function srs_init_rtc(id, query) {
     update_nav();
     $(id).val(build_default_rtc_url(query));
+}
+function srs_init_whip(id, query) {
+    update_nav();
+    $(id).val(build_default_whip_whep_url(query, '/rtc/v1/whip/'));
+}
+function srs_init_whep(id, query) {
+    update_nav();
+    $(id).val(build_default_whip_whep_url(query, '/rtc/v1/whip-play/'));
 }

--- a/trunk/research/players/js/srs.sdk.js
+++ b/trunk/research/players/js/srs.sdk.js
@@ -83,7 +83,7 @@ function SrsRtcPublisherAsync() {
             const xhr = new XMLHttpRequest();
             xhr.onload = function() {
                 if (xhr.readyState !== xhr.DONE) return;
-                if (xhr.status !== 200) return reject(xhr);
+                if (xhr.status !== 200 && xhr.status !== 201) return reject(xhr);
                 const data = JSON.parse(xhr.responseText);
                 console.log("Got answer: ", data);
                 return data.code ? reject(xhr) : resolve(data);
@@ -318,7 +318,7 @@ function SrsRtcPlayerAsync() {
             const xhr = new XMLHttpRequest();
             xhr.onload = function() {
                 if (xhr.readyState !== xhr.DONE) return;
-                if (xhr.status !== 200) return reject(xhr);
+                if (xhr.status !== 200 && xhr.status !== 201) return reject(xhr);
                 const data = JSON.parse(xhr.responseText);
                 console.log("Got answer: ", data);
                 return data.code ? reject(xhr) : resolve(data);
@@ -553,7 +553,7 @@ function SrsRtcWhipWhepAsync() {
             const xhr = new XMLHttpRequest();
             xhr.onload = function() {
                 if (xhr.readyState !== xhr.DONE) return;
-                if (xhr.status !== 200) return reject(xhr);
+                if (xhr.status !== 200 && xhr.status !== 201) return reject(xhr);
                 const data = xhr.responseText;
                 console.log("Got answer: ", data);
                 return data.code ? reject(xhr) : resolve(data);
@@ -586,7 +586,7 @@ function SrsRtcWhipWhepAsync() {
             const xhr = new XMLHttpRequest();
             xhr.onload = function() {
                 if (xhr.readyState !== xhr.DONE) return;
-                if (xhr.status !== 200) return reject(xhr);
+                if (xhr.status !== 200 && xhr.status !== 201) return reject(xhr);
                 const data = xhr.responseText;
                 console.log("Got answer: ", data);
                 return data.code ? reject(xhr) : resolve(data);

--- a/trunk/research/players/js/srs.sdk.js
+++ b/trunk/research/players/js/srs.sdk.js
@@ -134,14 +134,14 @@ function SrsRtcPublisherAsync() {
                 api += '/';
             }
 
-            apiUrl = schema + '//' + urlObject.server + ':' + port + api;
+            var apiUrl = schema + '//' + urlObject.server + ':' + port + api;
             for (var key in urlObject.user_query) {
                 if (key !== 'api' && key !== 'play') {
                     apiUrl += '&' + key + '=' + urlObject.user_query[key];
                 }
             }
             // Replace /rtc/v1/play/&k=v to /rtc/v1/play/?k=v
-            var apiUrl = apiUrl.replace(api + '&', api + '?');
+            apiUrl = apiUrl.replace(api + '&', api + '?');
 
             var streamUrl = urlObject.url;
 
@@ -369,14 +369,14 @@ function SrsRtcPlayerAsync() {
                 api += '/';
             }
 
-            apiUrl = schema + '//' + urlObject.server + ':' + port + api;
+            var apiUrl = schema + '//' + urlObject.server + ':' + port + api;
             for (var key in urlObject.user_query) {
                 if (key !== 'api' && key !== 'play') {
                     apiUrl += '&' + key + '=' + urlObject.user_query[key];
                 }
             }
             // Replace /rtc/v1/play/&k=v to /rtc/v1/play/?k=v
-            var apiUrl = apiUrl.replace(api + '&', api + '?');
+            apiUrl = apiUrl.replace(api + '&', api + '?');
 
             var streamUrl = urlObject.url;
 
@@ -499,6 +499,145 @@ function SrsRtcPlayerAsync() {
 
     // Create a stream to add track to the stream, @see https://webrtc.org/getting-started/remote-streams
     self.stream = new MediaStream();
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/ontrack
+    self.pc.ontrack = function(event) {
+        if (self.ontrack) {
+            self.ontrack(event);
+        }
+    };
+
+    return self;
+}
+
+// Depends on adapter-7.4.0.min.js from https://github.com/webrtc/adapter
+// Async-awat-prmise based SRS RTC Publisher by WHIP.
+function SrsRtcWhipWhepAsync() {
+    var self = {};
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
+    self.constraints = {
+        audio: true,
+        video: {
+            width: {ideal: 320, max: 576}
+        }
+    };
+
+    // See https://datatracker.ietf.org/doc/draft-ietf-wish-whip/
+    // @url The WebRTC url to publish with, for example:
+    //      http://localhost:1985/rtc/v1/whip/?app=live&stream=livestream
+    self.publish = async function (url) {
+        if (url.indexOf('/whip/') === -1) throw new Error(`invalid WHIP url ${url}`);
+
+        self.pc.addTransceiver("audio", {direction: "sendonly"});
+        self.pc.addTransceiver("video", {direction: "sendonly"});
+
+        if (!navigator.mediaDevices && window.location.protocol === 'http:' && window.location.hostname !== 'localhost') {
+            throw new SrsError('HttpsRequiredError', `Please use HTTPS or localhost to publish, read https://github.com/ossrs/srs/issues/2762#issuecomment-983147576`);
+        }
+        var stream = await navigator.mediaDevices.getUserMedia(self.constraints);
+
+        // @see https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream#Migrating_to_addTrack
+        stream.getTracks().forEach(function (track) {
+            self.pc.addTrack(track);
+
+            // Notify about local track when stream is ok.
+            self.ontrack && self.ontrack({track: track});
+        });
+
+        var offer = await self.pc.createOffer();
+        await self.pc.setLocalDescription(offer);
+        const answer = await new Promise(function (resolve, reject) {
+            console.log("Generated offer: ", offer);
+
+            const xhr = new XMLHttpRequest();
+            xhr.onload = function() {
+                if (xhr.readyState !== xhr.DONE) return;
+                if (xhr.status !== 200) return reject(xhr);
+                const data = xhr.responseText;
+                console.log("Got answer: ", data);
+                return data.code ? reject(xhr) : resolve(data);
+            }
+            xhr.open('POST', url, true);
+            xhr.setRequestHeader('Content-type', 'application/sdp');
+            xhr.send(offer.sdp);
+        });
+        await self.pc.setRemoteDescription(
+            new RTCSessionDescription({type: 'answer', sdp: answer})
+        );
+
+        return self.__internal.parseId(url, offer.sdp, answer);
+    };
+
+    // See https://datatracker.ietf.org/doc/draft-ietf-wish-whip/
+    // @url The WebRTC url to play with, for example:
+    //      http://localhost:1985/rtc/v1/whip-play/?app=live&stream=livestream
+    self.play = async function(url) {
+        if (url.indexOf('/whip-play/') === -1 && url.indexOf('/whep/') === -1) throw new Error(`invalid WHEP url ${url}`);
+
+        self.pc.addTransceiver("audio", {direction: "recvonly"});
+        self.pc.addTransceiver("video", {direction: "recvonly"});
+
+        var offer = await self.pc.createOffer();
+        await self.pc.setLocalDescription(offer);
+        const answer = await new Promise(function(resolve, reject) {
+            console.log("Generated offer: ", offer);
+
+            const xhr = new XMLHttpRequest();
+            xhr.onload = function() {
+                if (xhr.readyState !== xhr.DONE) return;
+                if (xhr.status !== 200) return reject(xhr);
+                const data = xhr.responseText;
+                console.log("Got answer: ", data);
+                return data.code ? reject(xhr) : resolve(data);
+            }
+            xhr.open('POST', url, true);
+            xhr.setRequestHeader('Content-type', 'application/sdp');
+            xhr.send(offer.sdp);
+        });
+        await self.pc.setRemoteDescription(
+            new RTCSessionDescription({type: 'answer', sdp: answer})
+        );
+
+        return self.__internal.parseId(url, offer.sdp, answer);
+    };
+
+    // Close the publisher.
+    self.close = function () {
+        self.pc && self.pc.close();
+        self.pc = null;
+    };
+
+    // The callback when got local stream.
+    // @see https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream#Migrating_to_addTrack
+    self.ontrack = function (event) {
+        // Add track to stream of SDK.
+        self.stream.addTrack(event.track);
+    };
+
+    self.pc = new RTCPeerConnection(null);
+
+    // To keep api consistent between player and publisher.
+    // @see https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream#Migrating_to_addTrack
+    // @see https://webrtc.org/getting-started/media-devices
+    self.stream = new MediaStream();
+
+    // Internal APIs.
+    self.__internal = {
+        parseId: (url, offer, answer) => {
+            let sessionid = offer.substr(offer.indexOf('a=ice-ufrag:') + 'a=ice-ufrag:'.length);
+            sessionid = sessionid.substr(0, sessionid.indexOf('\n') - 1) + ':';
+            sessionid += answer.substr(answer.indexOf('a=ice-ufrag:') + 'a=ice-ufrag:'.length);
+            sessionid = sessionid.substr(0, sessionid.indexOf('\n'));
+
+            const a = document.createElement("a");
+            a.href = url;
+            return {
+                sessionid: sessionid, // Should be ice-ufrag of answer:offer.
+                simulator: a.protocol + '//' + a.host + '/rtc/v1/nack/',
+            };
+        },
+    };
 
     // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/ontrack
     self.pc.ontrack = function(event) {

--- a/trunk/research/players/rtc_publisher.html
+++ b/trunk/research/players/rtc_publisher.html
@@ -26,6 +26,8 @@
                     <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
                     <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li class="active"><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
+                    <li><a id="nav_whip" href="whip.html">WHIP</a></li>
+                    <li><a id="nav_whep" href="whip.html">WHEP</a></li>
                     <li><a  href="http://ossrs.net/srs.release/releases/app.html">iOS/Andriod</a></li>
                     <!--<li><a id="nav_srs_publisher" href="srs_publisher.html">SRS编码器</a></li>-->
                     <!--<li><a id="nav_srs_chat" href="srs_chat.html">SRS会议</a></li>-->

--- a/trunk/research/players/srs_player.html
+++ b/trunk/research/players/srs_player.html
@@ -219,7 +219,7 @@
 
             show_for_video_ok();
 
-            tsPlayer = mpegts.createPlayer({type: 'mpegts', url: r.url, isLive: true});
+            tsPlayer = mpegts.createPlayer({type: 'mpegts', url: r.url, isLive: true, enableStashBuffer: false});
             tsPlayer.attachMediaElement(document.getElementById('video_player'));
             tsPlayer.load();
             tsPlayer.play();
@@ -264,7 +264,7 @@
 
             show_for_video_ok();
 
-            flvPlayer = mpegts.createPlayer({type: 'flv', url: r.url, isLive: true});
+            flvPlayer = mpegts.createPlayer({type: 'flv', url: r.url, isLive: true, enableStashBuffer: false});
             flvPlayer.attachMediaElement(document.getElementById('video_player'));
             flvPlayer.load();
             flvPlayer.play();

--- a/trunk/research/players/srs_player.html
+++ b/trunk/research/players/srs_player.html
@@ -21,6 +21,8 @@
                     <li class="active"><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
                     <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
+                    <li><a id="nav_whip" href="whip.html">WHIP</a></li>
+                    <li><a id="nav_whep" href="whip.html">WHEP</a></li>
                     <li><a  href="http://ossrs.net/srs.release/releases/app.html">iOS/Andriod</a></li>
                     <!--<li><a id="nav_srs_publisher" href="srs_publisher.html">SRS编码器</a></li>-->
                     <!--<li><a id="nav_srs_chat" href="srs_chat.html">SRS会议</a></li>-->

--- a/trunk/research/players/whep.html
+++ b/trunk/research/players/whep.html
@@ -16,7 +16,7 @@
     <script type="text/javascript" src="js/srs.page.js"></script>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcplayer'/>
+<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcpublisher'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">
@@ -24,10 +24,10 @@
             <div class="nav-collapse collapse">
                 <ul class="nav">
                     <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
-                    <li class="active"><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
+                    <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
                     <li><a id="nav_whip" href="whip.html">WHIP</a></li>
-                    <li><a id="nav_whep" href="whip.html">WHEP</a></li>
+                    <li class="active"><a id="nav_whep" href="whip.html">WHEP</a></li>
                     <li><a  href="http://ossrs.net/srs.release/releases/app.html">iOS/Andriod</a></li>
                     <!--<li><a id="nav_srs_publisher" href="srs_publisher.html">SRS编码器</a></li>-->
                     <!--<li><a id="nav_srs_chat" href="srs_chat.html">SRS会议</a></li>-->
@@ -48,11 +48,11 @@
     <div class="form-inline">
         URL:
         <input type="text" id="txt_url" class="input-xxlarge" value="">
-        <button class="btn btn-primary" id="btn_play">播放视频</button>
+        <button class="btn btn-primary" id="btn_play">Play</button>
     </div>
 
     <label></label>
-    <video id="rtc_media_player" controls autoplay></video>
+    <video id="rtc_media_player" width="320" autoplay muted></video>
 
     <label></label>
     SessionID: <span id='sessionid'></span>
@@ -67,7 +67,7 @@
 </div>
 <script type="text/javascript">
 $(function(){
-    var sdk = null; // Global handler to do cleanup when replaying.
+    var sdk = null; // Global handler to do cleanup when republishing.
     var startPlay = function() {
         $('#rtc_media_player').show();
 
@@ -75,9 +75,10 @@ $(function(){
         if (sdk) {
             sdk.close();
         }
-        sdk = new SrsRtcPlayerAsync();
+        sdk = new SrsRtcWhipWhepAsync();
 
-        // https://webrtc.org/getting-started/remote-streams
+        // User should set the stream when publish is done, @see https://webrtc.org/getting-started/media-devices
+        // However SRS SDK provides a consist API like https://webrtc.org/getting-started/remote-streams
         $('#rtc_media_player').prop('srcObject', sdk.stream);
         // Optional callback, SDK will add track to stream.
         // sdk.ontrack = function (event) { console.log('Got track', event); sdk.stream.addTrack(event.track); };
@@ -96,13 +97,10 @@ $(function(){
 
     $('#rtc_media_player').hide();
     var query = parse_query_string();
-    srs_init_rtc("#txt_url", query);
+    srs_init_whep("#txt_url", query);
 
-    $("#btn_play").click(function() {
-        $('#rtc_media_player').prop('muted', false);
-        startPlay();
-    });
-
+    $("#btn_play").click(startPlay);
+    // Never play util windows loaded @see https://github.com/ossrs/srs/issues/2732
     if (query.autostart === 'true') {
         $('#rtc_media_player').prop('muted', true);
         console.warn('For autostart, we should mute it, see https://www.jianshu.com/p/c3c6944eed5a ' +
@@ -113,3 +111,4 @@ $(function(){
 </script>
 </body>
 </html>
+

--- a/trunk/research/players/whep.html
+++ b/trunk/research/players/whep.html
@@ -52,7 +52,7 @@
     </div>
 
     <label></label>
-    <video id="rtc_media_player" width="320" autoplay muted></video>
+    <video id="rtc_media_player" controls autoplay></video>
 
     <label></label>
     SessionID: <span id='sessionid'></span>

--- a/trunk/research/players/whip.html
+++ b/trunk/research/players/whip.html
@@ -16,7 +16,7 @@
     <script type="text/javascript" src="js/srs.page.js"></script>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcplayer'/>
+<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcpublisher'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">
@@ -24,9 +24,9 @@
             <div class="nav-collapse collapse">
                 <ul class="nav">
                     <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
-                    <li class="active"><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
+                    <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
-                    <li><a id="nav_whip" href="whip.html">WHIP</a></li>
+                    <li class="active"><a id="nav_whip" href="whip.html">WHIP</a></li>
                     <li><a id="nav_whep" href="whip.html">WHEP</a></li>
                     <li><a  href="http://ossrs.net/srs.release/releases/app.html">iOS/Andriod</a></li>
                     <!--<li><a id="nav_srs_publisher" href="srs_publisher.html">SRS编码器</a></li>-->
@@ -48,14 +48,18 @@
     <div class="form-inline">
         URL:
         <input type="text" id="txt_url" class="input-xxlarge" value="">
-        <button class="btn btn-primary" id="btn_play">播放视频</button>
+        <button class="btn btn-primary" id="btn_publish">Publish</button>
     </div>
 
     <label></label>
-    <video id="rtc_media_player" controls autoplay></video>
+    <video id="rtc_media_player" width="320" autoplay muted></video>
 
     <label></label>
     SessionID: <span id='sessionid'></span>
+
+    <label></label>
+    Audio: <span id='acodecs'></span><br/>
+    Video: <span id='vcodecs'></span>
 
     <label></label>
     Simulator: <a href='#' id='simulator-drop'>Drop</a>
@@ -67,27 +71,55 @@
 </div>
 <script type="text/javascript">
 $(function(){
-    var sdk = null; // Global handler to do cleanup when replaying.
-    var startPlay = function() {
+    var sdk = null; // Global handler to do cleanup when republishing.
+    var startPublish = function() {
         $('#rtc_media_player').show();
 
         // Close PC when user replay.
         if (sdk) {
             sdk.close();
         }
-        sdk = new SrsRtcPlayerAsync();
+        sdk = new SrsRtcWhipWhepAsync();
 
-        // https://webrtc.org/getting-started/remote-streams
+        // User should set the stream when publish is done, @see https://webrtc.org/getting-started/media-devices
+        // However SRS SDK provides a consist API like https://webrtc.org/getting-started/remote-streams
         $('#rtc_media_player').prop('srcObject', sdk.stream);
         // Optional callback, SDK will add track to stream.
         // sdk.ontrack = function (event) { console.log('Got track', event); sdk.stream.addTrack(event.track); };
 
+        // https://developer.mozilla.org/en-US/docs/Web/Media/Formats/WebRTC_codecs#getting_the_supported_codecs
+        sdk.pc.onicegatheringstatechange = function (event) {
+            if (sdk.pc.iceGatheringState === "complete") {
+                $('#acodecs').html(SrsRtcFormatSenders(sdk.pc.getSenders(), "audio"));
+                $('#vcodecs').html(SrsRtcFormatSenders(sdk.pc.getSenders(), "video"));
+            }
+        };
+
         // For example: webrtc://r.ossrs.net/live/livestream
         var url = $("#txt_url").val();
-        sdk.play(url).then(function(session){
+        sdk.publish(url).then(function(session){
             $('#sessionid').html(session.sessionid);
             $('#simulator-drop').attr('href', session.simulator + '?drop=1&username=' + session.sessionid);
         }).catch(function (reason) {
+            // Throw by sdk.
+            if (reason instanceof SrsError) {
+                if (reason.name === 'HttpsRequiredError') {
+                    alert(`WebRTC推流必须是HTTPS或者localhost：${reason.name} ${reason.message}`);
+                } else {
+                    alert(`${reason.name} ${reason.message}`);
+                }
+            }
+            // See https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#exceptions
+            if (reason instanceof DOMException) {
+                if (reason.name === 'NotFoundError') {
+                    alert(`找不到麦克风和摄像头设备：getUserMedia ${reason.name} ${reason.message}`);
+                } else if (reason.name === 'NotAllowedError') {
+                    alert(`你禁止了网页访问摄像头和麦克风：getUserMedia ${reason.name} ${reason.message}`);
+                } else if (['AbortError', 'NotAllowedError', 'NotFoundError', 'NotReadableError', 'OverconstrainedError', 'SecurityError', 'TypeError'].includes(reason.name)) {
+                    alert(`getUserMedia ${reason.name} ${reason.message}`);
+                }
+            }
+
             sdk.close();
             $('#rtc_media_player').hide();
             console.error(reason);
@@ -96,20 +128,15 @@ $(function(){
 
     $('#rtc_media_player').hide();
     var query = parse_query_string();
-    srs_init_rtc("#txt_url", query);
+    srs_init_whip("#txt_url", query);
 
-    $("#btn_play").click(function() {
-        $('#rtc_media_player').prop('muted', false);
-        startPlay();
-    });
-
+    $("#btn_publish").click(startPublish);
+    // Never play util windows loaded @see https://github.com/ossrs/srs/issues/2732
     if (query.autostart === 'true') {
-        $('#rtc_media_player').prop('muted', true);
-        console.warn('For autostart, we should mute it, see https://www.jianshu.com/p/c3c6944eed5a ' +
-            'or https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#audiovideo_elements');
-        window.addEventListener("load", function(){ startPlay(); });
+        window.addEventListener("load", function(){ startPublish(); });
     }
 });
 </script>
 </body>
 </html>
+

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -4030,7 +4030,12 @@ int SrsConfig::get_rtc_server_listen()
 
 std::string SrsConfig::get_rtc_server_candidates()
 {
-    SRS_OVERWRITE_BY_ENV_STRING("srs.rtc_server.candidate"); // SRS_RTC_SERVER_CANDIDATE
+    // Note that the value content might be an environment variable.
+    std::string eval = srs_getenv("srs.rtc_server.candidate"); // SRS_RTC_SERVER_CANDIDATE
+    if (!eval.empty()) {
+        if (!srs_string_starts_with(eval, "$")) return eval;
+        SRS_OVERWRITE_BY_ENV_STRING(eval);
+    }
 
     static string DEFAULT = "*";
 

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -534,6 +534,7 @@ srs_error_t SrsGoApiRtcPublish::check_remote_sdp(const SrsSdp& remote_sdp)
     }
 
     for (std::vector<SrsMediaDesc>::const_iterator iter = remote_sdp.media_descs_.begin(); iter != remote_sdp.media_descs_.end(); ++iter) {
+        // donot need check "application"
         if (iter->type_ == "application") {
             continue;
         }

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -220,16 +220,14 @@ srs_error_t SrsGoApiRtcPlay::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
         }
     }
 
+    if ((err = http_hooks_on_play(ruc->req_)) != srs_success) {
+        return srs_error_wrap(err, "RTC: http_hooks_on_play");
+    }
+
     // TODO: FIXME: When server enabled, but vhost disabled, should report error.
-    // We must do stat the client before hooks, because hooks depends on it.
     SrsRtcConnection* session = NULL;
     if ((err = server_->create_session(ruc, local_sdp, &session)) != srs_success) {
         return srs_error_wrap(err, "create session, dtls=%u, srtp=%u, eip=%s", ruc->dtls_, ruc->srtp_, ruc->eip_.c_str());
-    }
-
-    // We must do hook after stat, because depends on it.
-    if ((err = http_hooks_on_play(ruc->req_)) != srs_success) {
-        return srs_error_wrap(err, "RTC: http_hooks_on_play");
     }
 
     ostringstream os;

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -534,11 +534,15 @@ srs_error_t SrsGoApiRtcPublish::check_remote_sdp(const SrsSdp& remote_sdp)
     }
 
     for (std::vector<SrsMediaDesc>::const_iterator iter = remote_sdp.media_descs_.begin(); iter != remote_sdp.media_descs_.end(); ++iter) {
+        if (iter->type_ == "application") {
+            continue;
+        }
+        
         if (iter->type_ != "audio" && iter->type_ != "video") {
             return srs_error_new(ERROR_RTC_SDP_EXCHANGE, "unsupport media type=%s", iter->type_.c_str());
         }
 
-        if (! iter->rtcp_mux_) {
+        if (!iter->rtcp_mux_) {
             return srs_error_new(ERROR_RTC_SDP_EXCHANGE, "now only suppor rtcp-mux");
         }
 

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -605,6 +605,41 @@ srs_error_t SrsGoApiRtcWhip::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     // For each RTC session, we use short-term HTTP connection.
     w->header()->set("Connection", "Close");
 
+    // Client stop publish.
+    // TODO: FIXME: Stop and cleanup the RTC session.
+    if (r->method() == SRS_CONSTS_HTTP_DELETE) {
+        srs_trace("WHIP: Delete stream %s", r->url().c_str());
+        w->write_header(SRS_CONSTS_HTTP_OK);
+        return w->write(NULL, 0);
+    }
+
+    SrsRtcUserConfig ruc;
+    if ((err = do_serve_http(w, r, &ruc)) != srs_success) {
+        return srs_error_wrap(err, "serve");
+    }
+    if (ruc.local_sdp_str_.empty()) {
+        return srs_go_http_error(w, SRS_CONSTS_HTTP_InternalServerError);
+    }
+
+    // The SDP to response.
+    string sdp = ruc.local_sdp_str_;
+
+    // Setup the content type to SDP.
+    w->header()->set("Content-Type", "application/sdp");
+    // The location for DELETE resource, not required by SRS, but required by WHIP.
+    w->header()->set("Location", srs_fmt("/rtc/v1/whip/?app=%s&stream=%s", ruc.req_->app.c_str(), ruc.req_->stream.c_str()));
+    w->header()->set_content_length((int64_t)sdp.length());
+    // Must be 201, see https://datatracker.ietf.org/doc/draft-ietf-wish-whip/
+    w->write_header(201);
+
+    // Response the SDP content.
+    return w->write((char*)sdp.data(), (int)sdp.length());
+}
+
+srs_error_t SrsGoApiRtcWhip::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, SrsRtcUserConfig* ruc)
+{
+    srs_error_t err = srs_success;
+
     string remote_sdp_str;
     if ((err = r->body_read_all(remote_sdp_str)) != srs_success) {
         return srs_error_wrap(err, "read sdp");
@@ -637,48 +672,41 @@ srs_error_t SrsGoApiRtcWhip::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     }
 
     // The RTC user config object.
-    SrsRtcUserConfig ruc;
-    ruc.req_->ip = clientip;
-    ruc.req_->host = r->host();
-    ruc.req_->vhost = ruc.req_->host;
-    ruc.req_->app = app.empty() ? "live" : app;
-    ruc.req_->stream = stream.empty() ? "livestream" : stream;
-    ruc.req_->param = r->query();
+    ruc->req_->ip = clientip;
+    ruc->req_->host = r->host();
+    ruc->req_->vhost = ruc->req_->host;
+    ruc->req_->app = app.empty() ? "live" : app;
+    ruc->req_->stream = stream.empty() ? "livestream" : stream;
+    ruc->req_->param = r->query();
 
     // discovery vhost, resolve the vhost from config
-    SrsConfDirective* parsed_vhost = _srs_config->get_vhost(ruc.req_->vhost);
+    SrsConfDirective* parsed_vhost = _srs_config->get_vhost(ruc->req_->vhost);
     if (parsed_vhost) {
-        ruc.req_->vhost = parsed_vhost->arg0();
+        ruc->req_->vhost = parsed_vhost->arg0();
     }
 
     srs_trace("RTC whip %s %s, clientip=%s, app=%s, stream=%s, offer=%dB, eip=%s, codec=%s, param=%s",
-        action.c_str(), ruc.req_->get_stream_url().c_str(), clientip.c_str(), ruc.req_->app.c_str(), ruc.req_->stream.c_str(),
-        remote_sdp_str.length(), eip.c_str(), codec.c_str(), ruc.req_->param.c_str()
+        action.c_str(), ruc->req_->get_stream_url().c_str(), clientip.c_str(), ruc->req_->app.c_str(), ruc->req_->stream.c_str(),
+        remote_sdp_str.length(), eip.c_str(), codec.c_str(), ruc->req_->param.c_str()
     );
 
-    ruc.eip_ = eip;
-    ruc.codec_ = codec;
-    ruc.publish_ = (action == "publish");
-    ruc.dtls_ = ruc.srtp_ = true;
+    ruc->eip_ = eip;
+    ruc->codec_ = codec;
+    ruc->publish_ = (action == "publish");
+    ruc->dtls_ = ruc->srtp_ = true;
 
     // TODO: FIXME: It seems remote_sdp doesn't represents the full SDP information.
-    ruc.remote_sdp_str_ = remote_sdp_str;
-    if ((err = ruc.remote_sdp_.parse(remote_sdp_str)) != srs_success) {
+    ruc->remote_sdp_str_ = remote_sdp_str;
+    if ((err = ruc->remote_sdp_.parse(remote_sdp_str)) != srs_success) {
         return srs_error_wrap(err, "parse sdp failed: %s", remote_sdp_str.c_str());
     }
 
-    err = action == "publish" ? publish_->serve_http(w, r, &ruc) : play_->serve_http(w, r, &ruc);
+    err = action == "publish" ? publish_->serve_http(w, r, ruc) : play_->serve_http(w, r, ruc);
     if (err != srs_success) {
         return srs_error_wrap(err, "serve");
     }
 
-    if (ruc.local_sdp_str_.empty()) {
-        return srs_go_http_error(w, SRS_CONSTS_HTTP_InternalServerError);
-    }
-
-    string sdp = ruc.local_sdp_str_;
-    w->header()->set("Content-Type", "application/sdp");
-    return w->write((char*)sdp.data(), (int)sdp.length());
+    return err;
 }
 
 SrsGoApiRtcNACK::SrsGoApiRtcNACK(SrsRtcServer* server)

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -263,6 +263,11 @@ srs_error_t SrsGoApiRtcPlay::check_remote_sdp(const SrsSdp& remote_sdp)
     }
 
     for (std::vector<SrsMediaDesc>::const_iterator iter = remote_sdp.media_descs_.begin(); iter != remote_sdp.media_descs_.end(); ++iter) {
+        // NOT need check "application"
+        if (iter->type_ == "application") {
+            continue;
+        }
+
         if (iter->type_ != "audio" && iter->type_ != "video") {
             return srs_error_new(ERROR_RTC_SDP_EXCHANGE, "unsupport media type=%s", iter->type_.c_str());
         }
@@ -532,7 +537,7 @@ srs_error_t SrsGoApiRtcPublish::check_remote_sdp(const SrsSdp& remote_sdp)
     }
 
     for (std::vector<SrsMediaDesc>::const_iterator iter = remote_sdp.media_descs_.begin(); iter != remote_sdp.media_descs_.end(); ++iter) {
-        // donot need check "application"
+        // NOT need check "application"
         if (iter->type_ == "application") {
             continue;
         }

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -643,6 +643,7 @@ srs_error_t SrsGoApiRtcWhip::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     ruc.req_->vhost = ruc.req_->host;
     ruc.req_->app = app.empty() ? "live" : app;
     ruc.req_->stream = stream.empty() ? "livestream" : stream;
+    ruc.req_->param = r->query();
 
     // discovery vhost, resolve the vhost from config
     SrsConfDirective* parsed_vhost = _srs_config->get_vhost(ruc.req_->vhost);
@@ -650,9 +651,9 @@ srs_error_t SrsGoApiRtcWhip::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
         ruc.req_->vhost = parsed_vhost->arg0();
     }
 
-    srs_trace("RTC whip %s %s, clientip=%s, app=%s, stream=%s, offer=%dB, eip=%s, codec=%s",
+    srs_trace("RTC whip %s %s, clientip=%s, app=%s, stream=%s, offer=%dB, eip=%s, codec=%s, param=%s",
         action.c_str(), ruc.req_->get_stream_url().c_str(), clientip.c_str(), ruc.req_->app.c_str(), ruc.req_->stream.c_str(),
-        remote_sdp_str.length(), eip.c_str(), codec.c_str()
+        remote_sdp_str.length(), eip.c_str(), codec.c_str(), ruc.req_->param.c_str()
     );
 
     ruc.eip_ = eip;

--- a/trunk/src/app/srs_app_rtc_api.hpp
+++ b/trunk/src/app/srs_app_rtc_api.hpp
@@ -65,6 +65,8 @@ public:
     virtual ~SrsGoApiRtcWhip();
 public:
     virtual srs_error_t serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r);
+private:
+    virtual srs_error_t do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r, SrsRtcUserConfig* ruc);
 };
 
 class SrsGoApiRtcNACK : public ISrsHttpHandler

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -1948,6 +1948,11 @@ srs_error_t SrsRtcConnection::add_player(SrsRtcUserConfig* ruc, SrsSdp& local_sd
     while (it != play_sub_relations.end()) {
         SrsRtcTrackDescription* track_desc = it->second;
 
+
+        if (track_desc->type_ == "application") {
+            stream_desc->application_track_desc_ = track_desc->copy();
+        }
+
         // TODO: FIXME: we only support one audio track.
         if (track_desc->type_ == "audio" && !stream_desc->audio_track_desc_) {
             stream_desc->audio_track_desc_ = track_desc->copy();

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -2802,6 +2802,7 @@ srs_error_t SrsRtcConnection::negotiate_publish_capability(SrsRtcUserConfig* ruc
         } else if (remote_media_desc.is_application()) {
             track_desc->type_ = "application";
             stream_desc->application_track_desc_ = track_desc->copy();
+	    // the "application" have NOT media and ssrc, so we just copy it
             continue;
         }
 

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -1896,7 +1896,7 @@ srs_error_t SrsRtcConnection::add_publisher(SrsRtcUserConfig* ruc, SrsSdp& local
 
     // TODO: FIXME: Change to api of stream desc.
     if ((err = negotiate_publish_capability(ruc, stream_desc)) != srs_success) {
-        return srs_error_wrap(err, "publish negotiate, offer=%s", ruc->remote_sdp_str_.c_str());
+        return srs_error_wrap(err, "publish negotiate, offer=%s", srs_string_replace(ruc->remote_sdp_str_.c_str(), "\r\n", "\\r\\n").c_str());
     }
 
     if ((err = generate_publish_local_sdp(req, local_sdp, stream_desc, ruc->remote_sdp_.is_unified(), ruc->audio_before_video_)) != srs_success) {
@@ -1935,7 +1935,7 @@ srs_error_t SrsRtcConnection::add_player(SrsRtcUserConfig* ruc, SrsSdp& local_sd
 
     std::map<uint32_t, SrsRtcTrackDescription*> play_sub_relations;
     if ((err = negotiate_play_capability(ruc, play_sub_relations)) != srs_success) {
-        return srs_error_wrap(err, "play negotiate, offer=%s", ruc->remote_sdp_str_.c_str());
+        return srs_error_wrap(err, "play negotiate, offer=%s", srs_string_replace(ruc->remote_sdp_str_.c_str(), "\r\n", "\\r\\n").c_str());
     }
 
     if (!play_sub_relations.size()) {

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -543,6 +543,7 @@ private:
     srs_error_t generate_publish_local_sdp(SrsRequest* req, SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, bool unified_plan, bool audio_before_video);
     srs_error_t generate_publish_local_sdp_for_audio(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc);
     srs_error_t generate_publish_local_sdp_for_video(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, bool unified_plan);
+    srs_error_t generate_publish_local_sdp_for_application(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc);
     // play media capabilitiy negotiate
     //TODO: Use StreamDescription to negotiate and remove first negotiate_play_capability function
     srs_error_t negotiate_play_capability(SrsRtcUserConfig* ruc, std::map<uint32_t, SrsRtcTrackDescription*>& sub_relations);

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -550,6 +550,7 @@ private:
     srs_error_t generate_play_local_sdp(SrsRequest* req, SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, bool unified_plan, bool audio_before_video);
     srs_error_t generate_play_local_sdp_for_audio(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, std::string cname);
     srs_error_t generate_play_local_sdp_for_video(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, bool unified_plan, std::string cname);
+    srs_error_t generate_play_local_sdp_for_application(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc);
     srs_error_t create_player(SrsRequest* request, std::map<uint32_t, SrsRtcTrackDescription*> sub_relations);
     srs_error_t create_publisher(SrsRequest* request, SrsRtcSourceDescription* stream_desc);
 };

--- a/trunk/src/app/srs_app_rtc_sdp.cpp
+++ b/trunk/src/app/srs_app_rtc_sdp.cpp
@@ -390,6 +390,10 @@ srs_error_t SrsMediaDesc::encode(std::ostringstream& os)
         os << " " << iter->payload_type_;
     }
 
+    if (is_application()) {
+        os << " webrtc-datachannel";
+    }
+
     os << kCRLF;
 
     // TODO:nettype and address type

--- a/trunk/src/app/srs_app_rtc_sdp.hpp
+++ b/trunk/src/app/srs_app_rtc_sdp.hpp
@@ -140,6 +140,7 @@ public:
 
     bool is_audio() const { return type_ == "audio"; }
     bool is_video() const { return type_ == "video"; }
+    bool is_application() const { return type_ == "application"; }
 private:
     srs_error_t parse_attribute(const std::string& content);
     srs_error_t parse_attr_rtpmap(const std::string& value);

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2269,11 +2269,13 @@ SrsRtcTrackDescription* SrsRtcTrackDescription::copy()
 SrsRtcSourceDescription::SrsRtcSourceDescription()
 {
     audio_track_desc_ = NULL;
+    application_track_desc_ = NULL;
 }
 
 SrsRtcSourceDescription::~SrsRtcSourceDescription()
 {
     srs_freep(audio_track_desc_);
+    srs_freep(application_track_desc_);
 
     for (int i = 0; i < (int)video_track_descs_.size(); ++i) {
         srs_freep(video_track_descs_.at(i));
@@ -2289,6 +2291,10 @@ SrsRtcSourceDescription* SrsRtcSourceDescription::copy()
         stream_desc->audio_track_desc_ = audio_track_desc_->copy();
     }
 
+    if (application_track_desc_) {
+        stream_desc->application_track_desc_ = application_track_desc_->copy();
+    }
+
     for (int i = 0; i < (int)video_track_descs_.size(); ++i) {
         stream_desc->video_track_descs_.push_back(video_track_descs_.at(i)->copy());
     }
@@ -2300,6 +2306,10 @@ SrsRtcTrackDescription* SrsRtcSourceDescription::find_track_description_by_ssrc(
 {
     if (audio_track_desc_ && audio_track_desc_->has_ssrc(ssrc)) {
         return audio_track_desc_;
+    }
+
+    if (application_track_desc_ && application_track_desc_->has_ssrc(ssrc)) {
+        return application_track_desc_;
     }
 
     for (int i = 0; i < (int)video_track_descs_.size(); ++i) {

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2308,10 +2308,6 @@ SrsRtcTrackDescription* SrsRtcSourceDescription::find_track_description_by_ssrc(
         return audio_track_desc_;
     }
 
-    if (application_track_desc_ && application_track_desc_->has_ssrc(ssrc)) {
-        return application_track_desc_;
-    }
-
     for (int i = 0; i < (int)video_track_descs_.size(); ++i) {
         if (video_track_descs_.at(i)->has_ssrc(ssrc)) {
             return video_track_descs_.at(i);

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -681,6 +681,13 @@ std::vector<SrsRtcTrackDescription*> SrsRtcSource::get_track_desc(std::string ty
         }
     }
 
+    if (type == "application") {
+        if (!stream_desc_->application_track_desc_) {
+            return track_descs;
+        }
+        track_descs.push_back(stream_desc_->application_track_desc_);
+    }
+
     return track_descs;
 }
 

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -413,6 +413,19 @@ void SrsRtcSource::init_for_play_before_publishing()
         video_payload->set_h264_param_desc("level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f");
     }
 
+    // application track description
+    if (true) {
+        SrsRtcTrackDescription* app_track_desc = new SrsRtcTrackDescription();
+        stream_desc->application_track_desc_ = app_track_desc;
+
+        app_track_desc->type_ = "application";
+        app_track_desc->id_ = "application-" + srs_random_str(8);
+
+        uint32_t app_ssrc = SrsRtcSSRCGenerator::instance()->generate_ssrc();
+        app_track_desc->ssrc_ = app_ssrc;
+        app_track_desc->direction_ = "sendrecv";
+    }
+
     set_stream_desc(stream_desc);
 }
 

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -497,6 +497,7 @@ public:
 
     SrsRtcTrackDescription* audio_track_desc_;
     std::vector<SrsRtcTrackDescription*> video_track_descs_;
+    SrsRtcTrackDescription* application_track_desc_;
 public:
     SrsRtcSourceDescription();
     virtual ~SrsRtcSourceDescription();

--- a/trunk/src/core/srs_core.hpp
+++ b/trunk/src/core/srs_core.hpp
@@ -44,17 +44,13 @@
 // To free the p and set to NULL.
 // @remark The p must be a pointer T*.
 #define srs_freep(p) \
-    if (p) { \
-        delete p; \
-        p = NULL; \
-    } \
+    delete p; \
+    p = NULL; \
     (void)0
 // Please use the freepa(T[]) to free an array, otherwise the behavior is undefined.
 #define srs_freepa(pa) \
-    if (pa) { \
-        delete[] pa; \
-        pa = NULL; \
-    } \
+    delete[] pa; \
+    pa = NULL; \
     (void)0
 
 // Check CPU for ST(state-threads), please read https://github.com/ossrs/state-threads/issues/22

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    146
+#define VERSION_REVISION    147
 
 #endif

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    148
+#define VERSION_REVISION    150
 
 #endif

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    150
+#define VERSION_REVISION    151
 
 #endif

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    147
+#define VERSION_REVISION    148
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    38
+#define VERSION_REVISION    39
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    36
+#define VERSION_REVISION    38
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    34
+#define VERSION_REVISION    35
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    35
+#define VERSION_REVISION    36
 
 #endif

--- a/trunk/src/kernel/srs_kernel_error.cpp
+++ b/trunk/src/kernel/srs_kernel_error.cpp
@@ -19,6 +19,8 @@
 #include <vector>
 using namespace std;
 
+const int maxLogBuf = 4 * 1024 * 1024;
+
 #if defined(SRS_BACKTRACE) && defined(__linux)
 #include <execinfo.h>
 #include <dlfcn.h>
@@ -264,8 +266,8 @@ SrsCplxError* SrsCplxError::create(const char* func, const char* file, int line,
 
     va_list ap;
     va_start(ap, fmt);
-    static char buffer[4096];
-    int r0 = vsnprintf(buffer, sizeof(buffer), fmt, ap);
+    static char* buffer = new char[maxLogBuf];
+    int r0 = vsnprintf(buffer, maxLogBuf, fmt, ap);
     va_end(ap);
     
     SrsCplxError* err = new SrsCplxError();
@@ -275,7 +277,7 @@ SrsCplxError* SrsCplxError::create(const char* func, const char* file, int line,
     err->line = line;
     err->code = code;
     err->rerrno = rerrno;
-    if (r0 > 0 && r0 < (int)sizeof(buffer)) {
+    if (r0 > 0 && r0 < maxLogBuf) {
         err->msg = string(buffer, r0);
     }
     err->wrapped = NULL;
@@ -291,8 +293,8 @@ SrsCplxError* SrsCplxError::wrap(const char* func, const char* file, int line, S
     
     va_list ap;
     va_start(ap, fmt);
-    static char buffer[4096];
-    int r0 = vsnprintf(buffer, sizeof(buffer), fmt, ap);
+    static char* buffer = new char[maxLogBuf];
+    int r0 = vsnprintf(buffer, maxLogBuf, fmt, ap);
     va_end(ap);
     
     SrsCplxError* err = new SrsCplxError();
@@ -304,7 +306,7 @@ SrsCplxError* SrsCplxError::wrap(const char* func, const char* file, int line, S
         err->code = v->code;
     }
     err->rerrno = rerrno;
-    if (r0 > 0 && r0 < (int)sizeof(buffer)) {
+    if (r0 > 0 && r0 < maxLogBuf) {
         err->msg = string(buffer, r0);
     }
     err->wrapped = v;

--- a/trunk/src/protocol/srs_protocol_http_conn.cpp
+++ b/trunk/src/protocol/srs_protocol_http_conn.cpp
@@ -1162,7 +1162,9 @@ srs_error_t SrsHttpResponseReader::read_chunked(void* data, size_t nb_data, ssiz
     if (nb_chunk <= 0) {
         // for the last chunk, eof.
         is_eof = true;
-        *nb_read = 0;
+        if (nb_read) {
+            *nb_read = 0;
+        }
     } else {
         // for not the last chunk, there must always exists bytes.
         // left bytes in chunk, read some.

--- a/trunk/src/utest/srs_utest_config.cpp
+++ b/trunk/src/utest/srs_utest_config.cpp
@@ -4311,6 +4311,23 @@ VOID TEST(ConfigEnvTest, CheckEnvValuesRtcServer)
         SrsSetEnvConfig(rtc_server_black_hole_addr, "SRS_RTC_SERVER_BLACK_HOLE_ADDR", "xxx");
         EXPECT_STREQ("xxx", conf.get_rtc_server_black_hole_addr().c_str());
     }
+
+    if (true) {
+        MockSrsConfig conf;
+
+        SrsSetEnvConfig(rtc_server_candidates, "SRS_RTC_SERVER_CANDIDATE", "192.168.0.1");
+        EXPECT_STREQ("192.168.0.1", conf.get_rtc_server_candidates().c_str());
+
+        SrsSetEnvConfig(rtc_server_candidates2, "SRS_RTC_SERVER_CANDIDATE", "MY_CANDIDATE");
+        EXPECT_STREQ("MY_CANDIDATE", conf.get_rtc_server_candidates().c_str());
+
+        SrsSetEnvConfig(rtc_server_candidates3, "SRS_RTC_SERVER_CANDIDATE", "$MY_CANDIDATE");
+        EXPECT_STREQ("*", conf.get_rtc_server_candidates().c_str());
+
+        SrsSetEnvConfig(candidates, "MY_CANDIDATE", "192.168.0.11");
+        SrsSetEnvConfig(rtc_server_candidates4, "SRS_RTC_SERVER_CANDIDATE", "$MY_CANDIDATE");
+        EXPECT_STREQ("192.168.0.11", conf.get_rtc_server_candidates().c_str());
+    }
 }
 
 VOID TEST(ConfigEnvTest, CheckEnvValuesVhostRtc)


### PR DESCRIPTION
Currently, SRS does not support WebRTC data channel. If a client requests to establish a data channel connection, it will cause an error in the browser.
```
Failed to set remote answer sdp: The order of m-lines in answer doesn't match order in offer. Reject
```

The SDP response from SRS before modification is as follows:
```
v=0
...
a=group:BUNDLE 0 1
m=audio 9 UDP/TLS/RTP/SAVPF 111
...
m=video 9 UDP/TLS/RTP/SAVPF 106 114
...
```

After modification:
```
v=0
...
a=group:BUNDLE 0 1 2
m=audio 9 UDP/TLS/RTP/SAVPF 111
...
m=video 9 UDP/TLS/RTP/SAVPF 106 114
...
m=application 9 UDP/DTLS/SCTP webrtc-datachannel
...
```

**Doubtful:**
~~Is datachannel considered as a media stream? Does it count as a track? If not, it should not be placed inside the `SrsMediaDesc` class, but should be separated.~~

---------

`TRANS_BY_GPT3`