### PR TITLE
Support include empty config file. v5.0.173 v6.0.68

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fossrs%2Fsrs.svg?type=small)](https://app.fossa.com/projects/git%2Bgithub.com%2Fossrs%2Fsrs?ref=badge_small)
 [![](https://ossrs.net/wiki/images/srs-faq.svg)](https://ossrs.net/lts/zh-cn/faq)
 [![](https://badgen.net/badge/srs/stackoverflow/orange?icon=terminal)](https://stackoverflow.com/questions/tagged/simple-realtime-server)
-[![](https://opencollective.com/srs-server/tiers/badge.svg)](https://opencollective.com/srs-server/contribute)
+[![](https://opencollective.com/srs-server/tiers/badge.svg)](https://opencollective.com/srs-server)
 [![](https://img.shields.io/docker/pulls/ossrs/srs)](https://hub.docker.com/r/ossrs/srs/tags)
 [![](https://ossrs.net/wiki/images/do-btn-srs-125x20.svg)](https://cloud.digitalocean.com/droplets/new?appId=133468816&size=s-1vcpu-512mb-10gb&region=sgp1&image=ossrs-srs&type=applications)
 [![](https://api.securityscorecards.dev/projects/github.com/ossrs/srs/badge)](https://api.securityscorecards.dev/projects/github.com/ossrs/srs)
@@ -104,15 +104,24 @@ Here are some other important wikis:
 * Usage: What are the strategies for improving edge performance on multiple CPUs? ([CN](https://ossrs.net/lts/zh-cn/docs/v5/doc/reuse-port), [EN](https://ossrs.io/lts/en-us/docs/v5/doc/reuse-port))
 * Usage: How can bugs be reported or contact be made with us? ([CN](https://ossrs.net/lts/zh-cn/contact), [EN](https://ossrs.io/lts/en-us/contact))
 
+## Sponsor
+
+Would you like additional assistance from us? By becoming a sponsor or backer of SRS, we can provide you 
+with the support you need:
+
+* Backer: $5 per month, online text chat support through Discord.
+* Sponsor: $100 per month, online meeting support, 1 meeting per month in 1 hour.
+
+Please visit [OpenCollective](https://opencollective.com/srs-server) to become a backer or sponsor, and send 
+us a direct message on [Discord](https://discord.gg/yZ4BnPmHAd). We are currently providing support to the 
+developers listed below:
+
+[![](https://opencollective.com/srs-server/backers.svg?width=800&button=false)](https://opencollective.com/srs-server)
+
+We at SRS aim to establish a non-profit, open-source community that assists developers worldwide in creating 
+their own high-quality streaming and RTC platforms to support your businesses.
+
 ## AUTHORS
-
-We highly appreciate all our contributors for their significant contributions that have made a remarkable difference. 
-Thank you! 🙏
-
-If you wish to support this project financially, you can donate [through Open Collective](https://opencollective.com/srs-server). 
-We appreciate your contribution!
-
-[![](https://opencollective.com/srs-server/backers.svg?width=800&button=true)](https://opencollective.com/srs-server/contribute/backer-34941/checkout?interval=month&amount=5)
 
 The [TOC(Technical Oversight Committee)](trunk/AUTHORS.md#toc) and [contributors](trunk/AUTHORS.md#contributors):
 

--- a/trunk/configure
+++ b/trunk/configure
@@ -434,7 +434,7 @@ fi
 if [[ $SRS_UTEST == YES ]]; then
     MODULE_FILES=("srs_utest" "srs_utest_amf0" "srs_utest_kernel" "srs_utest_core"
         "srs_utest_config" "srs_utest_rtmp" "srs_utest_http" "srs_utest_avc" "srs_utest_reload"
-        "srs_utest_mp4" "srs_utest_service" "srs_utest_app" "srs_utest_rtc"
+        "srs_utest_mp4" "srs_utest_service" "srs_utest_app" "srs_utest_rtc" "srs_utest_config2"
         "srs_utest_protocol" "srs_utest_protocol2" "srs_utest_kernel2")
     if [[ $SRS_SRT == YES ]]; then
         MODULE_FILES+=("srs_utest_srt")

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-08-28, Merge [#3768](https://github.com/ossrs/srs/pull/3768): Support include empty config file. v6.0.67 (#3768)
 * v6.0, 2023-08-25, Merge [#3782](https://github.com/ossrs/srs/pull/3782): HLS: Support reload HLS asynchronously. v6.0.67 (#3782)
 * v6.0, 2023-08-22, Merge [#3775](https://github.com/ossrs/srs/pull/3775): Bugfix: Log format output type does not match. v6.0.66 (#3699)
 * v6.0, 2023-08-02, Merge [#3750](https://github.com/ossrs/srs/pull/3750): HLS: Ignore empty NALU to avoid error. v6.0.64 (#3750)
@@ -79,6 +80,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-08-28, Merge [#3768](https://github.com/ossrs/srs/pull/3768): Support include empty config file. v5.0.172 (#3768)
 * v5.0, 2023-08-25, Merge [#3782](https://github.com/ossrs/srs/pull/3782): HLS: Support reload HLS asynchronously.. v5.0.171 (#3782)
 * v5.0, 2023-08-22, Merge [#3775](https://github.com/ossrs/srs/pull/3775): Bugfix: Log format output type does not match. v5.0.171 (#3699)
 * v5.0, 2023-08-02, HLS: Ignore empty NALU to avoid error. v5.0.170

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -123,6 +123,8 @@ namespace srs_internal
         
         // read all.
         int filesize = (int)reader.filesize();
+        // Ignore if empty file.
+        if (filesize <= 0) return err;
         
         // create buffer
         srs_freepa(start);
@@ -1068,6 +1070,9 @@ SrsJsonAny* SrsConfDirective::dumps_arg0_to_boolean()
 srs_error_t SrsConfDirective::parse_conf(SrsConfigBuffer* buffer, SrsDirectiveContext ctx, SrsConfig* conf)
 {
     srs_error_t err = srs_success;
+
+    // Ignore empty config file.
+    if (ctx == SrsDirectiveContextFile && buffer->empty()) return err;
     
     while (true) {
         std::vector<string> args;
@@ -1127,7 +1132,7 @@ srs_error_t SrsConfDirective::parse_conf(SrsConfigBuffer* buffer, SrsDirectiveCo
             }
 
             if ((err = parse_conf(include_file_buffer, SrsDirectiveContextFile, conf)) != srs_success) {
-                return srs_error_wrap(err, "parse include buffer");
+                return srs_error_wrap(err, "parse include buffer %s", file.c_str());
             }
         }
     }
@@ -2197,11 +2202,11 @@ srs_error_t SrsConfig::parse_file(const char* filename)
     SrsConfigBuffer* buffer = NULL;
     SrsAutoFree(SrsConfigBuffer, buffer);
     if ((err = build_buffer(config_file, &buffer)) != srs_success) {
-        return srs_error_wrap(err, "buffer fullfill %s", config_file.c_str());
+        return srs_error_wrap(err, "buffer fullfill %s", filename);
     }
     
     if ((err = parse_buffer(buffer)) != srs_success) {
-        return srs_error_wrap(err, "parse buffer");
+        return srs_error_wrap(err, "parse buffer %s", filename);
     }
     
     return err;

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    172
+#define VERSION_REVISION    173
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    67
+#define VERSION_REVISION    68
 
 #endif

--- a/trunk/src/utest/srs_utest_config.cpp
+++ b/trunk/src/utest/srs_utest_config.cpp
@@ -85,11 +85,14 @@ srs_error_t MockSrsConfig::build_buffer(std::string src, srs_internal::SrsConfig
 {
     srs_error_t err = srs_success;
 
-    string content = included_files[src];
-    if(content.empty()) {
+    // No file, error.
+    if(included_files.find(src) == included_files.end()) {
         return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "file %s: no found", src.c_str());
     }
 
+    string content = included_files[src];
+
+    // Empty file, ok.
     *pbuffer = new MockSrsConfigBuffer(content);
 
     return err;
@@ -689,10 +692,30 @@ VOID TEST(ConfigDirectiveTest, ParseInvalidNoEndOfDirective)
 VOID TEST(ConfigDirectiveTest, ParseInvalidNoEndOfSubDirective)
 {
     srs_error_t err;
-    
-    MockSrsConfigBuffer buf("dir0 {");
-    SrsConfDirective conf;
-    HELPER_ASSERT_FAILED(conf.parse(&buf));
+
+    if (true) {
+        MockSrsConfigBuffer buf("");
+        SrsConfDirective conf;
+        HELPER_ASSERT_SUCCESS(conf.parse(&buf));
+    }
+
+    if (true) {
+        MockSrsConfigBuffer buf("# OK");
+        SrsConfDirective conf;
+        HELPER_ASSERT_SUCCESS(conf.parse(&buf));
+    }
+
+    if (true) {
+        MockSrsConfigBuffer buf("dir0 {");
+        SrsConfDirective conf;
+        HELPER_ASSERT_FAILED(conf.parse(&buf));
+    }
+
+    if (true) {
+        MockSrsConfigBuffer buf("dir0 {} dir1 {");
+        SrsConfDirective conf;
+        HELPER_ASSERT_FAILED(conf.parse(&buf));
+    }
 }
 
 VOID TEST(ConfigDirectiveTest, ParseInvalidNoStartOfSubDirective)

--- a/trunk/src/utest/srs_utest_config2.cpp
+++ b/trunk/src/utest/srs_utest_config2.cpp
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2013-2023 The SRS Authors
+//
+// SPDX-License-Identifier: MIT or MulanPSL-2.0
+//
+#include <srs_utest_config2.hpp>
+
+#include <srs_kernel_error.hpp>
+#include <srs_kernel_file.hpp>
+#include <srs_utest_kernel.hpp>
+
+VOID TEST(ConfigMainTest, CheckIncludeEmptyConfig)
+{
+    srs_error_t err;
+
+    if (true) {
+        string filepath = _srs_tmp_file_prefix + "utest-main.conf";
+        MockFileRemover _mfr(filepath);
+
+        string included = _srs_tmp_file_prefix + "utest-included-empty.conf";
+        MockFileRemover _mfr2(included);
+
+        if (true) {
+            SrsFileWriter fw;
+            fw.open(included);
+        }
+
+        if (true) {
+            SrsFileWriter fw;
+            fw.open(filepath);
+            string content = _MIN_OK_CONF "include " + included + ";";
+            fw.write((void*)content.data(), (int)content.length(), NULL);
+        }
+
+        SrsConfig conf;
+        HELPER_ASSERT_SUCCESS(conf.parse_file(filepath.c_str()));
+        EXPECT_EQ(1, (int)conf.get_listens().size());
+    }
+
+    if (true) {
+        MockSrsConfig conf;
+        conf.mock_include("test.conf", "");
+        HELPER_ASSERT_SUCCESS(conf.parse(_MIN_OK_CONF "include test.conf;"));
+        EXPECT_EQ(1, (int)conf.get_listens().size());
+    }
+}
+

--- a/trunk/src/utest/srs_utest_config2.hpp
+++ b/trunk/src/utest/srs_utest_config2.hpp
@@ -1,0 +1,16 @@
+//
+// Copyright (c) 2013-2023 The SRS Authors
+//
+// SPDX-License-Identifier: MIT or MulanPSL-2.0
+//
+
+#ifndef SRS_UTEST_CONFIG2_HPP
+#define SRS_UTEST_CONFIG2_HPP
+
+/*
+#include <srs_utest_config2.hpp>
+*/
+#include <srs_utest_config.hpp>
+
+#endif
+


### PR DESCRIPTION
## Include Empty Config File

SRS supports including another configuration in the include package. When generating configurations, we can only generate the changed configurations, while the unchanged configurations are in the fixed files, for example:

```nginx
listen 1935;
include server.conf;
```

In `server.conf`, we can manage the changing configurations with the program:

```nginx
http_api { enabled on; }
```

However, during system initialization, we often create an empty `server.conf`, and the content is generated only after the program starts, so `server.conf` might be an empty file. This also makes it convenient to use a script to confirm the existence of this file:

```bash
touch server.conf
```

Currently, SRS does not support empty configurations and will report an error. This PR is to solve this problem, making it more convenient to use include.

`TRANS_BY_GPT4`

---------

Co-authored-by: Haibo Chen <495810242@qq.com>