### PR TITLE
HLS: Support reload HLS asynchronously. v5.0.172 v6.0.67

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-08-25, Merge [#3782](https://github.com/ossrs/srs/pull/3782): HLS: Support reload HLS asynchronously.. v6.0.66 (#3782)
 * v6.0, 2023-08-22, Merge [#3775](https://github.com/ossrs/srs/pull/3775): Bugfix: Log format output type does not match. v6.0.66 (#3699)
 * v6.0, 2023-08-02, Merge [#3750](https://github.com/ossrs/srs/pull/3750): HLS: Ignore empty NALU to avoid error. v6.0.64 (#3750)
 * v6.0, 2023-07-27, Merge [#3611](https://github.com/ossrs/srs/pull/3611): Design and implement helm capabilities to streamline the deployment process of an SRS cluster.. v6.0.63 (#3611)
@@ -78,6 +79,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-08-25, Merge [#3782](https://github.com/ossrs/srs/pull/3782): HLS: Support reload HLS asynchronously.. v5.0.171 (#3782)
 * v5.0, 2023-08-22, Merge [#3775](https://github.com/ossrs/srs/pull/3775): Bugfix: Log format output type does not match. v5.0.171 (#3699)
 * v5.0, 2023-08-02, HLS: Ignore empty NALU to avoid error. v5.0.170
 * v5.0, 2023-07-26, Merge [#3699](https://github.com/ossrs/srs/pull/3699): Bugfix: Eliminate the redundant declaration of the _srs_rtc_manager variable. v5.0.168 (#3699)

--- a/trunk/src/app/srs_app_hls.hpp
+++ b/trunk/src/app/srs_app_hls.hpp
@@ -275,8 +275,13 @@ private:
     SrsHlsController* controller;
 private:
     SrsRequest* req;
+    // Whether the HLS is enabled.
     bool enabled;
+    // Whether the HLS stream is able to be disposed.
     bool disposable;
+    // Whether requires HLS to do reload asynchronously.
+    bool reloading_;
+    // To detect heartbeat and dipose it if configured.
     srs_utime_t last_update_time;
 private:
     // If the diff=dts-previous_audio_dts is about 23,
@@ -293,6 +298,10 @@ private:
 public:
     SrsHls();
     virtual ~SrsHls();
+public:
+    virtual void async_reload();
+private:
+    srs_error_t reload();
 public:
     virtual void dispose();
     virtual srs_error_t cycle();

--- a/trunk/src/app/srs_app_hls.hpp
+++ b/trunk/src/app/srs_app_hls.hpp
@@ -280,6 +280,7 @@ private:
     // Whether the HLS stream is able to be disposed.
     bool disposable;
     // Whether requires HLS to do reload asynchronously.
+    bool async_reload_;
     bool reloading_;
     // To detect heartbeat and dipose it if configured.
     srs_utime_t last_update_time;

--- a/trunk/src/app/srs_app_hls.hpp
+++ b/trunk/src/app/srs_app_hls.hpp
@@ -303,6 +303,7 @@ public:
     virtual void async_reload();
 private:
     srs_error_t reload();
+    srs_error_t do_reload(int *reloading, int *reloaded, int *refreshed);
 public:
     virtual void dispose();
     virtual srs_error_t cycle();

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -368,6 +368,8 @@ public:
     virtual srs_error_t on_forwarder_start(SrsForwarder* forwarder);
     // For the SrsDvr to callback to request the sequence headers.
     virtual srs_error_t on_dvr_request_sh();
+    // For the SrsHls to callback to request the sequence headers.
+    virtual srs_error_t on_hls_request_sh();
 // Interface ISrsReloadHandler
 public:
     virtual srs_error_t on_reload_vhost_forward(std::string vhost);

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    171
+#define VERSION_REVISION    172
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    66
+#define VERSION_REVISION    67
 
 #endif


### PR DESCRIPTION
When reloading HLS, it directly operates unpublish and publish. At this time, if HLS is pushed, an exception may occur. The crash log is displayed as:

```
[2023-08-19 11:36:37.649][INFO][1][mo5u8823] HLS: Switch audio codec 16(Other) to 10(AAC)

[2023-08-19 11:36:37.659][ERROR][1][mo5u8823][0] backtrace 18 frames of ./objs/srs SRS/5.0.170(Bee)
AddressSanitizer:DEADLYSIGNAL
=================================================================
==1==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7f8e0289e941 bp 0x7f8e02a34588 sp 0x7f8dfc2e1400 T1)
==1==The signal is caused by a READ memory access.
==1==Hint: address points to the zero page.
    #0 0x7f8e0289e940 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x22940)
    #1 0x7f8e0289e728  (/lib/x86_64-linux-gnu/libc.so.6+0x22728)
    #2 0x7f8e028affd5 in __assert_fail (/lib/x86_64-linux-gnu/libc.so.6+0x33fd5)
    #3 0x55e98f7aa811 in SrsCplxError::srs_assert(bool) src/kernel/srs_kernel_error.cpp:446
    #4 0x55e98fa4ec89 in SrsHlsMuxer::is_segment_absolutely_overflow() src/app/srs_app_hls.cpp:535
    #5 0x55e98fa58150 in SrsHlsController::write_audio(SrsAudioFrame*, long) src/app/srs_app_hls.cpp:1008
    #6 0x55e98fa5b772 in SrsHls::on_audio(SrsSharedPtrMessage*, SrsFormat*) src/app/srs_app_hls.cpp:1315
    #7 0x55e98fa1adfe in SrsOriginHub::on_audio(SrsSharedPtrMessage*) src/app/srs_app_source.cpp:966
    #8 0x55e98fa2e82d in SrsLiveSource::on_audio_imp(SrsSharedPtrMessage*) src/app/srs_app_source.cpp:2320
    #9 0x55e98fa2db3f in SrsLiveSource::on_audio(SrsCommonMessage*) src/app/srs_app_source.cpp:2269
    #10 0x55e98fa0a913 in SrsRtmpConn::process_publish_message(SrsLiveSource*, SrsCommonMessage*) src/app/srs_app_rtmp_conn.cpp:1187
    #11 0x55e98fa0a5a0 in SrsRtmpConn::handle_publish_message(SrsLiveSource*, SrsCommonMessage*) src/app/srs_app_rtmp_conn.cpp:1166
    #12 0x55e98fc1fd53 in SrsPublishRecvThread::consume(SrsCommonMessage*) src/app/srs_app_recv_thread.cpp:373
    #13 0x55e98fc1d5b9 in SrsRecvThread::do_cycle() src/app/srs_app_recv_thread.cpp:131
    #14 0x55e98fc1d03a in SrsRecvThread::cycle() src/app/srs_app_recv_thread.cpp:100
    #15 0x55e98fa80e93 in SrsFastCoroutine::cycle() src/app/srs_app_st.cpp:285
    #16 0x55e98fa80fe3 in SrsFastCoroutine::pfn(void*) src/app/srs_app_st.cpp:300
    #17 0x55e98fe320c9 in _st_thread_main /srs/trunk/objs/Platform-SRS5-Linux-5.15.0-GCC9.4.0-x86_64/st-srs/sched.c:380
    #18 0x55e98fe329ef in st_thread_create /srs/trunk/objs/Platform-SRS5-Linux-5.15.0-GCC9.4.0-x86_64/st-srs/sched.c:666
    #19 0x55e990230647  (/usr/local/srs/objs/srs+0xf78647)
```

The reason is that these two coroutines operated on the HLS object at the same time, causing a null pointer.

Solution: Use asynchronous reload. During reload, only set variables and let the message processing coroutine implement the reload.



---------

`TRANS_BY_GPT4`

---------

Co-authored-by: Haibo Chen <495810242@qq.com>
Co-authored-by: chundonglinlin <chundonglinlin@163.com>