### PR TITLE
TYPO : fix misspelling coroutine word.

### DIFF
--- a/trunk/src/app/srs_app_st.hpp
+++ b/trunk/src/app/srs_app_st.hpp
@@ -54,7 +54,7 @@ public:
     virtual srs_error_t cycle() = 0;
 };
 
-// Start the object, generally a croutine.
+// Start the object, generally a coroutine.
 class ISrsStartable
 {
 public:


### PR DESCRIPTION
The word `coroutine` is misspelled in `trunk/src/app/srs_app_st.hpp`.
