### PR TITLE
4.0 srt bug

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -30,6 +30,7 @@ The changelog for SRS.
 * v4.0, 2022-03-19, Merge [#2908](https://github.com/ossrs/srs/pull/2908): SRT: url supports multiple QueryStrings (#2908). v4.0.250
 * v4.0, 2022-03-17, SRT: Support debug and run with CLion. v4.0.249
 * v4.0, 2022-03-15, Merge [#2966](https://github.com/ossrs/srs/pull/2966): Bugfix: Fix rtcp nack blp encode bug (#2966). v4.0.248
+* v4.0, 2022-03-11, Merge [#2914](https://github.com/ossrs/srs/pull/2914): Security: Enable CIDR for allow/deny play/publish.
 * v4.0, 2022-03-07, RTC: Identify the WebRTC publisher in param for hooks. v4.0.247
 * v4.0, 2022-03-07, SRT: Append vhost to stream, not app. v4.0.246
 * v4.0, 2022-02-15, Fix warnings for uuid. v4.0.245

--- a/trunk/src/srt/srt_handle.cpp
+++ b/trunk/src/srt/srt_handle.cpp
@@ -263,7 +263,7 @@ void srt_handle::handle_push_data(SRT_SOCKSTATUS status, const std::string& path
 void srt_handle::check_alive() {
     long long diff_t;
     std::list<SRT_CONN_PTR> conn_list;
-    auto srt_now_ms = now_ms();
+    srt_now_ms = now_ms();
 
     if (_last_check_alive_ts == 0) {
         _last_check_alive_ts = srt_now_ms;

--- a/trunk/src/srt/srt_handle.cpp
+++ b/trunk/src/srt/srt_handle.cpp
@@ -263,6 +263,7 @@ void srt_handle::handle_push_data(SRT_SOCKSTATUS status, const std::string& path
 void srt_handle::check_alive() {
     long long diff_t;
     std::list<SRT_CONN_PTR> conn_list;
+    auto srt_now_ms = now_ms();
 
     if (_last_check_alive_ts == 0) {
         _last_check_alive_ts = srt_now_ms;


### PR DESCRIPTION
Please describe the summary for this PR.
srt serve error code=6007(SrtStreamBusy)(SRT stream alredy exists or busy) : srt stream /k=livegw/d7f58fe0ef busy
![image](https://github.com/ossrs/srs/assets/20635217/9ff8420d-adec-4c52-a973-ea6de6e1a360)