### PR TITLE
Support set the ice-ufrag and ice-pwd for connectivity check. v5.0.191 v6.0.91

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-10-17, Merge [#3837](https://github.com/ossrs/srs/pull/3837): Support set the ice-ufrag and ice-pwd for connectivity check. v6.0.91 (#3837)
 * v6.0, 2023-10-17, Merge [#3758](https://github.com/ossrs/srs/pull/3758): Refine docker detect mechenism. v6.0.90 (#3758)
 * v6.0, 2023-10-11, Merge [#3827](https://github.com/ossrs/srs/pull/3827): Fix bug for upgrading to OpenSSL 3.0. v6.0.89 (#3827)
 * v6.0, 2023-10-10, Merge [#3825](https://github.com/ossrs/srs/pull/3825): SRT: Fix the missing config mss. v6.0.88 (#3825)
@@ -102,6 +103,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-10-17, Merge [#3837](https://github.com/ossrs/srs/pull/3837): Support set the ice-ufrag and ice-pwd for connectivity check. v5.0.191 (#3837)
 * v5.0, 2023-10-17, Merge [#3758](https://github.com/ossrs/srs/pull/3758): Refine docker detect mechenism. v5.0.190 (#3758)
 * v5.0, 2023-10-11, Merge [#3827](https://github.com/ossrs/srs/pull/3827): Fix bug for upgrading to OpenSSL 3.0. v5.0.189 (#3827)
 * v5.0, 2023-10-10, Merge [#3825](https://github.com/ossrs/srs/pull/3825): SRT: Fix the missing config mss. v5.0.188 (#3825)

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -689,9 +689,16 @@ srs_error_t SrsGoApiRtcWhip::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
     ruc->req_->vhost = ruc->req_->host;
     ruc->req_->app = app.empty() ? "live" : app;
     ruc->req_->stream = stream.empty() ? "livestream" : stream;
+    ruc->req_->param = r->query();
+
     ruc->req_->ice_ufrag_ = r->query_get("ice-ufrag");
     ruc->req_->ice_pwd_ = r->query_get("ice-pwd");
-    ruc->req_->param = r->query();
+    if (!ruc->req_->ice_ufrag_.empty() && (ruc->req_->ice_ufrag_.length() < 4 || ruc->req_->ice_ufrag_.length() > 32)) {
+        return srs_error_new(ERROR_RTC_INVALID_ICE, "Invalid ice-ufrag %s", ruc->req_->ice_ufrag_.c_str());
+    }
+    if (!ruc->req_->ice_pwd_.empty() && (ruc->req_->ice_pwd_.length() < 22 || ruc->req_->ice_pwd_.length() > 32)) {
+        return srs_error_new(ERROR_RTC_INVALID_ICE, "Invalid ice-pwd %s", ruc->req_->ice_pwd_.c_str());
+    }
 
     // discovery vhost, resolve the vhost from config
     SrsConfDirective* parsed_vhost = _srs_config->get_vhost(ruc->req_->vhost);

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -689,6 +689,8 @@ srs_error_t SrsGoApiRtcWhip::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
     ruc->req_->vhost = ruc->req_->host;
     ruc->req_->app = app.empty() ? "live" : app;
     ruc->req_->stream = stream.empty() ? "livestream" : stream;
+    ruc->req_->ice_ufrag_ = r->query_get("ice-ufrag");
+    ruc->req_->ice_pwd_ = r->query_get("ice-pwd");
     ruc->req_->param = r->query();
 
     // discovery vhost, resolve the vhost from config
@@ -701,9 +703,10 @@ srs_error_t SrsGoApiRtcWhip::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
     string srtp = r->query_get("encrypt");
     string dtls = r->query_get("dtls");
 
-    srs_trace("RTC whip %s %s, clientip=%s, app=%s, stream=%s, offer=%dB, eip=%s, codec=%s, srtp=%s, dtls=%s, param=%s",
+    srs_trace("RTC whip %s %s, clientip=%s, app=%s, stream=%s, offer=%dB, eip=%s, codec=%s, srtp=%s, dtls=%s, ufrag=%s, pwd=%s, param=%s",
         action.c_str(), ruc->req_->get_stream_url().c_str(), clientip.c_str(), ruc->req_->app.c_str(), ruc->req_->stream.c_str(),
-        remote_sdp_str.length(), eip.c_str(), codec.c_str(), srtp.c_str(), dtls.c_str(), ruc->req_->param.c_str()
+        remote_sdp_str.length(), eip.c_str(), codec.c_str(), srtp.c_str(), dtls.c_str(), ruc->req_->ice_ufrag_.c_str(),
+        ruc->req_->ice_pwd_.c_str(), ruc->req_->param.c_str()
     );
 
     ruc->eip_ = eip;

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -20,6 +20,14 @@
 #include <deque>
 using namespace std;
 
+// To limit the ICE ufrag/username to avoid unknown issue.
+#define SRS_ICE_UFRAG_MIN 4
+#define SRS_ICE_UFRAG_MAX 32
+// STUN/ICE pwd should not be too short, browser will fail with error.
+#define SRS_ICE_PWD_MIN 22
+// To limit user to use too long password, to cause unknown issue.
+#define SRS_ICE_PWD_MAX 32
+
 SrsGoApiRtcPlay::SrsGoApiRtcPlay(SrsRtcServer* server)
 {
     server_ = server;
@@ -693,10 +701,10 @@ srs_error_t SrsGoApiRtcWhip::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMe
 
     ruc->req_->ice_ufrag_ = r->query_get("ice-ufrag");
     ruc->req_->ice_pwd_ = r->query_get("ice-pwd");
-    if (!ruc->req_->ice_ufrag_.empty() && (ruc->req_->ice_ufrag_.length() < 4 || ruc->req_->ice_ufrag_.length() > 32)) {
+    if (!ruc->req_->ice_ufrag_.empty() && (ruc->req_->ice_ufrag_.length() < SRS_ICE_UFRAG_MIN || ruc->req_->ice_ufrag_.length() > SRS_ICE_UFRAG_MAX)) {
         return srs_error_new(ERROR_RTC_INVALID_ICE, "Invalid ice-ufrag %s", ruc->req_->ice_ufrag_.c_str());
     }
-    if (!ruc->req_->ice_pwd_.empty() && (ruc->req_->ice_pwd_.length() < 22 || ruc->req_->ice_pwd_.length() > 32)) {
+    if (!ruc->req_->ice_pwd_.empty() && (ruc->req_->ice_pwd_.length() < SRS_ICE_PWD_MIN || ruc->req_->ice_pwd_.length() > SRS_ICE_PWD_MAX)) {
         return srs_error_new(ERROR_RTC_INVALID_ICE, "Invalid ice-pwd %s", ruc->req_->ice_pwd_.c_str());
     }
 

--- a/trunk/src/app/srs_app_rtc_server.cpp
+++ b/trunk/src/app/srs_app_rtc_server.cpp
@@ -543,17 +543,18 @@ srs_error_t SrsRtcServer::do_create_session(SrsRtcUserConfig* ruc, SrsSdp& local
     // All tracks default as inactive, so we must enable them.
     session->set_all_tracks_status(req->get_stream_url(), ruc->publish_, true);
 
-    std::string local_pwd = srs_random_str(32);
-    std::string local_ufrag = "";
+    std::string local_pwd = ruc->req_->ice_pwd_.empty() ? srs_random_str(32) : ruc->req_->ice_pwd_;
+    std::string local_ufrag = ruc->req_->ice_ufrag_.empty() ? srs_random_str(8) : ruc->req_->ice_ufrag_;
     // TODO: FIXME: Rename for a better name, it's not an username.
     std::string username = "";
     while (true) {
-        local_ufrag = srs_random_str(8);
-
         username = local_ufrag + ":" + ruc->remote_sdp_.get_ice_ufrag();
         if (!_srs_rtc_manager->find_by_name(username)) {
             break;
         }
+
+        // Username conflict, regenerate a new one.
+        local_ufrag = srs_random_str(8);
     }
 
     local_sdp.set_ice_ufrag(local_ufrag);

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    190
+#define VERSION_REVISION    191
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    90
+#define VERSION_REVISION    91
 
 #endif

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -374,7 +374,8 @@
     XX(ERROR_RTC_TCP_PACKET                , 5033, "RtcTcpStun", "RTC TCP first packet must be STUN") \
     XX(ERROR_RTC_TCP_STUN                  , 5034, "RtcTcpSession", "RTC TCP packet is invalid for session not found") \
     XX(ERROR_RTC_TCP_UNIQUE                , 5035, "RtcUnique", "RTC only support one UDP or TCP network") \
-    XX(ERROR_RTC_INVALID_SESSION           , 5036, "RtcInvalidSession", "Invalid request for no RTC session matched")
+    XX(ERROR_RTC_INVALID_SESSION           , 5036, "RtcInvalidSession", "Invalid request for no RTC session matched") \
+    XX(ERROR_RTC_INVALID_ICE               , 5037, "RtcInvalidIce", "Invalid ICE ufrag or pwd")
 
 /**************************************************/
 /* SRT protocol error. */

--- a/trunk/src/protocol/srs_protocol_rtmp_stack.hpp
+++ b/trunk/src/protocol/srs_protocol_rtmp_stack.hpp
@@ -424,6 +424,10 @@ public:
     std::string param;
     // The stream in play/publish
     std::string stream;
+    // User specify the ice-ufrag, the username of ice, for test only.
+    std::string ice_ufrag_;
+    // User specify the ice-pwd, the password of ice, for test only.
+    std::string ice_pwd_;
     // For play live stream,
     // used to specified the stop when exceed the duration.
     // in srs_utime_t.


### PR DESCRIPTION
Checking the HTTPS API or UDP connectivity for WHIP tests can be difficult. For example, if the UDP port isn't available but the API is fine, OBS only says it can't connect to the server. It's hard to see the HTTPS API response or check if the UDP port is available.

This feature lets you set the ice username and password in SRS. You can then send a STUN request using nc and see the response, making it easier to check UDP port connectivity.

1. Use curl to test the WHIP API, including ice-frag and ice-pwd queries.
2. Use nc to send a STUN binding request to test UDP connectivity.
3. If both the API and UDP are working, you should get a STUN response.

Troubleshooting Connection Failures in OBS WHIP, see https://github.com/ossrs/srs/issues/2843

---------

Co-authored-by: john <hondaxiao@tencent.com>