### PR TITLE
Bugfix: Avoid repeat transcoding when the transcode is the same and source ip is localhost

### DIFF
--- a/trunk/src/app/srs_app_encoder.hpp
+++ b/trunk/src/app/srs_app_encoder.hpp
@@ -45,7 +45,7 @@ private:
     virtual SrsFFMPEG* at(int index);
     virtual srs_error_t parse_scope_engines(SrsRequest* req);
     virtual srs_error_t parse_ffmpeg(SrsRequest* req, SrsConfDirective* conf);
-    virtual srs_error_t initialize_ffmpeg(SrsFFMPEG* ffmpeg, SrsRequest* req, SrsConfDirective* engine);
+    virtual srs_error_t initialize_ffmpeg(SrsFFMPEG* ffmpeg, SrsRequest* req, SrsConfDirective* conf, SrsConfDirective* engine);
     virtual void show_encode_log_message();
 };
 


### PR DESCRIPTION
When transcoding, if the output is set as "rtmp://127.0.0.1:[port]/[app]/[stream]_[engine]?vhost=[vhost]", 
the source ip is "127.0.0.1", then it will cause repeated transcoding on the same server  and the program crash.

For example:
```
-rw-rw-r-- 1 li li 9.6K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream.log
-rw-rw-r-- 1 li li 9.4K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream_.log
-rw-rw-r-- 1 li li 8.8K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream__.log
-rw-rw-r-- 1 li li 8.5K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream___.log
-rw-rw-r-- 1 li li 8.3K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream____.log
-rw-rw-r-- 1 li li 8.1K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream_____.log
-rw-rw-r-- 1 li li 7.5K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream______.log
-rw-rw-r-- 1 li li 7.4K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream_______.log
-rw-rw-r-- 1 li li 6.9K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream________.log
-rw-rw-r-- 1 li li 6.8K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream_________.log
-rw-rw-r-- 1 li li 3.3K  Jul  6 12:54 ffmpeg-encoder-__defaultVhost__-live-livestream__________.log

```

---------

`TRANS_BY_GPT3`