### PR TITLE
Support SRS Stack token for authentication. v6.0.74

### DIFF
--- a/trunk/3rdparty/httpx-static/README.md
+++ b/trunk/3rdparty/httpx-static/README.md
@@ -15,9 +15,8 @@ Images at https://cr.console.aliyun.com/repository/cn-hangzhou/ossrs/httpx/image
 *HTTP*: Start a HTTP static server
 
 ```
-go get github.com/ossrs/go-oryx/httpx-static &&
-cd $GOPATH/src/github.com/ossrs/go-oryx/httpx-static &&
-$GOPATH/bin/httpx-static -http 8080 -root `pwd`/html
+go install github.com/ossrs/go-oryx/httpx-static@latest &&
+$HOME/go/bin/httpx-static -http 8080 -root `pwd`
 ```
 
 Open http://localhost:8080/ in browser.
@@ -25,12 +24,11 @@ Open http://localhost:8080/ in browser.
 *HTTPS self-sign*: Start a HTTPS static server
 
 ```
-go get github.com/ossrs/go-oryx/httpx-static &&
-cd $GOPATH/src/github.com/ossrs/go-oryx/httpx-static &&
+go install github.com/ossrs/go-oryx/httpx-static@latest &&
 openssl genrsa -out server.key 2048 &&
 subj="/C=CN/ST=Beijing/L=Beijing/O=Me/OU=Me/CN=me.org" &&
 openssl req -new -x509 -key server.key -out server.crt -days 365 -subj $subj &&
-$GOPATH/bin/httpx-static -https 8443 -root `pwd`/html
+$HOME/go/bin/httpx-static -https 8443 -root `pwd`
 ```
 
 Open https://localhost:8443/ in browser.
@@ -40,12 +38,11 @@ Open https://localhost:8443/ in browser.
 *HTTPS proxy*: Proxy http as https
 
 ```
-go get github.com/ossrs/go-oryx/httpx-static &&
-cd $GOPATH/src/github.com/ossrs/go-oryx/httpx-static &&
+go install github.com/ossrs/go-oryx/httpx-static@latest &&
 openssl genrsa -out server.key 2048 &&
 subj="/C=CN/ST=Beijing/L=Beijing/O=Me/OU=Me/CN=me.org" &&
 openssl req -new -x509 -key server.key -out server.crt -days 365 -subj $subj &&
-$GOPATH/bin/httpx-static -https 8443 -root `pwd`/html -proxy http://ossrs.net:1985/api/v1
+$HOME/go/bin/httpx-static -https 8443 -root `pwd` -proxy http://ossrs.net:1985/api/v1
 ```
 
 Open https://localhost:8443/api/v1/summaries in browser.

--- a/trunk/3rdparty/srs-bench/gb28181/gb28181.go
+++ b/trunk/3rdparty/srs-bench/gb28181/gb28181.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2022 Winlin
+// Copyright (c) 2022 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/gb28181/gb28181_test.go
+++ b/trunk/3rdparty/srs-bench/gb28181/gb28181_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2022 Winlin
+// Copyright (c) 2022 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/gb28181/gb_test.go
+++ b/trunk/3rdparty/srs-bench/gb28181/gb_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2022 Winlin
+// Copyright (c) 2022 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/gb28181/ingester.go
+++ b/trunk/3rdparty/srs-bench/gb28181/ingester.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2022 Winlin
+// Copyright (c) 2022 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/gb28181/ps.go
+++ b/trunk/3rdparty/srs-bench/gb28181/ps.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2022 Winlin
+// Copyright (c) 2022 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/gb28181/sip.go
+++ b/trunk/3rdparty/srs-bench/gb28181/sip.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2022 Winlin
+// Copyright (c) 2022 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/gb28181/util.go
+++ b/trunk/3rdparty/srs-bench/gb28181/util.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2022 Winlin
+// Copyright (c) 2022 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-09-08, Merge [#3794](https://github.com/ossrs/srs/pull/3794): Support SRS Stack token for authentication. v6.0.74 (#3794)
 * v6.0, 2023-09-07, Merge [#3795](https://github.com/ossrs/srs/pull/3795): Fix dash crash if format not supported. v6.0.73 (#3795)
 * v6.0, 2023-08-30, Merge [#3776](https://github.com/ossrs/srs/pull/3776): Compile: Add aarch64 to the conditions of use of the cbrt function. v6.0.72 (#3776)
 * v6.0, 2023-08-30, Merge [#3779](https://github.com/ossrs/srs/pull/3779): Support HTTP-API for fetching reload result. v6.0.71 (#3779)

--- a/trunk/research/console/js/srs.console.js
+++ b/trunk/research/console/js/srs.console.js
@@ -644,14 +644,19 @@ scApp.provider("$sc_server", [function(){
             baseurl: function(){
                 return self.schema + "://" + self.host + (self.port === 80? "": ":" + self.port);
             },
+            sstq: function () {
+                const s = localStorage.getItem('SRS_TERRAFORM_TOKEN');
+                const obj = s ? JSON.parse(s) : {};
+                return obj.token ? `&token=${obj.token}` : '';
+            },
             jsonp: function(url){
-                return self.baseurl() + url + "?callback=JSON_CALLBACK";
+                return self.baseurl() + url + "?callback=JSON_CALLBACK" + self.sstq();
             },
             jsonp_delete: function(url) {
-                return self.jsonp(url) + "&method=DELETE";
+                return self.jsonp(url) + "&method=DELETE" + self.sstq();
             },
             jsonp_query: function(url, query){
-                return self.baseurl() + url + "?callback=JSON_CALLBACK&" + query;
+                return self.baseurl() + url + "?callback=JSON_CALLBACK&" + query + self.sstq();
             },
             buildNavUrl: function () {
                 var $location = self.$location;

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2502,6 +2502,7 @@ srs_error_t SrsRtcAudioRecvTrack::on_rtp(SrsRtcSource* source, SrsRtpPacket* pkt
     srs_error_t err = srs_success;
 
     pkt->set_avsync_time(cal_avsync_time(pkt->header.get_timestamp()));
+    srs_info("Audio async rate=%d, rtp=%u, corrected=%" PRId64, (int)rate_, pkt->header.get_timestamp(), pkt->get_avsync_time());
 
     if ((err = source->on_rtp(pkt)) != srs_success) {
         return srs_error_wrap(err, "source on rtp");
@@ -2560,6 +2561,7 @@ srs_error_t SrsRtcVideoRecvTrack::on_rtp(SrsRtcSource* source, SrsRtpPacket* pkt
     srs_error_t err = srs_success;
 
     pkt->set_avsync_time(cal_avsync_time(pkt->header.get_timestamp()));
+    srs_info("Video async rate=%d, rtp=%u, corrected=%" PRId64, (int)rate_, pkt->header.get_timestamp(), pkt->get_avsync_time());
 
     if ((err = source->on_rtp(pkt)) != srs_success) {
         return srs_error_wrap(err, "source on rtp");

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    73
+#define VERSION_REVISION    74
 
 #endif

--- a/trunk/src/kernel/srs_kernel_rtc_rtp.hpp
+++ b/trunk/src/kernel/srs_kernel_rtc_rtp.hpp
@@ -335,6 +335,7 @@ public:
     virtual srs_error_t decode(SrsBuffer* buf);
 public:
     bool is_keyframe();
+    // Get and set the packet sync time in milliseconds.
     void set_avsync_time(int64_t avsync_time) { avsync_time_ = avsync_time; }
     int64_t get_avsync_time() const { return avsync_time_; }
 };


### PR DESCRIPTION
When accessing the SRS Stack, you should log in and use a token for each request, or utilize the HTTP API with a secret Bearer token included in every request. The SRS Stack HTTP API proxies both /api/v1 and /rtc/v1 to the SRS HTTP API while ensuring secure authentication. Additionally, there is a console in the SRS Stack that requires the same token to request the SRS Stack HTTP API, which is then proxied to the SRS HTTP API.

The SRS Stack runs SRS with the HTTP API listening at 127.0.0.1:1985 on the local loopback interface, allowing only the SRS Stack to access it without authentication. All other users must login and access the SRS Stack through its interface, rather than directly accessing the SRS HTTP API within the SRS Stack.




---------

Co-authored-by: panda <542638787@qq.com>