### PR TITLE
Replace sprintf with snprintf to eliminate compile warnings. v6.0.45

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-05-14, Merge [#3534](https://github.com/ossrs/srs/pull/3534): Replace sprintf with snprintf to eliminate compile warnings. v6.0.45 (#3534)
 * v6.0, 2023-05-13, Merge [#3541](https://github.com/ossrs/srs/pull/3541): asan: Fix memory leak in asan by releasing global IPs when run_directly_or_daemon fails. v6.0.44 (#3541)
 * v6.0, 2023-05-12, Merge [#3539](https://github.com/ossrs/srs/pull/3539): WHIP: Improve HTTP DELETE for notifying server unpublish event. v6.0.43 (#3539)
 * v6.0, 2023-04-08, Merge [#3495](https://github.com/ossrs/srs/pull/3495): RTMP: Support enhanced RTMP specification for HEVC. v6.0.42 (#3495)

--- a/trunk/research/players/js/srs.page.js
+++ b/trunk/research/players/js/srs.page.js
@@ -35,6 +35,7 @@ function user_extra_params(query, params, rtc) {
             || key === 'http_port' || key === 'pathname' || key === 'port'
             || key === 'server' || key === 'stream' || key === 'buffer'
             || key === 'schema' || key === 'vhost' || key === 'api'
+            || key === 'path'
         ) {
             continue;
         }
@@ -123,12 +124,14 @@ function build_default_whip_whep_url(query, apiPath) {
     console.log('?eip=x.x.x.x to overwrite candidate. 覆盖服务器candidate(外网IP)配置');
     console.log('?api=x to overwrite WebRTC API(1985).');
     console.log('?schema=http|https to overwrite WebRTC API protocol.');
+    console.log(`?path=xxx to overwrite default ${apiPath}`);
 
     var server = (!query.server)? window.location.hostname:query.server;
     var vhost = (!query.vhost)? window.location.hostname:query.vhost;
     var app = (!query.app)? "live":query.app;
     var stream = (!query.stream)? "livestream":query.stream;
     var api = ':' + (query.api || (window.location.protocol === 'http:' ? '1985' : '1990'));
+    const realApiPath = query.path || apiPath;
 
     var queries = [];
     if (server !== vhost && vhost !== "__defaultVhost__") {
@@ -139,7 +142,7 @@ function build_default_whip_whep_url(query, apiPath) {
     }
     queries = user_extra_params(query, queries, true);
 
-    var uri = window.location.protocol + "//" + server + api + apiPath + "?app=" + app + "&stream=" + stream + "&" + queries.join('&');
+    var uri = window.location.protocol + "//" + server + api + realApiPath + "?app=" + app + "&stream=" + stream + "&" + queries.join('&');
     while (uri.lastIndexOf("?") === uri.length - 1) {
         uri = uri.slice(0, uri.length - 1);
     }

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -218,6 +218,16 @@ srs_error_t SrsSemiSecurityTransport::protect_rtcp(void* packet, int* nb_cipher)
     return srs_success;
 }
 
+srs_error_t SrsSemiSecurityTransport::unprotect_rtp(void* packet, int* nb_plaintext)
+{
+    return srs_success;
+}
+
+srs_error_t SrsSemiSecurityTransport::unprotect_rtcp(void* packet, int* nb_plaintext)
+{
+    return srs_success;
+}
+
 SrsPlaintextTransport::SrsPlaintextTransport(ISrsRtcNetwork* s)
 {
     network_ = s;

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -134,6 +134,8 @@ public:
 public:
     srs_error_t protect_rtp(void* packet, int* nb_cipher);
     srs_error_t protect_rtcp(void* packet, int* nb_cipher);
+    srs_error_t unprotect_rtp(void* packet, int* nb_plaintext);
+    srs_error_t unprotect_rtcp(void* packet, int* nb_plaintext);
 };
 
 // Plaintext transport, without DTLS or SRTP.

--- a/trunk/src/app/srs_app_rtc_dtls.cpp
+++ b/trunk/src/app/srs_app_rtc_dtls.cpp
@@ -329,17 +329,20 @@ srs_error_t SrsDtlsCertificate::initialize()
 
     // Show DTLS fingerprint
     if (true) {
-        char fp[100] = {0};
-        char *p = fp;
         unsigned char md[EVP_MAX_MD_SIZE];
         unsigned int n = 0;
 
         // TODO: FIXME: Unused variable.
         /*int r = */X509_digest(dtls_cert, EVP_sha256(), md, &n);
 
+        char* fp = new char[3 * n];
+        SrsAutoFreeA(char, fp);
+        char *p = fp;
+
         for (unsigned int i = 0; i < n; i++, ++p) {
-            snprintf(p, 3, "%02X", md[i]);
-            p += 2;
+            int nb = snprintf(p, 3, "%02X", md[i]);
+            srs_assert(nb > 0 && nb < (3 * n - (p - fp)));
+            p += nb;
 
             if(i < (n-1)) {
                 *p = ':';

--- a/trunk/src/app/srs_app_rtc_dtls.cpp
+++ b/trunk/src/app/srs_app_rtc_dtls.cpp
@@ -338,7 +338,7 @@ srs_error_t SrsDtlsCertificate::initialize()
         /*int r = */X509_digest(dtls_cert, EVP_sha256(), md, &n);
 
         for (unsigned int i = 0; i < n; i++, ++p) {
-            sprintf(p, "%02X", md[i]);
+            snprintf(p, 3, "%02X", md[i]);
             p += 2;
 
             if(i < (n-1)) {

--- a/trunk/src/app/srs_app_tencentcloud.cpp
+++ b/trunk/src/app/srs_app_tencentcloud.cpp
@@ -42,7 +42,7 @@ namespace tencentcloud_api_sign {
         SHA1_Final(digest, &ctx);
         char c_sha1[SHA_DIGEST_LENGTH*2+1];
         for (unsigned i = 0; i < SHA_DIGEST_LENGTH; ++i) {
-            sprintf(&c_sha1[i*2], "%02x", (unsigned int)digest[i]);
+            snprintf(&c_sha1[i*2], 3, "%02x", (unsigned int)digest[i]);
         }
         return c_sha1;
     }
@@ -67,7 +67,7 @@ namespace tencentcloud_api_sign {
         HMAC_CTX_free(ctx);
 #endif
         for (unsigned i = 0; i != digest_len; ++i) {
-            sprintf(&c_hmacsha1[i*2], "%02x", (unsigned int)digest[i]);
+            snprintf(&c_hmacsha1[i*2], 3, "%02x", (unsigned int)digest[i]);
         }
         return c_hmacsha1;
     }

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    44
+#define VERSION_REVISION    45
 
 #endif

--- a/trunk/src/protocol/srs_protocol_json.cpp
+++ b/trunk/src/protocol/srs_protocol_json.cpp
@@ -567,7 +567,8 @@ json_value * json_parse_ex (json_settings * settings,
             if (flags & flag_string)
             {
                 if (!b)
-                {  sprintf (error, "Unexpected EOF in string (at %d:%d)", line_and_col);
+                {
+                    snprintf(error, json_error_max, "Unexpected EOF in string (at %d:%d)", line_and_col);
                     goto e_failed;
                 }
                 
@@ -593,7 +594,7 @@ json_value * json_parse_ex (json_settings * settings,
                                 (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
                                 (uc_b4 = hex_value (*++ state.ptr)) == 0xFF)
                             {
-                                sprintf (error, "Invalid character value `%c` (at %d:%d)", b, line_and_col);
+                                snprintf(error, json_error_max, "Invalid character value `%c` (at %d:%d)", b, line_and_col);
                                 goto e_failed;
                             }
                             
@@ -610,7 +611,7 @@ json_value * json_parse_ex (json_settings * settings,
                                     (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
                                     (uc_b4 = hex_value (*++ state.ptr)) == 0xFF)
                                 {
-                                    sprintf (error, "Invalid character value `%c` (at %d:%d)", b, line_and_col);
+                                    snprintf(error, json_error_max, "Invalid character value `%c` (at %d:%d)", b, line_and_col);
                                     goto e_failed;
                                 }
                                 
@@ -739,7 +740,8 @@ json_value * json_parse_ex (json_settings * settings,
                     if (flags & flag_block_comment)
                     {
                         if (!b)
-                        {  sprintf (error, "%d:%d: Unexpected EOF in block comment", line_and_col);
+                        {
+                            snprintf(error, json_error_max, "%d:%d: Unexpected EOF in block comment", line_and_col);
                             goto e_failed;
                         }
                         
@@ -755,12 +757,14 @@ json_value * json_parse_ex (json_settings * settings,
                 else if (b == '/')
                 {
                     if (! (flags & (flag_seek_value | flag_done)) && top->type != json_object)
-                    {  sprintf (error, "%d:%d: Comment not allowed here", line_and_col);
+                    {
+                        snprintf(error, json_error_max, "%d:%d: Comment not allowed here", line_and_col);
                         goto e_failed;
                     }
                     
                     if (++ state.ptr == end)
-                    {  sprintf (error, "%d:%d: EOF unexpected", line_and_col);
+                    {
+                        snprintf(error, json_error_max, "%d:%d: EOF unexpected", line_and_col);
                         goto e_failed;
                     }
                     
@@ -775,7 +779,7 @@ json_value * json_parse_ex (json_settings * settings,
                             continue;
                             
                         default:
-                            sprintf (error, "%d:%d: Unexpected `%c` in comment opening sequence", line_and_col, b);
+                            snprintf(error, json_error_max, "%d:%d: Unexpected `%c` in comment opening sequence", line_and_col, b);
                             goto e_failed;
                     };
                 }
@@ -793,7 +797,7 @@ json_value * json_parse_ex (json_settings * settings,
                         
                     default:
                         
-                        sprintf (error, "%d:%d: Trailing garbage: `%c`",
+                        snprintf(error, json_error_max, "%d:%d: Trailing garbage: `%c`",
                                  state.cur_line, state.cur_col, b);
                         
                         goto e_failed;
@@ -812,7 +816,8 @@ json_value * json_parse_ex (json_settings * settings,
                         if (top && top->type == json_array)
                             flags = (flags & ~ (flag_need_comma | flag_seek_value)) | flag_next;
                         else
-                        {  sprintf (error, "%d:%d: Unexpected ]", line_and_col);
+                        {
+                            snprintf(error, json_error_max, "%d:%d: Unexpected ]", line_and_col);
                             goto e_failed;
                         }
                         
@@ -828,7 +833,7 @@ json_value * json_parse_ex (json_settings * settings,
                             }
                             else
                             {
-                                sprintf (error, "%d:%d: Expected , before %c",
+                                snprintf(error, json_error_max, "%d:%d: Expected , before %c",
                                          state.cur_line, state.cur_col, b);
                                 
                                 goto e_failed;
@@ -843,7 +848,7 @@ json_value * json_parse_ex (json_settings * settings,
                             }
                             else
                             {
-                                sprintf (error, "%d:%d: Expected : before %c",
+                                snprintf(error, json_error_max, "%d:%d: Expected : before %c",
                                          state.cur_line, state.cur_col, b);
                                 
                                 goto e_failed;
@@ -969,7 +974,8 @@ json_value * json_parse_ex (json_settings * settings,
                                 continue;
                             }
                             else
-                            {  sprintf (error, "%d:%d: Unexpected %c when seeking value", line_and_col, b);
+                            {
+                                snprintf(error, json_error_max, "%d:%d: Unexpected %c when seeking value", line_and_col, b);
                                 goto e_failed;
                             }
                     };
@@ -989,7 +995,8 @@ json_value * json_parse_ex (json_settings * settings,
                         case '"':
                             
                             if (flags & flag_need_comma)
-                            {  sprintf (error, "%d:%d: Expected , before \"", line_and_col);
+                            {
+                                snprintf(error, json_error_max, "%d:%d: Expected , before \"", line_and_col);
                                 goto e_failed;
                             }
                             
@@ -1014,7 +1021,7 @@ json_value * json_parse_ex (json_settings * settings,
                             }
                             
                         default:
-                            sprintf (error, "%d:%d: Unexpected `%c` in object", line_and_col, b);
+                            snprintf(error, json_error_max, "%d:%d: Unexpected `%c` in object", line_and_col, b);
                             goto e_failed;
                     };
                         
@@ -1032,7 +1039,8 @@ json_value * json_parse_ex (json_settings * settings,
                                 if (! (flags & flag_num_e))
                                 {
                                     if (flags & flag_num_zero)
-                                    {  sprintf (error, "%d:%d: Unexpected `0` before `%c`", line_and_col, b);
+                                    {
+                                        snprintf(error, json_error_max, "%d:%d: Unexpected `0` before `%c`", line_and_col, b);
                                         goto e_failed;
                                     }
                                     
@@ -1069,7 +1077,8 @@ json_value * json_parse_ex (json_settings * settings,
                         else if (b == '.' && top->type == json_integer)
                         {
                             if (!num_digits)
-                            {  sprintf (error, "%d:%d: Expected digit before `.`", line_and_col);
+                            {
+                                snprintf(error, json_error_max, "%d:%d: Expected digit before `.`", line_and_col);
                                 goto e_failed;
                             }
                             
@@ -1085,7 +1094,8 @@ json_value * json_parse_ex (json_settings * settings,
                             if (top->type == json_double)
                             {
                                 if (!num_digits)
-                                {  sprintf (error, "%d:%d: Expected digit after `.`", line_and_col);
+                                {
+                                    snprintf(error, json_error_max, "%d:%d: Expected digit after `.`", line_and_col);
                                     goto e_failed;
                                 }
                                 
@@ -1111,7 +1121,8 @@ json_value * json_parse_ex (json_settings * settings,
                         else
                         {
                             if (!num_digits)
-                            {  sprintf (error, "%d:%d: Expected digit after `e`", line_and_col);
+                            {
+                                snprintf(error, json_error_max, "%d:%d: Expected digit after `e`", line_and_col);
                                 goto e_failed;
                             }
                             
@@ -1196,8 +1207,8 @@ json_value * json_parse_ex (json_settings * settings,
     return root;
     
 e_unknown_value:
-    
-    sprintf (error, "%d:%d: Unknown value", line_and_col);
+
+    snprintf(error, json_error_max, "%d:%d: Unknown value", line_and_col);
     goto e_failed;
     
 e_alloc_failure:
@@ -1206,8 +1217,8 @@ e_alloc_failure:
     goto e_failed;
     
 e_overflow:
-    
-    sprintf (error, "%d:%d: Too long (caught overflow)", line_and_col);
+
+    snprintf(error, json_error_max, "%d:%d: Too long (caught overflow)", line_and_col);
     goto e_failed;
     
 e_failed:

--- a/trunk/src/utest/srs_utest_core.cpp
+++ b/trunk/src/utest/srs_utest_core.cpp
@@ -54,7 +54,7 @@ VOID TEST(CoreLogger, CheckVsnprintf)
         HELPER_ARRAY_INIT(buf, sizeof(buf), 0xf);
 
         // Return the number of characters printed.
-        EXPECT_EQ(6, sprintf(buf, "%s", "Hello!"));
+        EXPECT_EQ(6, snprintf(buf, sizeof(buf), "%s", "Hello!"));
         EXPECT_EQ('H', buf[0]);
         EXPECT_EQ('!', buf[5]);
         EXPECT_EQ(0x0, buf[6]);


### PR DESCRIPTION
- Replaced all occurrences of sprintf with snprintf to address deprecation warnings
- Ensured proper buffer size is passed to snprintf to prevent potential buffer overflows
- Ran tests to confirm that the changes do not introduce any new issues or regressions

Remove compile warnings by using snprintf instead of sprintf, likely

```bash
warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  
Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
sprintf(error, "%d:%d: Unknown value", line_and_col);
```