### PR TITLE
WHIP: Improve HTTP DELETE for notifying server unpublish event

### DIFF
--- a/trunk/src/app/srs_app_rtc_api.hpp
+++ b/trunk/src/app/srs_app_rtc_api.hpp
@@ -58,6 +58,7 @@ private:
 class SrsGoApiRtcWhip : public ISrsHttpHandler
 {
 private:
+    SrsRtcServer* server_;
     SrsGoApiRtcPublish* publish_;
     SrsGoApiRtcPlay* play_;
 public:


### PR DESCRIPTION
This PR improves the functionality of the HTTP DELETE method used by WHIP to notify the server when the client stops publishing. The URL is parsed from the location header returned by SRS, and the URL is refined with the addition of the `action=delete` parameter to ensure more accurate identification of the DELETE request.

Furthermore, SRS will disconnect and close the session, enabling the client to publish the stream again quickly and easily. This update eliminates the approximately 30-second waiting period previously required for republishing the stream after an unpublish event.

Overall, this update provides a more effective and efficient method for notifying the server about unpublish events and will enhance the workflow experience for users of the WHIP platform.
