### PR TITLE
Prevent the output of srt logs in utest. v5.0.181 v6.0.79

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-09-21, Merge [#3807](https://github.com/ossrs/srs/pull/3807): Prevent the output of srt logs in utest. v6.0.79 (#3807)
 * v6.0, 2023-09-21, Merge [#3696](https://github.com/ossrs/srs/pull/3696): SRT: modify log level from error to debug when no socket to accept. v6.0.78 (#3696)
 * v6.0, 2023-09-18, Merge [#3804](https://github.com/ossrs/srs/pull/3804): Support FFmpeg timecode, fix AMF0 parsing failed. v6.0.77 (#3804)
 * v6.0, 2023-09-18, Merge [#3722](https://github.com/ossrs/srs/pull/3722): Bugfix: HEVC SRT stream supports multiple PPS fields. v6.0.76 (#3722)
@@ -90,6 +91,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-09-21, Merge [#3807](https://github.com/ossrs/srs/pull/3807): Prevent the output of srt logs in utest. v5.0.181 (#3807)
 * v5.0, 2023-09-21, Merge [#3696](https://github.com/ossrs/srs/pull/3696): SRT: modify log level from error to debug when no socket to accept. v5.0.180 (#3696)
 * v5.0, 2023-09-18, Merge [#3804](https://github.com/ossrs/srs/pull/3804): Support FFmpeg timecode, fix AMF0 parsing failed. v5.0.179 (#3804)
 * v5.0, 2023-09-08, Merge [#3597](https://github.com/ossrs/srs/pull/3597): Fix RBSP stream parsing bug, should drop 0x03. v5.0.178 (#3597)

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    180
+#define VERSION_REVISION    181
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    78
+#define VERSION_REVISION    79
 
 #endif

--- a/trunk/src/utest/srs_utest.cpp
+++ b/trunk/src/utest/srs_utest.cpp
@@ -21,6 +21,7 @@ using namespace std;
 #include <sys/mman.h>
 
 #ifdef SRS_SRT
+#include <srt/srt.h>
 #include <srs_app_srt_server.hpp>
 #endif
 
@@ -44,6 +45,14 @@ bool _srs_config_by_env = false;
 const char* _srs_binary = NULL;
 
 #include <srs_app_st.hpp>
+
+#ifdef SRS_SRT
+static void srs_srt_utest_null_log_handler(void* opaque, int level, const char* file, int line,
+                                           const char* area, const char* message)
+{
+    // srt null log handler, do no print any log.
+}
+#endif
 
 // Initialize global settings.
 srs_error_t prepare_main() {
@@ -71,6 +80,9 @@ srs_error_t prepare_main() {
     if ((err = srs_srt_log_initialize()) != srs_success) {
         return srs_error_wrap(err, "srt log initialize");
     }
+
+    // Prevent the output of srt logs in utest.
+    srt_setloghandler(NULL, srs_srt_utest_null_log_handler);
 
     _srt_eventloop = new SrsSrtEventLoop();
     if ((err = _srt_eventloop->initialize()) != srs_success) {


### PR DESCRIPTION
Prevent the output of srt logs in utest.

Before 

![image](https://github.com/ossrs/srs/assets/8449258/eeed4397-8602-4fc7-82f8-f964b2e3d78a)


After 

![image](https://github.com/ossrs/srs/assets/8449258/d3674cd2-4c87-4b30-9e1b-c564aaf362d6)


---------

Co-authored-by: chundonglinlin <chundonglinlin@163.com>