### PR TITLE
SSL: Fix SSL_get_error get the error of other coroutine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![](https://badgen.net/badge/srs/stackoverflow/orange?icon=terminal)](https://stackoverflow.com/questions/tagged/simple-realtime-server)
 [![](https://opencollective.com/srs-server/tiers/badge.svg)](https://opencollective.com/srs-server/contribute)
 [![](https://img.shields.io/docker/pulls/ossrs/srs)](https://hub.docker.com/r/ossrs/srs/tags)
-[![](https://ossrs.net/wiki/images/do-btn-srs-125x20.svg)](https://cloud.digitalocean.com/droplets/new?appId=104916642&size=s-1vcpu-1gb&region=sgp1&image=ossrs-srs&type=applications)
+[![](https://ossrs.net/wiki/images/do-btn-srs-125x20.svg)](https://cloud.digitalocean.com/droplets/new?appId=133468816&size=s-1vcpu-512mb-10gb&region=sgp1&image=ossrs-srs&type=applications)
 [![](https://api.securityscorecards.dev/projects/github.com/ossrs/srs/badge)](https://api.securityscorecards.dev/projects/github.com/ossrs/srs)
 [![](https://bestpractices.coreinfrastructure.org/projects/5619/badge)](https://bestpractices.coreinfrastructure.org/projects/5619)
 

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-05-29, Merge [#3513](https://github.com/ossrs/srs/pull/3513): SSL: Fix SSL_get_error get the error of other coroutine. v6.0.46 (#3513)
 * v6.0, 2023-05-14, Merge [#3534](https://github.com/ossrs/srs/pull/3534): Replace sprintf with snprintf to eliminate compile warnings. v6.0.45 (#3534)
 * v6.0, 2023-05-13, Merge [#3541](https://github.com/ossrs/srs/pull/3541): asan: Fix memory leak in asan by releasing global IPs when run_directly_or_daemon fails. v6.0.44 (#3541)
 * v6.0, 2023-05-12, Merge [#3539](https://github.com/ossrs/srs/pull/3539): WHIP: Improve HTTP DELETE for notifying server unpublish event. v6.0.43 (#3539)
@@ -59,6 +60,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-05-29, Merge [#3513](https://github.com/ossrs/srs/pull/3513): SSL: Fix SSL_get_error get the error of other coroutine. v5.0.155 (#3513)
 * v5.0, 2023-05-13, Merge [#3541](https://github.com/ossrs/srs/pull/3541): asan: Fix memory leak in asan by releasing global IPs when run_directly_or_daemon fails. v5.0.154 (#3541)
 * v5.0, 2023-05-12, Merge [#3539](https://github.com/ossrs/srs/pull/3539): WHIP: Improve HTTP DELETE for notifying server unpublish event. v5.0.153 (#3539)
 * v5.0, 2023-03-27, Merge [#3450](https://github.com/ossrs/srs/pull/3450): WebRTC: Error message carries the SDP when failed. v5.0.151 (#3450)

--- a/trunk/src/app/srs_app_conn.cpp
+++ b/trunk/src/app/srs_app_conn.cpp
@@ -798,9 +798,8 @@ srs_error_t SrsSslConnection::handshake(string key_file, string crt_file)
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "BIO_write r0=%d, data=%p, size=%d", r0, buf, nn);
         }
 
-        r0 = SSL_do_handshake(ssl); r1 = SSL_get_error(ssl, r0);
+        r0 = SSL_do_handshake(ssl); r1 = SSL_get_error(ssl, r0); ERR_clear_error();
         if (r0 != -1 || r1 != SSL_ERROR_WANT_READ) {
-            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "handshake r0=%d, r1=%d", r0, r1);
         }
 
@@ -841,13 +840,12 @@ srs_error_t SrsSslConnection::handshake(string key_file, string crt_file)
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "BIO_write r0=%d, data=%p, size=%d", r0, buf, nn);
         }
 
-        r0 = SSL_do_handshake(ssl); r1 = SSL_get_error(ssl, r0);
+        r0 = SSL_do_handshake(ssl); r1 = SSL_get_error(ssl, r0); ERR_clear_error();
         if (r0 == 1 && r1 == SSL_ERROR_NONE) {
             break;
         }
 
         if (r0 != -1 || r1 != SSL_ERROR_WANT_READ) {
-            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "handshake r0=%d, r1=%d", r0, r1);
         }
 
@@ -910,7 +908,7 @@ srs_error_t SrsSslConnection::read(void* plaintext, size_t nn_plaintext, ssize_t
     srs_error_t err = srs_success;
 
     while (true) {
-        int r0 = SSL_read(ssl, plaintext, nn_plaintext); int r1 = SSL_get_error(ssl, r0);
+        int r0 = SSL_read(ssl, plaintext, nn_plaintext); int r1 = SSL_get_error(ssl, r0); ERR_clear_error();
         int r2 = BIO_ctrl_pending(bio_in); int r3 = SSL_is_init_finished(ssl);
 
         // OK, got data.
@@ -945,7 +943,6 @@ srs_error_t SrsSslConnection::read(void* plaintext, size_t nn_plaintext, ssize_t
 
         // Fail for error.
         if (r0 <= 0) {
-            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_READ, "SSL_read r0=%d, r1=%d, r2=%d, r3=%d",
                 r0, r1, r2, r3);
         }
@@ -969,9 +966,8 @@ srs_error_t SrsSslConnection::write(void* plaintext, size_t nn_plaintext, ssize_
     for (char* p = (char*)plaintext; p < (char*)plaintext + nn_plaintext;) {
         int left = (int)nn_plaintext - (p - (char*)plaintext);
         int r0 = SSL_write(ssl, (const void*)p, left);
-        int r1 = SSL_get_error(ssl, r0);
+        int r1 = SSL_get_error(ssl, r0); ERR_clear_error();
         if (r0 <= 0) {
-            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_WRITE, "https: write data=%p, size=%d, r0=%d, r1=%d", p, left, r0, r1);
         }
 

--- a/trunk/src/app/srs_app_conn.cpp
+++ b/trunk/src/app/srs_app_conn.cpp
@@ -800,6 +800,7 @@ srs_error_t SrsSslConnection::handshake(string key_file, string crt_file)
 
         r0 = SSL_do_handshake(ssl); r1 = SSL_get_error(ssl, r0);
         if (r0 != -1 || r1 != SSL_ERROR_WANT_READ) {
+            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "handshake r0=%d, r1=%d", r0, r1);
         }
 
@@ -846,6 +847,7 @@ srs_error_t SrsSslConnection::handshake(string key_file, string crt_file)
         }
 
         if (r0 != -1 || r1 != SSL_ERROR_WANT_READ) {
+            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "handshake r0=%d, r1=%d", r0, r1);
         }
 
@@ -943,6 +945,7 @@ srs_error_t SrsSslConnection::read(void* plaintext, size_t nn_plaintext, ssize_t
 
         // Fail for error.
         if (r0 <= 0) {
+            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_READ, "SSL_read r0=%d, r1=%d, r2=%d, r3=%d",
                 r0, r1, r2, r3);
         }
@@ -968,6 +971,7 @@ srs_error_t SrsSslConnection::write(void* plaintext, size_t nn_plaintext, ssize_
         int r0 = SSL_write(ssl, (const void*)p, left);
         int r1 = SSL_get_error(ssl, r0);
         if (r0 <= 0) {
+            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_WRITE, "https: write data=%p, size=%d, r0=%d, r1=%d", p, left, r0, r1);
         }
 

--- a/trunk/src/app/srs_app_conn.hpp
+++ b/trunk/src/app/srs_app_conn.hpp
@@ -14,6 +14,7 @@
 #include <map>
 
 #include <openssl/ssl.h>
+#include <openssl/err.h>
 
 #include <srs_app_st.hpp>
 #include <srs_protocol_kbps.hpp>

--- a/trunk/src/app/srs_app_rtc_dtls.cpp
+++ b/trunk/src/app/srs_app_rtc_dtls.cpp
@@ -77,7 +77,7 @@ void ssl_on_info(const SSL* dtls, int where, int ret)
         method = "undefined";
     }
 
-    int r1 = SSL_get_error(dtls, ret);
+    int r1 = SSL_get_error(dtls, ret); ERR_clear_error();
     if (where & SSL_CB_LOOP) {
         srs_info("DTLS: method=%s state=%s(%s), where=%d, ret=%d, r1=%d", method, SSL_state_string(dtls),
             SSL_state_string_long(dtls), where, ret, r1);
@@ -525,7 +525,7 @@ srs_error_t SrsDtlsImpl::do_on_dtls(char* data, int nb_data)
     for (int i = 0; i < 1024 && BIO_ctrl_pending(bio_in) > 0; i++) {
         char buf[8092];
         int r0 = SSL_read(dtls, buf, sizeof(buf));
-        int r1 = SSL_get_error(dtls, r0);
+        int r1 = SSL_get_error(dtls, r0); ERR_clear_error();
 
         if (r0 <= 0) {
             // SSL_ERROR_ZERO_RETURN
@@ -577,11 +577,10 @@ srs_error_t SrsDtlsImpl::do_handshake()
 
     // Do handshake and get the result.
     int r0 = SSL_do_handshake(dtls);
-    int r1 = SSL_get_error(dtls, r0);
+    int r1 = SSL_get_error(dtls, r0); ERR_clear_error();
 
     // Fatal SSL error, for example, no available suite when peer is DTLS 1.0 while we are DTLS 1.2.
     if (r0 < 0 && (r1 != SSL_ERROR_NONE && r1 != SSL_ERROR_WANT_READ && r1 != SSL_ERROR_WANT_WRITE)) {
-        ERR_clear_error();
         return srs_error_new(ERROR_RTC_DTLS, "handshake r0=%d, r1=%d", r0, r1);
     }
 
@@ -862,9 +861,8 @@ srs_error_t SrsDtlsClientImpl::cycle()
         }
 
         // The timeout is 0, so there must be a ARQ packet to transmit in openssl.
-        r0 = BIO_reset(bio_out); int r1 = SSL_get_error(dtls, r0);
+        r0 = BIO_reset(bio_out); int r1 = SSL_get_error(dtls, r0); ERR_clear_error();
         if (r0 != 1) {
-            ERR_clear_error();
             return srs_error_new(ERROR_OpenSslBIOReset, "BIO_reset r0=%d, r1=%d", r0, r1);
         }
 
@@ -872,12 +870,11 @@ srs_error_t SrsDtlsClientImpl::cycle()
         // had expired, it returns 0. Otherwise, it retransmits the previous flight of handshake
         // messages and returns 1. If too many timeouts had expired without progress or an error
         // occurs, it returns -1.
-        r0 = DTLSv1_handle_timeout(dtls); r1 = SSL_get_error(dtls, r0);
+        r0 = DTLSv1_handle_timeout(dtls); r1 = SSL_get_error(dtls, r0); ERR_clear_error();
         if (r0 == 0) {
             continue; // No timeout had expired.
         }
         if (r0 != 1) {
-            ERR_clear_error();
             return srs_error_new(ERROR_RTC_DTLS, "ARQ r0=%d, r1=%d", r0, r1);
         }
 

--- a/trunk/src/app/srs_app_rtc_dtls.cpp
+++ b/trunk/src/app/srs_app_rtc_dtls.cpp
@@ -581,6 +581,7 @@ srs_error_t SrsDtlsImpl::do_handshake()
 
     // Fatal SSL error, for example, no available suite when peer is DTLS 1.0 while we are DTLS 1.2.
     if (r0 < 0 && (r1 != SSL_ERROR_NONE && r1 != SSL_ERROR_WANT_READ && r1 != SSL_ERROR_WANT_WRITE)) {
+        ERR_clear_error();
         return srs_error_new(ERROR_RTC_DTLS, "handshake r0=%d, r1=%d", r0, r1);
     }
 
@@ -863,6 +864,7 @@ srs_error_t SrsDtlsClientImpl::cycle()
         // The timeout is 0, so there must be a ARQ packet to transmit in openssl.
         r0 = BIO_reset(bio_out); int r1 = SSL_get_error(dtls, r0);
         if (r0 != 1) {
+            ERR_clear_error();
             return srs_error_new(ERROR_OpenSslBIOReset, "BIO_reset r0=%d, r1=%d", r0, r1);
         }
 
@@ -875,6 +877,7 @@ srs_error_t SrsDtlsClientImpl::cycle()
             continue; // No timeout had expired.
         }
         if (r0 != 1) {
+            ERR_clear_error();
             return srs_error_new(ERROR_RTC_DTLS, "ARQ r0=%d, r1=%d", r0, r1);
         }
 

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    154
+#define VERSION_REVISION    155
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    45
+#define VERSION_REVISION    46
 
 #endif

--- a/trunk/src/protocol/srs_protocol_http_client.cpp
+++ b/trunk/src/protocol/srs_protocol_http_client.cpp
@@ -90,9 +90,8 @@ srs_error_t SrsSslClient::handshake()
     SSL_set_mode(ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
 
     // Send ClientHello.
-    int r0 = SSL_do_handshake(ssl); int r1 = SSL_get_error(ssl, r0);
+    int r0 = SSL_do_handshake(ssl); int r1 = SSL_get_error(ssl, r0); ERR_clear_error();
     if (r0 != -1 || r1 != SSL_ERROR_WANT_READ) {
-        ERR_clear_error();
         return srs_error_new(ERROR_HTTPS_HANDSHAKE, "handshake r0=%d, r1=%d", r0, r1);
     }
 
@@ -122,8 +121,8 @@ srs_error_t SrsSslClient::handshake()
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "BIO_write r0=%d, data=%p, size=%d", r0, buf, nn);
         }
 
-        if ((r0 = SSL_do_handshake(ssl)) != -1 || (r1 = SSL_get_error(ssl, r0)) != SSL_ERROR_WANT_READ) {
-            ERR_clear_error();
+        r0 = SSL_do_handshake(ssl); r1 = SSL_get_error(ssl, r0); ERR_clear_error();
+        if (r0 != -1 || r1 != SSL_ERROR_WANT_READ) {
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "handshake r0=%d, r1=%d", r0, r1);
         }
 
@@ -161,13 +160,12 @@ srs_error_t SrsSslClient::handshake()
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "BIO_write r0=%d, data=%p, size=%d", r0, buf, nn);
         }
 
-        r0 = SSL_do_handshake(ssl); r1 = SSL_get_error(ssl, r0);
+        r0 = SSL_do_handshake(ssl); r1 = SSL_get_error(ssl, r0); ERR_clear_error();
         if (r0 == 1 && r1 == SSL_ERROR_NONE) {
             break;
         }
 
         if (r0 != -1 || r1 != SSL_ERROR_WANT_READ) {
-            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "handshake r0=%d, r1=%d", r0, r1);
         }
     }
@@ -183,7 +181,7 @@ srs_error_t SrsSslClient::read(void* plaintext, size_t nn_plaintext, ssize_t* nr
     srs_error_t err = srs_success;
 
     while (true) {
-        int r0 = SSL_read(ssl, plaintext, nn_plaintext); int r1 = SSL_get_error(ssl, r0);
+        int r0 = SSL_read(ssl, plaintext, nn_plaintext); int r1 = SSL_get_error(ssl, r0); ERR_clear_error();
         int r2 = BIO_ctrl_pending(bio_in); int r3 = SSL_is_init_finished(ssl);
 
         // OK, got data.
@@ -218,7 +216,6 @@ srs_error_t SrsSslClient::read(void* plaintext, size_t nn_plaintext, ssize_t* nr
 
         // Fail for error.
         if (r0 <= 0) {
-            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_READ, "SSL_read r0=%d, r1=%d, r2=%d, r3=%d",
                 r0, r1, r2, r3);
         }
@@ -232,9 +229,8 @@ srs_error_t SrsSslClient::write(void* plaintext, size_t nn_plaintext, ssize_t* n
     for (char* p = (char*)plaintext; p < (char*)plaintext + nn_plaintext;) {
         int left = (int)nn_plaintext - (p - (char*)plaintext);
         int r0 = SSL_write(ssl, (const void*)p, left);
-        int r1 = SSL_get_error(ssl, r0);
+        int r1 = SSL_get_error(ssl, r0); ERR_clear_error();
         if (r0 <= 0) {
-            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_WRITE, "https: write data=%p, size=%d, r0=%d, r1=%d", p, left, r0, r1);
         }
 

--- a/trunk/src/protocol/srs_protocol_http_client.cpp
+++ b/trunk/src/protocol/srs_protocol_http_client.cpp
@@ -92,6 +92,7 @@ srs_error_t SrsSslClient::handshake()
     // Send ClientHello.
     int r0 = SSL_do_handshake(ssl); int r1 = SSL_get_error(ssl, r0);
     if (r0 != -1 || r1 != SSL_ERROR_WANT_READ) {
+        ERR_clear_error();
         return srs_error_new(ERROR_HTTPS_HANDSHAKE, "handshake r0=%d, r1=%d", r0, r1);
     }
 
@@ -122,6 +123,7 @@ srs_error_t SrsSslClient::handshake()
         }
 
         if ((r0 = SSL_do_handshake(ssl)) != -1 || (r1 = SSL_get_error(ssl, r0)) != SSL_ERROR_WANT_READ) {
+            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "handshake r0=%d, r1=%d", r0, r1);
         }
 
@@ -165,6 +167,7 @@ srs_error_t SrsSslClient::handshake()
         }
 
         if (r0 != -1 || r1 != SSL_ERROR_WANT_READ) {
+            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_HANDSHAKE, "handshake r0=%d, r1=%d", r0, r1);
         }
     }
@@ -215,6 +218,7 @@ srs_error_t SrsSslClient::read(void* plaintext, size_t nn_plaintext, ssize_t* nr
 
         // Fail for error.
         if (r0 <= 0) {
+            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_READ, "SSL_read r0=%d, r1=%d, r2=%d, r3=%d",
                 r0, r1, r2, r3);
         }
@@ -230,6 +234,7 @@ srs_error_t SrsSslClient::write(void* plaintext, size_t nn_plaintext, ssize_t* n
         int r0 = SSL_write(ssl, (const void*)p, left);
         int r1 = SSL_get_error(ssl, r0);
         if (r0 <= 0) {
+            ERR_clear_error();
             return srs_error_new(ERROR_HTTPS_WRITE, "https: write data=%p, size=%d, r0=%d, r1=%d", p, left, r0, r1);
         }
 

--- a/trunk/src/protocol/srs_protocol_http_client.hpp
+++ b/trunk/src/protocol/srs_protocol_http_client.hpp
@@ -13,6 +13,7 @@
 #include <map>
 
 #include <openssl/ssl.h>
+#include <openssl/err.h>
 
 #include <srs_protocol_st.hpp>
 #include <srs_protocol_http_stack.hpp>


### PR DESCRIPTION
When you run srs by `./objs/srs -c conf/https.docker.conf`, then we open two player webpages, One player using https-IP, and another player using a local domain. Likely,
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/13824813/232176280-2d3fcd35-01ee-4b09-87a3-f37e022ad703.png">
> It can play successfully.
url1': 'https://127.0.0.1:8088/live/livestream.flv

> It may experience playback failure and will cause the first to stop.
url2': 'https://ossrs.net:8088/live/livestream.flv

---------

`TRANS_BY_GPT3`