### PR TITLE
asan: Fix memory leak in asan by releasing global IPs when run_directly_or_daemon fails. v5.0.154, v6.0.44

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-05-13, Merge [#3541](https://github.com/ossrs/srs/pull/3541): asan: Fix memory leak in asan by releasing global IPs when run_directly_or_daemon fails. v6.0.44 (#3541)
 * v6.0, 2023-05-12, Merge [#3539](https://github.com/ossrs/srs/pull/3539): WHIP: Improve HTTP DELETE for notifying server unpublish event. v6.0.43 (#3539)
 * v6.0, 2023-04-08, Merge [#3495](https://github.com/ossrs/srs/pull/3495): RTMP: Support enhanced RTMP specification for HEVC. v6.0.42 (#3495)
 * v6.0, 2023-04-01, Merge [#3392](https://github.com/ossrs/srs/pull/3392): Support composited bridges for 1:N protocols converting. v6.0.41 (#3392)
@@ -57,6 +58,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-05-13, Merge [#3541](https://github.com/ossrs/srs/pull/3541): asan: Fix memory leak in asan by releasing global IPs when run_directly_or_daemon fails. v5.0.154 (#3541)
 * v5.0, 2023-05-12, Merge [#3539](https://github.com/ossrs/srs/pull/3539): WHIP: Improve HTTP DELETE for notifying server unpublish event. v5.0.153 (#3539)
 * v5.0, 2023-03-27, Merge [#3450](https://github.com/ossrs/srs/pull/3450): WebRTC: Error message carries the SDP when failed. v5.0.151 (#3450)
 * v5.0, 2023-03-25, Merge [#3477](https://github.com/ossrs/srs/pull/3477): Remove unneccessary NULL check in srs_freep. v5.0.150 (#3477)

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    153
+#define VERSION_REVISION    154
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    43
+#define VERSION_REVISION    44
 
 #endif

--- a/trunk/src/main/srs_main_server.cpp
+++ b/trunk/src/main/srs_main_server.cpp
@@ -243,6 +243,7 @@ srs_error_t do_main(int argc, char** argv, char** envp)
 #endif
     
     if ((err = run_directly_or_daemon()) != srs_success) {
+        srs_free_global_system_ips();
         return srs_error_wrap(err, "run");
     }
 

--- a/trunk/src/main/srs_main_server.cpp
+++ b/trunk/src/main/srs_main_server.cpp
@@ -241,13 +241,12 @@ srs_error_t do_main(int argc, char** argv, char** envp)
 #ifdef SRS_SANITIZER_LOG
     __asan_set_error_report_callback(asan_report_callback);
 #endif
-    
-    if ((err = run_directly_or_daemon()) != srs_success) {
-        srs_free_global_system_ips();
+
+    err = run_directly_or_daemon();
+    srs_free_global_system_ips();
+    if (err != srs_success) {
         return srs_error_wrap(err, "run");
     }
-
-    srs_free_global_system_ips();
 
     return err;
 }


### PR DESCRIPTION
- Resolved a memory leak issue in asan when run_directly_or_daemon fails
- Previously, global IP lists were not freed, causing asan to report memory leaks
- Updated the code to always free global IP lists, regardless of whether run_directly_or_daemon fails or succeeds