### PR TITLE
Fix bug for upgrading to OpenSSL 3.0. v5.0.189 v6.0.89

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-10-11, Merge [#3827](https://github.com/ossrs/srs/pull/3827): Fix bug for upgrading to OpenSSL 3.0. v6.0.89 (#3827)
 * v6.0, 2023-10-10, Merge [#3825](https://github.com/ossrs/srs/pull/3825): SRT: Fix the missing config mss. v6.0.88 (#3825)
 * v6.0, 2023-10-08, Merge [#3824](https://github.com/ossrs/srs/pull/3824): Solve the problem of inaccurate HLS TS duration. v6.0.87 (#3824)
 * v6.0, 2023-10-08, Merge [#3815](https://github.com/ossrs/srs/pull/3815): Use new cache image name. v6.0.86 (#3815)
@@ -100,6 +101,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-10-11, Merge [#3827](https://github.com/ossrs/srs/pull/3827): Fix bug for upgrading to OpenSSL 3.0. v5.0.189 (#3827)
 * v5.0, 2023-10-10, Merge [#3825](https://github.com/ossrs/srs/pull/3825): SRT: Fix the missing config mss. v5.0.188 (#3825)
 * v5.0, 2023-10-08, Merge [#3824](https://github.com/ossrs/srs/pull/3824): Solve the problem of inaccurate HLS TS duration. v5.0.187 (#3824)
 * v5.0, 2023-10-08, Merge [#3815](https://github.com/ossrs/srs/pull/3815): Use new cache image name. v5.0.186 (#3815)

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    188
+#define VERSION_REVISION    189
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    88
+#define VERSION_REVISION    89
 
 #endif

--- a/trunk/src/protocol/srs_protocol_rtmp_handshake.cpp
+++ b/trunk/src/protocol/srs_protocol_rtmp_handshake.cpp
@@ -327,10 +327,7 @@ namespace srs_internal
             return srs_error_new(ERROR_OpenSslSetG, "set word");
         }
         
-        // 4. Set the key length
-        // DH_set_length(pdh, bits_count);
-        
-        // 5. Generate private and public key
+        // 4. Generate private and public key
         // @see ./test/dhtest.c:152
         if (!DH_generate_key(pdh)) {
             return srs_error_new(ERROR_OpenSslGenerateDHKeys, "dh generate key");

--- a/trunk/src/protocol/srs_protocol_rtmp_handshake.cpp
+++ b/trunk/src/protocol/srs_protocol_rtmp_handshake.cpp
@@ -328,7 +328,7 @@ namespace srs_internal
         }
         
         // 4. Set the key length
-        DH_set_length(pdh, bits_count);
+        // DH_set_length(pdh, bits_count);
         
         // 5. Generate private and public key
         // @see ./test/dhtest.c:152


### PR DESCRIPTION
The fix is for the DH_set_length error. As shown in lines 2-5, OpenSSL 3.0 added a check for length, which allowed this issue to be exposed.
```
1 if (dh->params.q == NULL) {
2       /* secret exponent length, must satisfy 2^(l-1) <= p */
3        if (dh->length != 0
4            && dh->length >= BN_num_bits(dh->params.p))
5            goto err;
6        l = dh->length ? dh->length : BN_num_bits(dh->params.p) - 1;
7        if (!BN_priv_rand_ex(priv_key, l, BN_RAND_TOP_ONE,
8                             BN_RAND_BOTTOM_ANY, 0, ctx))
9            goto err;
        ... ...
    }
```


---------

Co-authored-by: john <hondaxiao@tencent.com>