### PR TITLE
Incorrect use of two "int i" instances.

### DIFF
--- a/trunk/3rdparty/srs-bench/pcap/main.go
+++ b/trunk/3rdparty/srs-bench/pcap/main.go
@@ -108,12 +108,14 @@ func doMain(ctx context.Context) error {
 		}
 
 		if doRE {
-			if previousTime != nil {
-				if diff := ci.Timestamp.Sub(*previousTime); diff > 0 {
+			if previousTime == nil {
+				previousTime = &ci.Timestamp
+			} else {
+				if diff := ci.Timestamp.Sub(*previousTime); diff > 100*time.Millisecond {
 					time.Sleep(diff)
+					previousTime = &ci.Timestamp
 				}
 			}
-			previousTime = &ci.Timestamp
 		}
 
 		if doTrace {

--- a/trunk/src/app/srs_app_threads.cpp
+++ b/trunk/src/app/srs_app_threads.cpp
@@ -693,8 +693,8 @@ srs_error_t SrsThreadPool::run()
         // Check the threads status fastly.
         int loops = (int)(interval_ / SRS_UTIME_SECONDS);
         for (int i = 0; i < loops; i++) {
-            for (int i = 0; i < (int)threads.size(); i++) {
-                SrsThreadEntry* entry = threads.at(i);
+            for (int j = 0; j < (int)threads.size(); j++) {
+                SrsThreadEntry* entry = threads.at(j);
                 if (entry->err != srs_success) {
                     // Quit with success.
                     if (srs_error_code(entry->err) == ERROR_THREAD_FINISHED) {


### PR DESCRIPTION
Incorrect use of two "int i" instances; change one "int i" to "int j"