### PR TITLE
The identifier "ShowCouroutines" needs to be modified to "ShowCoroutines" in order to rectify the typographical error. v6.0.63

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-07-27, Merge [#3703](https://github.com/ossrs/srs/pull/3703): The identifier "ShowCouroutines" needs to be modified to "ShowCoroutines" in order to rectify the typographical error.. v6.0.62 (#3703)
 * v6.0, 2023-07-26, Merge [#3699](https://github.com/ossrs/srs/pull/3699): Bugfix: Eliminate the redundant declaration of the _srs_rtc_manager variable.. v6.0.61 (#3699)
 * v6.0, 2023-07-21, Merge [#3695](https://github.com/ossrs/srs/pull/3695): API: Fix HTTPS callback issue using SNI in TLS client handshake. v6.0.61 (#3695)
 * v6.0, 2023-07-18, Merge [#3515](https://github.com/ossrs/srs/pull/3515): WebRTC: Support config the bitrate of transcoding AAC to Opus. v6.0.60 (#3515)

--- a/trunk/gdb/srs.py
+++ b/trunk/gdb/srs.py
@@ -40,9 +40,9 @@ NnCouroutines()
 Usage:
     show_coroutines
 '''
-class ShowCouroutines(gdb.Command):
+class ShowCoroutines(gdb.Command):
     def __init__(self):
-        super(ShowCouroutines, self).__init__('show_coroutines', gdb.COMMAND_DATA)
+        super(ShowCoroutines, self).__init__('show_coroutines', gdb.COMMAND_DATA)
 
     # https://sourceware.org/gdb/current/onlinedocs/gdb/Python-API.html#Python-API
     def invoke(self, arg, from_tty):
@@ -67,4 +67,4 @@ class ShowCouroutines(gdb.Command):
             print('Error: prev=%s, this=%s, next=%s'%(prev, pthis, pnext))
             traceback.print_exc()
 
-ShowCouroutines()
+ShowCoroutines()

--- a/trunk/gdb/srs.py
+++ b/trunk/gdb/srs.py
@@ -5,9 +5,9 @@ Usage:
     nn_coroutines
     nn_coroutines 1000
 '''
-class NnCouroutines(gdb.Command):
+class NnCoroutines(gdb.Command):
     def __init__(self):
-        super(NnCouroutines, self).__init__('nn_coroutines', gdb.COMMAND_DATA)
+        super(NnCoroutines, self).__init__('nn_coroutines', gdb.COMMAND_DATA)
 
     # https://sourceware.org/gdb/current/onlinedocs/gdb/Python-API.html#Python-API
     def invoke(self, arg, from_tty):
@@ -34,7 +34,7 @@ class NnCouroutines(gdb.Command):
         # Result.
         print('total coroutines: %s'%(nn_coroutines))
 
-NnCouroutines()
+NnCoroutines()
 
 '''
 Usage:

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    62
+#define VERSION_REVISION    63
 
 #endif


### PR DESCRIPTION
Correct the word errors by changing "ShowCoroutines" to "ShowCoroutines".

---------

 `TRANS_BY_GPT3`

---------

Co-authored-by: chundonglinlin <chundonglinlin@163.com>
Co-authored-by: john <hondaxiao@tencent.com>