### PR TITLE
Rtcp sr and rr for rtc play

### DIFF
--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -1364,18 +1364,14 @@ srs_error_t SrsRtcPublishStream::send_rtcp_rr()
 {
     srs_error_t err = srs_success;
 
-    for (std::vector<SrsRtcVideoRecvTrack*>::iterator iter = video_tracks_.begin();
-         iter != video_tracks_.end();
-         iter++) {
+    for (std::vector<SrsRtcVideoRecvTrack*>::iterator iter = video_tracks_.begin(); iter != video_tracks_.end(); iter++) {
         SrsRtcVideoRecvTrack* track = *iter;
         if ((err = track->send_rtcp_rr()) != srs_success) {
             return srs_error_wrap(err, "send rtcp rr error, videotrack=%s", track->get_track_id().c_str());
         }
     }
 
-    for (std::vector<SrsRtcAudioRecvTrack*>::iterator iter = audio_tracks_.begin();
-         iter != audio_tracks_.end();
-         iter++) {
+    for (std::vector<SrsRtcAudioRecvTrack*>::iterator iter = audio_tracks_.begin(); iter != audio_tracks_.end(); iter++) {
         SrsRtcAudioRecvTrack* track = *iter;
         if ((err = track->send_rtcp_rr()) != srs_success) {
             return srs_error_wrap(err, "send rtcp rr error: audiotrack=%s", track->get_track_id().c_str());

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -985,7 +985,7 @@ srs_error_t SrsRtcPlayRtcpTimer::on_timer(srs_utime_t interval)
         return err;
     }
 
-    srs_utime_t now_ms = srs_update_system_time();
+    srs_utime_t now_ms = srs_update_system_time() / 1000;
     if ((err = p_->send_rtcp_sr(now_ms)) != srs_success) {
         srs_warn("RR err %s", srs_error_desc(err).c_str());
         srs_freep(err);

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -2148,9 +2148,7 @@ srs_error_t SrsRtcConnection::dispatch_rtcp(SrsRtcpCommon* rtcp)
         if (rr->rr_blocks_.empty()) { //for native client
             return err;
         }
-        for (std::vector<SrsRtcpRB>::iterator iter = rr->rr_blocks_.begin();
-             iter != rr->rr_blocks_.end();
-             iter++) {
+        for (std::vector<SrsRtcpRB>::iterator iter = rr->rr_blocks_.begin(); iter != rr->rr_blocks_.end(); iter++) {
             SrsRtcpRB& rb = *iter;
             if (rb.ssrc == 0) {
                 return err;
@@ -2166,9 +2164,7 @@ srs_error_t SrsRtcConnection::dispatch_rtcp(SrsRtcpCommon* rtcp)
     } else if (SrsRtcpType_rr == rtcp->type()) {
         SrsRtcpRR* rr = dynamic_cast<SrsRtcpRR*>(rtcp);
 
-        for (std::vector<SrsRtcpRB>::iterator iter = rr->rr_blocks_.begin();
-             iter != rr->rr_blocks_.end();
-             iter++) {
+        for (std::vector<SrsRtcpRB>::iterator iter = rr->rr_blocks_.begin(); iter != rr->rr_blocks_.end(); iter++) {
             SrsRtcpRB& rb = *iter;
             uint32_t ssrc = rb.ssrc;
             std::map<uint32_t, SrsRtcPlayStream*>::iterator it = players_ssrc_map_.find(ssrc);

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -264,7 +264,7 @@ public:
 public:
     virtual srs_error_t cycle();
 public:
-    srs_error_t send_rtcp_sr();
+    srs_error_t send_rtcp_sr(int64_t now_ms);
 private:
     srs_error_t send_packet(SrsRtpPacket*& pkt);
 public:

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -56,6 +56,7 @@ class SrsRtcNetworks;
 class SrsRtcUdpNetwork;
 class ISrsRtcNetwork;
 class SrsRtcTcpNetwork;
+class SrsRtcPlayRtcpTimer;
 
 const uint8_t kSR   = 200;
 const uint8_t kRR   = 201;
@@ -210,6 +211,7 @@ public:
 class SrsRtcPlayStream : public ISrsCoroutineHandler, public ISrsReloadHandler
     , public ISrsRtcPLIWorkerHandler, public ISrsRtcSourceChangeCallback
 {
+friend class SrsRtcPlayRtcpTimer;
 private:
     SrsContextId cid_;
     SrsFastCoroutine* trd_;
@@ -223,6 +225,8 @@ private:
     std::map<uint32_t, SrsRtcVideoSendTrack*> video_tracks_;
     // The pithy print for special stage.
     SrsErrorPithyPrint* nack_epp;
+private:
+    SrsRtcPlayRtcpTimer* timer_rtcp_;
 private:
     // Fast cache for tracks.
     uint32_t cache_ssrc0_;
@@ -259,6 +263,8 @@ public:
     virtual void stop();
 public:
     virtual srs_error_t cycle();
+public:
+    srs_error_t send_rtcp_sr();
 private:
     srs_error_t send_packet(SrsRtpPacket*& pkt);
 public:
@@ -285,6 +291,19 @@ private:
 public:
     SrsRtcPublishRtcpTimer(SrsRtcPublishStream* p);
     virtual ~SrsRtcPublishRtcpTimer();
+// interface ISrsFastTimer
+private:
+    srs_error_t on_timer(srs_utime_t interval);
+};
+
+// A fast timer for play stream, for RTCP feedback.
+class SrsRtcPlayRtcpTimer : public ISrsFastTimer
+{
+private:
+    SrsRtcPlayStream* p_;
+public:
+    SrsRtcPlayRtcpTimer(SrsRtcPlayStream* p);
+    virtual ~SrsRtcPlayRtcpTimer();
 // interface ISrsFastTimer
 private:
     srs_error_t on_timer(srs_utime_t interval);

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -276,7 +276,7 @@ private:
     srs_error_t on_rtcp_xr(SrsRtcpXr* rtcp);
     srs_error_t on_rtcp_nack(SrsRtcpNack* rtcp);
     srs_error_t on_rtcp_ps_feedback(SrsRtcpFbCommon* rtcp);
-    srs_error_t on_rtcp_rr(SrsRtcpRR* rtcp);
+    srs_error_t on_rtcp_rr(SrsRtcpRR* rtcp, int64_t now_ms);
     uint32_t get_video_publish_ssrc(uint32_t play_ssrc);
 // Interface ISrsRtcPLIWorkerHandler
 public:

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -264,7 +264,7 @@ public:
 public:
     virtual srs_error_t cycle();
 public:
-    srs_error_t send_rtcp_sr(int64_t now_ms);
+    srs_error_t send_rtcp_sr(srs_utime_t now_ms);
 private:
     srs_error_t send_packet(SrsRtpPacket*& pkt);
 public:

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2774,14 +2774,14 @@ srs_error_t SrsRtcSendTrack::handle_rtcp_rr(const SrsRtcpRB& rb, int64_t now_ms)
     if (lsr && dlsr && (compact_ntp > dlsr + lsr)) {
         rtt = compact_ntp - dlsr - lsr;
     }
-    //srs_trace("hand rtcp rr ssrc:%u, compact ntp:%lu, dlsr:%u, lsr:%u",
-    //        rb.ssrc, compact_ntp, dlsr, lsr);
+    srs_info("hand rtcp rr ssrc:%u, compact ntp:%lu, dlsr:%u, lsr:%u",
+            rb.ssrc, compact_ntp, dlsr, lsr);
     rtt_ = static_cast<float>(rtt >> 16) * 1000.0;
     rtt_ += (static_cast<float>(rtt & 0x0000FFFF) / 65536.0) * 1000.0;
 
     avg_rtt_ += (rtt_ - avg_rtt_) / 4.0;
-    //srs_trace("handle rtcp rr ssrc:%u, lost total:%u, lost rate:%.03f, jitter:%u, rtt_:%.02f, avg rtt:%.02f",
-    //        rb.ssrc, lost_total_, lost_rate_, jitter_, rtt_, avg_rtt_);
+    srs_info("handle rtcp rr ssrc:%u, lost total:%u, lost rate:%.03f, jitter:%u, rtt_:%.02f, avg rtt:%.02f",
+            rb.ssrc, lost_total_, lost_rate_, jitter_, rtt_, avg_rtt_);
     return srs_success;
 }
 

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2736,12 +2736,11 @@ void SrsRtcSendTrack::rebuild_packet(SrsRtpPacket* pkt)
     srs_info("RTC: Correct %s seq=%u/%u, ts=%u/%u", track_desc_->type_.c_str(), seq, pkt->header.get_sequence(), ts, pkt->header.get_timestamp());
 }
 
-srs_error_t SrsRtcSendTrack::send_rtcp_sr() {
+srs_error_t SrsRtcSendTrack::send_rtcp_sr(int64_t now_ms) {
     srs_error_t err = srs_success;
     SrsRtcpSR* sr = new SrsRtcpSR();
     uint32_t ssrc = track_desc_->ssrc_;
-    int64_t now_ms = srs_update_system_time()/1000;
-    
+
     last_sr_ntp_ = SrsNtp::from_time_ms(now_ms);
     int64_t current_sr = ((last_sr_ntp_.ntp_second_ & 0xffff) << 16) | (last_sr_ntp_.ntp_fractions_ & 0xffff);
     int64_t diff_ms = now_ms - last_rtp_ms_;

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2773,7 +2773,7 @@ void SrsRtcSendTrack::update_rtp_static(int64_t len, uint32_t rtp_ts) {
     send_count_++;
     send_bytes_ += len;
     last_rtp_pkt_ts_ = rtp_ts;
-    last_rtp_ms_     = srs_get_system_time() / 1000;//ms
+    last_rtp_ms_     = srs_update_system_time() / 1000;//ms
 }
 
 srs_error_t SrsRtcSendTrack::handle_rtcp_rr(const SrsRtcpRB& rb, int64_t now_ms) {

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2829,7 +2829,7 @@ srs_error_t SrsRtcSendTrack::on_nack(SrsRtpPacket** ppkt)
 srs_error_t SrsRtcSendTrack::on_recv_nack(const vector<uint16_t>& lost_seqs)
 {
     srs_error_t err = srs_success;
-    srs_utime_t now_ms = srs_update_system_time();
+    srs_utime_t now_ms = srs_update_system_time() / 1000;
 
     ++_srs_pps_rnack2->sugar;
 

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2710,6 +2710,42 @@ void SrsRtcSendTrack::rebuild_packet(SrsRtpPacket* pkt)
     srs_info("RTC: Correct %s seq=%u/%u, ts=%u/%u", track_desc_->type_.c_str(), seq, pkt->header.get_sequence(), ts, pkt->header.get_timestamp());
 }
 
+srs_error_t SrsRtcSendTrack::send_rtcp_sr() {
+    srs_error_t err = srs_success;
+    SrsRtcpSR* video_sr = new SrsRtcpSR();
+    uint32_t ssrc = track_desc_->ssrc_;
+    int64_t now_ms = srs_get_system_time() / 1000;//ms
+    
+    last_sr_ntp_ = SrsNtp::from_time_ms(now_ms);
+
+    int64_t diff_ms = now_ms - last_rtp_ms_;
+    int64_t diff_ts = diff_ms * track_desc_->media_->sample_ / 1000;
+    int64_t video_rtp_ts = last_rtp_pkt_ts_ + diff_ts;
+
+    video_sr->set_ssrc(ssrc);
+    video_sr->set_ntp(last_sr_ntp_.ntp_);
+    video_sr->set_rtp_ts(video_rtp_ts);
+    video_sr->set_rtp_send_packets(send_count_);
+    video_sr->set_rtp_send_bytes(send_bytes_);
+   
+    char data[1500];
+    SrsBuffer buffer(data, sizeof(data));
+    video_sr->encode(&buffer);
+    delete video_sr;
+    
+    session_->send_rtcp(buffer.data(), buffer.size());
+
+   
+    return err;
+}
+
+void SrsRtcSendTrack::update_rtp_static(int64_t len, uint32_t rtp_ts) {
+    send_count_++;
+    send_bytes_ += len;
+    last_rtp_pkt_ts_ = rtp_ts;
+    last_rtp_ms_     = srs_get_system_time() / 1000;//ms
+}
+
 srs_error_t SrsRtcSendTrack::on_nack(SrsRtpPacket** ppkt)
 {
     srs_error_t err = srs_success;
@@ -2789,6 +2825,7 @@ srs_error_t SrsRtcAudioSendTrack::on_rtp(SrsRtpPacket* pkt)
 
     // Rebuild the sequence number and timestamp of packet, see https://github.com/ossrs/srs/issues/3167
     rebuild_packet(pkt);
+    update_rtp_static(pkt->nb_bytes(), pkt->header.get_timestamp());
 
     if ((err = session_->do_send_packet(pkt)) != srs_success) {
         return srs_error_wrap(err, "raw send");
@@ -2839,6 +2876,7 @@ srs_error_t SrsRtcVideoSendTrack::on_rtp(SrsRtpPacket* pkt)
 
     // Rebuild the sequence number and timestamp of packet, see https://github.com/ossrs/srs/issues/3167
     rebuild_packet(pkt);
+    update_rtp_static(pkt->nb_bytes(), pkt->header.get_timestamp());
 
     if ((err = session_->do_send_packet(pkt)) != srs_success) {
         return srs_error_wrap(err, "raw send");

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2761,7 +2761,7 @@ srs_error_t SrsRtcSendTrack::send_rtcp_sr(int64_t now_ms) {
     SrsBuffer buffer(data, sr->nb_bytes());
     sr->encode(&buffer);
     delete sr;
-    sr = nullptr;
+    sr = NULL;
 
     session_->send_rtcp(buffer.data(), buffer.size());
 

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2645,6 +2645,14 @@ SrsRtcSendTrack::SrsRtcSendTrack(SrsRtcConnection* session, SrsRtcTrackDescripti
     lost_rate_  = 0.0;
     rtt_        = 0.0;
     avg_rtt_    = 10.0;
+
+    send_bytes_      = 0;
+    send_count_      = 0;
+    last_rtp_pkt_ts_ = 0;
+    last_rtp_ms_     = 0;
+    last_sr_         = 0;
+    last_ms_         = 0;
+
 }
 
 SrsRtcSendTrack::~SrsRtcSendTrack()
@@ -2661,7 +2669,7 @@ bool SrsRtcSendTrack::has_ssrc(uint32_t ssrc)
     return track_desc_->has_ssrc(ssrc);
 }
 
-SrsRtpPacket* SrsRtcSendTrack::fetch_rtp_packet(uint16_t seq, int64_t now_ms)
+SrsRtpPacket* SrsRtcSendTrack::fetch_rtp_packet(uint16_t seq, srs_utime_t now_ms)
 {
     SrsRtpPacket* pkt = rtp_queue_->at(seq);
     const int RESEND_MAX = 20;
@@ -2679,15 +2687,14 @@ SrsRtpPacket* SrsRtcSendTrack::fetch_rtp_packet(uint16_t seq, int64_t now_ms)
             pkt->resend_ms_ = now_ms;
             pkt->resend_count_++;
         } else {
-            int64_t diff_t = now_ms - pkt->resend_ms_;
-            int64_t interval = (int64_t)avg_rtt_;
+            srs_utime_t diff_t = now_ms - pkt->resend_ms_;
+            srs_utime_t interval = (srs_utime_t)avg_rtt_;
             interval = (interval > 10) ? (interval - 10) : interval;//for resend interval Residual
-            if (diff_t < (int64_t)interval) {
+            if (diff_t < interval) {
                 return NULL;
             }
             if (pkt->resend_count_ > RESEND_MAX) {
                 srs_warn("the rtp packet(seq=%d) resend count(%d) is too many", seq, pkt->resend_count_);
-                return NULL;
             }
             pkt->resend_ms_ = now_ms;
             pkt->resend_count_++;
@@ -2736,19 +2743,19 @@ void SrsRtcSendTrack::rebuild_packet(SrsRtpPacket* pkt)
     srs_info("RTC: Correct %s seq=%u/%u, ts=%u/%u", track_desc_->type_.c_str(), seq, pkt->header.get_sequence(), ts, pkt->header.get_timestamp());
 }
 
-srs_error_t SrsRtcSendTrack::send_rtcp_sr(int64_t now_ms) {
+srs_error_t SrsRtcSendTrack::send_rtcp_sr(srs_utime_t now_ms) {
     srs_error_t err = srs_success;
     SrsRtcpSR* sr = new SrsRtcpSR();
+    SrsAutoFree(SrsRtcpSR, sr);
+
     uint32_t ssrc = track_desc_->ssrc_;
 
     last_sr_ntp_ = SrsNtp::from_time_ms(now_ms);
     int64_t current_sr = ((last_sr_ntp_.ntp_second_ & 0xffff) << 16) | (last_sr_ntp_.ntp_fractions_ & 0xffff);
-    int64_t diff_ms = now_ms - last_rtp_ms_;
-    int64_t diff_ts = diff_ms * track_desc_->media_->sample_ / 1000;
-    int64_t video_rtp_ts = last_rtp_pkt_ts_ + diff_ts;
+    srs_utime_t diff_ms = now_ms - last_rtp_ms_;
+    srs_utime_t diff_ts = diff_ms * track_desc_->media_->sample_ / 1000;
+    srs_utime_t video_rtp_ts = last_rtp_pkt_ts_ + diff_ts;
 
-    //srs_trace("send rtcp sr ssrc:%u, current_sr:%ld, last_sr:%ld, diff:%ld", ssrc, current_sr, last_sr_, current_sr - last_sr_);
-    //srs_trace("send rtcp sr ssrc:%u, current ms:%ld, last ms:%ld, diff:%ld", ssrc, now_ms, last_ms_, now_ms - last_ms_);
     last_sr_ = current_sr;
     last_ms_ = now_ms;
     sr->set_ssrc(ssrc);
@@ -2757,12 +2764,9 @@ srs_error_t SrsRtcSendTrack::send_rtcp_sr(int64_t now_ms) {
     sr->set_rtp_send_packets(send_count_);
     sr->set_rtp_send_bytes(send_bytes_);
    
-    char data[1500];
+    char data[kRtcpPacketSize];
     SrsBuffer buffer(data, sr->nb_bytes());
     sr->encode(&buffer);
-    delete sr;
-    sr = NULL;
-
     session_->send_rtcp(buffer.data(), buffer.size());
 
     return err;
@@ -2775,7 +2779,7 @@ void SrsRtcSendTrack::update_rtp_static(int64_t len, uint32_t rtp_ts) {
     last_rtp_ms_     = srs_update_system_time() / 1000;//ms
 }
 
-srs_error_t SrsRtcSendTrack::handle_rtcp_rr(const SrsRtcpRB& rb, int64_t now_ms) {
+srs_error_t SrsRtcSendTrack::handle_rtcp_rr(const SrsRtcpRB& rb, srs_utime_t now_ms) {
     jitter_     = rb.jitter;
     lost_rate_  = rb.fraction_lost / 256.0;
     lost_total_ = rb.lost_packets;
@@ -2825,7 +2829,7 @@ srs_error_t SrsRtcSendTrack::on_nack(SrsRtpPacket** ppkt)
 srs_error_t SrsRtcSendTrack::on_recv_nack(const vector<uint16_t>& lost_seqs)
 {
     srs_error_t err = srs_success;
-    int64_t now_ms = srs_update_system_time();
+    srs_utime_t now_ms = srs_update_system_time();
 
     ++_srs_pps_rnack2->sugar;
 

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -700,7 +700,7 @@ public:
     // SrsRtcSendTrack::set_nack_no_copy
     void set_nack_no_copy(bool v) { nack_no_copy_ = v; }
     bool has_ssrc(uint32_t ssrc);
-    SrsRtpPacket* fetch_rtp_packet(uint16_t seq, int64_t now_ms);
+    SrsRtpPacket* fetch_rtp_packet(uint16_t seq, srs_utime_t now_ms);
     bool set_track_status(bool active);
     bool get_track_status();
     std::string get_track_id();
@@ -715,17 +715,17 @@ public:
     virtual srs_error_t on_rtcp(SrsRtpPacket* pkt) = 0;
     virtual srs_error_t on_recv_nack(const std::vector<uint16_t>& lost_seqs);
 public:
-    srs_error_t send_rtcp_sr(int64_t now_ms);
+    srs_error_t send_rtcp_sr(srs_utime_t now_ms);
     void update_rtp_static(int64_t len, uint32_t rtp_ts);
 public:
-    srs_error_t handle_rtcp_rr(const SrsRtcpRB& rb, int64_t now_ms);
+    srs_error_t handle_rtcp_rr(const SrsRtcpRB& rb, srs_utime_t now_ms);
 protected:
-    int64_t send_bytes_      = 0;
-    int64_t send_count_      = 0;
-    int64_t last_rtp_pkt_ts_ = 0;
-    int64_t last_rtp_ms_     = 0;
-    int64_t last_sr_         = 0;//for debug
-    int64_t last_ms_         = 0;//for debug
+    int64_t send_bytes_;
+    int64_t send_count_;
+    int64_t last_rtp_pkt_ts_;
+    srs_utime_t last_rtp_ms_;
+    srs_utime_t last_sr_;
+    srs_utime_t last_ms_;
     SrsNtp  last_sr_ntp_;
 };
 

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -700,7 +700,7 @@ public:
     // SrsRtcSendTrack::set_nack_no_copy
     void set_nack_no_copy(bool v) { nack_no_copy_ = v; }
     bool has_ssrc(uint32_t ssrc);
-    SrsRtpPacket* fetch_rtp_packet(uint16_t seq);
+    SrsRtpPacket* fetch_rtp_packet(uint16_t seq, int64_t now_ms);
     bool set_track_status(bool active);
     bool get_track_status();
     std::string get_track_id();

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -715,7 +715,7 @@ public:
     virtual srs_error_t on_rtcp(SrsRtpPacket* pkt) = 0;
     virtual srs_error_t on_recv_nack(const std::vector<uint16_t>& lost_seqs);
 public:
-    srs_error_t send_rtcp_sr();
+    srs_error_t send_rtcp_sr(int64_t now_ms);
     void update_rtp_static(int64_t len, uint32_t rtp_ts);
 public:
     srs_error_t handle_rtcp_rr(const SrsRtcpRB& rb, int64_t now_ms);

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -22,6 +22,7 @@
 #include <srs_app_hourglass.hpp>
 #include <srs_protocol_format.hpp>
 #include <srs_app_stream_bridge.hpp>
+#include <srs_kernel_rtc_rtcp.hpp>
 
 class SrsRequest;
 class SrsMetaCache;
@@ -685,6 +686,13 @@ private:
     bool nack_no_copy_;
     // The pithy print for special stage.
     SrsErrorPithyPrint* nack_epp;
+private:
+    //for rtcp rr
+    int64_t jitter_;
+    float lost_rate_;
+    int64_t lost_total_;
+    float rtt_;
+    float avg_rtt_;
 public:
     SrsRtcSendTrack(SrsRtcConnection* session, SrsRtcTrackDescription* track_desc, bool is_audio);
     virtual ~SrsRtcSendTrack();
@@ -709,12 +717,15 @@ public:
 public:
     srs_error_t send_rtcp_sr();
     void update_rtp_static(int64_t len, uint32_t rtp_ts);
-
+public:
+    srs_error_t handle_rtcp_rr(const SrsRtcpRB& rb, int64_t now_ms);
 protected:
     int64_t send_bytes_      = 0;
     int64_t send_count_      = 0;
     int64_t last_rtp_pkt_ts_ = 0;
     int64_t last_rtp_ms_     = 0;
+    int64_t last_sr_         = 0;//for debug
+    int64_t last_ms_         = 0;//for debug
     SrsNtp  last_sr_ntp_;
 };
 

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -706,6 +706,16 @@ public:
     virtual srs_error_t on_rtp(SrsRtpPacket* pkt) = 0;
     virtual srs_error_t on_rtcp(SrsRtpPacket* pkt) = 0;
     virtual srs_error_t on_recv_nack(const std::vector<uint16_t>& lost_seqs);
+public:
+    srs_error_t send_rtcp_sr();
+    void update_rtp_static(int64_t len, uint32_t rtp_ts);
+
+protected:
+    int64_t send_bytes_      = 0;
+    int64_t send_count_      = 0;
+    int64_t last_rtp_pkt_ts_ = 0;
+    int64_t last_rtp_ms_     = 0;
+    SrsNtp  last_sr_ntp_;
 };
 
 class SrsRtcAudioSendTrack : public SrsRtcSendTrack

--- a/trunk/src/kernel/srs_kernel_rtc_rtcp.cpp
+++ b/trunk/src/kernel/srs_kernel_rtc_rtcp.cpp
@@ -595,7 +595,10 @@ block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
         return srs_error_wrap(err, "encode header");
     }
     
-    for (SrsRtcpRB& rb : this->rr_blocks_) {
+    for (std::vector<SrsRtcpRB>::iterator iter = this->rr_blocks_.begin();
+         iter != this->rr_blocks_.end();
+         iter++) {
+        SrsRtcpRB& rb = *iter;
         buffer->write_4bytes(rb.ssrc);
         buffer->write_1bytes(rb.fraction_lost);
         buffer->write_3bytes(rb.lost_packets);

--- a/trunk/src/kernel/srs_kernel_rtc_rtcp.hpp
+++ b/trunk/src/kernel/srs_kernel_rtc_rtcp.hpp
@@ -138,6 +138,38 @@ struct SrsRtcpRB
         lsr = 0;
         dlsr = 0;
     }
+    void set_rb_ssrc(uint32_t ssrc)
+    {
+        this->ssrc = ssrc;
+    }
+    void set_lost_rate(float rate)
+    {
+        this->fraction_lost = rate * 256;
+    }
+    void set_lost_packets(uint32_t count)
+    {
+        this->lost_packets = count;
+    }
+    void set_highest_sn(uint32_t sn)
+    {
+        this->highest_sn = sn;
+    }
+    void set_jitter(uint32_t jitter)
+    {
+        this->jitter = jitter;
+    }
+    void set_lsr(uint32_t lsr)
+    {
+        this->lsr = lsr;
+    }
+    void set_dlsr(uint32_t dlsr)
+    {
+        this->dlsr = dlsr;
+    }
+    void set_sender_ntp(uint64_t ntp)
+    {
+        this->lsr = (uint32_t)((ntp >> 16) & 0xFFFFFFFF);
+    }
 };
 
 class SrsRtcpSR : public SrsRtcpCommon
@@ -173,8 +205,8 @@ public:
 
 class SrsRtcpRR : public SrsRtcpCommon
 {
-private:
-    SrsRtcpRB rb_;
+public:
+    std::vector<SrsRtcpRB> rr_blocks_;
 public:
     SrsRtcpRR(uint32_t sender_ssrc = 0);
     virtual ~SrsRtcpRR();
@@ -182,22 +214,6 @@ public:
     // overload SrsRtcpCommon
     virtual uint8_t type() const;
 
-    uint32_t get_rb_ssrc() const;
-    float get_lost_rate() const;
-    uint32_t get_lost_packets() const;
-    uint32_t get_highest_sn() const;
-    uint32_t get_jitter() const;
-    uint32_t get_lsr() const;
-    uint32_t get_dlsr() const;
-
-    void set_rb_ssrc(uint32_t ssrc);
-    void set_lost_rate(float rate);
-    void set_lost_packets(uint32_t count);
-    void set_highest_sn(uint32_t sn);
-    void set_jitter(uint32_t jitter);
-    void set_lsr(uint32_t lsr);
-    void set_dlsr(uint32_t dlsr);
-    void set_sender_ntp(uint64_t ntp);
 // interface ISrsCodec
 public:
     virtual srs_error_t decode(SrsBuffer *buffer);

--- a/trunk/src/kernel/srs_kernel_rtc_rtp.cpp
+++ b/trunk/src/kernel/srs_kernel_rtc_rtp.cpp
@@ -764,6 +764,9 @@ SrsRtpPacket::SrsRtpPacket()
     decode_handler = NULL;
     avsync_time_ = -1;
 
+    //rtp resend for nack
+    resend_count_ = 0;
+    resend_ms_ = -1;
     ++_srs_pps_objs_rtps->sugar;
 }
 

--- a/trunk/src/kernel/srs_kernel_rtc_rtp.hpp
+++ b/trunk/src/kernel/srs_kernel_rtc_rtp.hpp
@@ -292,6 +292,10 @@ public:
     SrsAvcNaluType nalu_type;
     // The frame type, for RTMP bridge or SFU source.
     SrsFrameType frame_type;
+//Rtp resend for rtcp nack
+public:
+    int resend_count_;
+    int64_t resend_ms_;
 // Fast cache for performance.
 private:
     // The cached payload size for packet.

--- a/trunk/src/kernel/srs_kernel_rtc_rtp.hpp
+++ b/trunk/src/kernel/srs_kernel_rtc_rtp.hpp
@@ -295,7 +295,7 @@ public:
 //Rtp resend for rtcp nack
 public:
     int resend_count_;
-    int64_t resend_ms_;
+    srs_utime_t resend_ms_;
 // Fast cache for performance.
 private:
     // The cached payload size for packet.

--- a/trunk/src/utest/srs_utest_rtc.cpp
+++ b/trunk/src/utest/srs_utest_rtc.cpp
@@ -720,15 +720,16 @@ VOID TEST(KernelRTCTest, NACKFetchRTPPacket)
         track->rtp_queue_->set(pkt->header.get_sequence(), pkt);
     }
 
+    int64_t now_ms = srs_update_system_time();
     // If sequence not match, packet not found.
     if (true) {
-        SrsRtpPacket* pkt = track->fetch_rtp_packet(10);
+        SrsRtpPacket* pkt = track->fetch_rtp_packet(10, now_ms);
         EXPECT_TRUE(pkt == NULL);
     }
 
     // The sequence matched, we got the packet.
     if (true) {
-        SrsRtpPacket* pkt = track->fetch_rtp_packet(100);
+        SrsRtpPacket* pkt = track->fetch_rtp_packet(100, now_ms);
         EXPECT_TRUE(pkt != NULL);
     }
 
@@ -740,7 +741,7 @@ VOID TEST(KernelRTCTest, NACKFetchRTPPacket)
         EXPECT_TRUE(pkt != NULL);
 
         // But the track requires exactly match, so it returns NULL.
-        pkt = track->fetch_rtp_packet(1100);
+        pkt = track->fetch_rtp_packet(1100, now_ms);
         EXPECT_TRUE(pkt == NULL);
     }
 }

--- a/trunk/src/utest/srs_utest_rtc.cpp
+++ b/trunk/src/utest/srs_utest_rtc.cpp
@@ -720,7 +720,7 @@ VOID TEST(KernelRTCTest, NACKFetchRTPPacket)
         track->rtp_queue_->set(pkt->header.get_sequence(), pkt);
     }
 
-    int64_t now_ms = srs_update_system_time();
+    srs_utime_t now_ms = srs_update_system_time();
     // If sequence not match, packet not found.
     if (true) {
         SrsRtpPacket* pkt = track->fetch_rtp_packet(10, now_ms);


### PR DESCRIPTION
For WebRTC downlink, add:
* Sending RTCP SR.
* Receiving and processing RTCP RR to calculate RTT.
* Retransmission of NACK based on RTT.

The main functionality is to calculate RTT in the downlink, which prevents unnecessary retransmissions within a time period less than RTT, avoiding unnecessary retransmissions.


---------

`TRANS_BY_GPT3`