### PR TITLE
Bugfix: Resolved the problem of player not playing FLV in 5.0release.

### DIFF
--- a/trunk/research/players/srs_player.html
+++ b/trunk/research/players/srs_player.html
@@ -242,7 +242,7 @@
                 return;
             }
 
-            show_for_video_ok();
+            show_for_ok();
 
             flvPlayer = mpegts.createPlayer({type: 'flv', url: r.url, isLive: true, enableStashBuffer: false});
             flvPlayer.attachMediaElement(document.getElementById('video_player'));


### PR DESCRIPTION
srs version:5.0-b1 
srs_player cannot play flv video. I found out the cause of the mistake (show_for_video_ok is not defined).
This piece of code was added in a previous commit
But in 5.0 this function is called "show_for_ok"

---------

`TRANS_BY_GPT3`