### PR TITLE
WHIP: Add OBS support, ensuring compatibility with a unique SDP. v5.0.158, v6.0.51

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for SRS.
 
 ## SRS 6.0 Changelog
 
+* v6.0, 2023-06-15, Merge [#3581](https://github.com/ossrs/srs/pull/3581): WHIP: Add OBS support, ensuring compatibility with a unique SDP. v6.0.50 (#3581)
 * v6.0, 2023-06-12, Merge [#3570](https://github.com/ossrs/srs/pull/3570): GB: Correct the range of keyframe error for compile warning. v6.0.49 (#3570)
 * v6.0, 2023-06-05, Fix command injection in demonstration api-server for HTTP callback. v6.0.48
 * v6.0, 2023-06-05, Merge [#3565](https://github.com/ossrs/srs/pull/3565): DTLS: Use bio callback to get fragment packet. v6.0.47 (#3565)
@@ -63,6 +64,7 @@ The changelog for SRS.
 
 ## SRS 5.0 Changelog
 
+* v5.0, 2023-06-15, Merge [#3581](https://github.com/ossrs/srs/pull/3581): WHIP: Add OBS support, ensuring compatibility with a unique SDP. v5.0.158 (#3581)
 * v5.0, 2023-06-05, Fix command injection in demonstration api-server for HTTP callback. v5.0.157
 * v5.0, 2023-06-05, Merge [#3565](https://github.com/ossrs/srs/pull/3565): DTLS: Use bio callback to get fragment packet. v5.0.156 (#3565)
 * v5.0, 2023-05-29, Merge [#3513](https://github.com/ossrs/srs/pull/3513): SSL: Fix SSL_get_error get the error of other coroutine. v5.0.155 (#3513)

--- a/trunk/src/app/srs_app_rtc_sdp.cpp
+++ b/trunk/src/app/srs_app_rtc_sdp.cpp
@@ -940,7 +940,12 @@ void SrsSdp::add_candidate(const std::string& protocol, const std::string& ip, c
 
 std::string SrsSdp::get_ice_ufrag() const
 {
-    // Becaues we use BUNDLE, so we can choose the first element.
+    // For OBS WHIP, use the global ice-ufrag.
+    if (!session_info_.ice_ufrag_.empty()) {
+        return session_info_.ice_ufrag_;
+    }
+
+    // Because we use BUNDLE, so we can choose the first element.
     for (std::vector<SrsMediaDesc>::const_iterator iter = media_descs_.begin(); iter != media_descs_.end(); ++iter) {
         const SrsMediaDesc* desc = &(*iter);
         return desc->session_info_.ice_ufrag_;
@@ -951,7 +956,12 @@ std::string SrsSdp::get_ice_ufrag() const
 
 std::string SrsSdp::get_ice_pwd() const
 {
-    // Becaues we use BUNDLE, so we can choose the first element.
+    // For OBS WHIP, use the global ice pwd.
+    if (!session_info_.ice_pwd_.empty()) {
+        return session_info_.ice_pwd_;
+    }
+
+    // Because we use BUNDLE, so we can choose the first element.
     for (std::vector<SrsMediaDesc>::const_iterator iter = media_descs_.begin(); iter != media_descs_.end(); ++iter) {
         const SrsMediaDesc* desc = &(*iter);
         return desc->session_info_.ice_pwd_;
@@ -962,7 +972,7 @@ std::string SrsSdp::get_ice_pwd() const
 
 std::string SrsSdp::get_dtls_role() const
 {
-    // Becaues we use BUNDLE, so we can choose the first element.
+    // Because we use BUNDLE, so we can choose the first element.
     for (std::vector<SrsMediaDesc>::const_iterator iter = media_descs_.begin(); iter != media_descs_.end(); ++iter) {
         const SrsMediaDesc* desc = &(*iter);
         return desc->session_info_.setup_;
@@ -1131,6 +1141,12 @@ srs_error_t SrsSdp::parse_attr_group(const std::string& value)
 {
     srs_error_t err = srs_success;
     // @see: https://tools.ietf.org/html/rfc5888#section-5
+
+    // Overlook the OBS WHIP group LS, as it is utilized for synchronizing the playback of
+    // the relevant media streams, see https://datatracker.ietf.org/doc/html/rfc5888#section-7
+    if (srs_string_starts_with(value, "LS")) {
+        return err;
+    }
 
     std::istringstream is(value);
 

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -684,7 +684,10 @@ std::vector<SrsRtcTrackDescription*> SrsRtcSource::get_track_desc(std::string ty
         if (! stream_desc_->audio_track_desc_) {
             return track_descs;
         }
-        if (stream_desc_->audio_track_desc_->media_->name_ == media_name) {
+
+        string name = stream_desc_->audio_track_desc_->media_->name_;
+        std::transform(name.begin(), name.end(), name.begin(), static_cast<int(*)(int)>(std::tolower));
+        if (name == media_name) {
             track_descs.push_back(stream_desc_->audio_track_desc_);
         }
     }

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    157
+#define VERSION_REVISION    158
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    49
+#define VERSION_REVISION    50
 
 #endif


### PR DESCRIPTION
1. Ignore SDP GROUP LS.
2. Support ice in global session info.
3. Support audio codec "OPUS" or "opus".

See https://github.com/obsproject/obs-studio/pull/7926

Known issue: 

* #3583
* #3582

See also #3170