### PR TITLE
SRT check SRT alive bug.

### DIFF
--- a/trunk/src/srt/srt_handle.cpp
+++ b/trunk/src/srt/srt_handle.cpp
@@ -263,7 +263,7 @@ void srt_handle::handle_push_data(SRT_SOCKSTATUS status, const std::string& path
 void srt_handle::check_alive() {
     long long diff_t;
     std::list<SRT_CONN_PTR> conn_list;
-    auto srt_now_ms = now_ms();
+    srt_now_ms = now_ms();
 
     if (_last_check_alive_ts == 0) {
         _last_check_alive_ts = srt_now_ms;

--- a/trunk/src/srt/srt_handle.cpp
+++ b/trunk/src/srt/srt_handle.cpp
@@ -263,6 +263,7 @@ void srt_handle::handle_push_data(SRT_SOCKSTATUS status, const std::string& path
 void srt_handle::check_alive() {
     long long diff_t;
     std::list<SRT_CONN_PTR> conn_list;
+    auto srt_now_ms = now_ms();
 
     if (_last_check_alive_ts == 0) {
         _last_check_alive_ts = srt_now_ms;


### PR DESCRIPTION
Please describe the summary for this PR.
srt serve error code=6007(SrtStreamBusy)(SRT stream alredy exists or busy) : srt stream /k=livegw/d7f58fe0ef busy
![image](https://github.com/ossrs/srs/assets/20635217/88ddd0f7-e753-4539-b3ac-fd4dc6be8d98)
