### PR TITLE
RTC: Refine FFmpeg opus audio noisy issue. v5.0.197 v6.0.97

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,8 @@ jobs:
       - name: Run SRS regression-test
         run: |
           docker run --rm srs:test bash -c './objs/srs -c conf/regression-test.conf && \
-              cd 3rdparty/srs-bench && ./objs/srs_test -test.v && ./objs/srs_gb28181_test -test.v'
+              cd 3rdparty/srs-bench && (./objs/srs_test -test.v || (cat ../../objs/srs.log && exit 1)) && \
+              ./objs/srs_gb28181_test -test.v'
     runs-on: ubuntu-20.04
 
   coverage:

--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -451,8 +451,7 @@ function parse_user_option() {
         --ffmpeg-tool)                  SRS_FFMPEG_TOOL=$(switch2value $value) ;;
 
         # use cache for build.
-        --build-cache)                  SRS_BUILD_CACHE=YES         ;;
-        --without-build-cache)          SRS_BUILD_CACHE=NO          ;;
+        --build-cache)                  SRS_BUILD_CACHE=$(switch2value $value) ;;
 
         *)
             echo "$0: error: invalid option \"$option\""

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-11-04, Merge [#3852](https://github.com/ossrs/srs/pull/3852): RTC: Refine FFmpeg opus audio noisy issue. v6.0.97 (#3852)
 * v6.0, 2023-11-01, Merge [#3858](https://github.com/ossrs/srs/pull/3858): Support build without cache to test if actions fail. v6.0.96 (#3858)
 * v6.0, 2023-10-25, Merge [#3845](https://github.com/ossrs/srs/pull/3845): RTC: Fix FFmpeg opus audio noisy issue. v6.0.95 (#3845)
 * v6.0, 2023-10-21, Merge [#3847](https://github.com/ossrs/srs/pull/3847): WebRTC: TCP transport should use read_fully instead of read. v6.0.94 (#3847)
@@ -108,6 +109,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-11-04, Merge [#3852](https://github.com/ossrs/srs/pull/3852): RTC: Refine FFmpeg opus audio noisy issue. v5.0.197 (#3852)
 * v5.0, 2023-11-01, Merge [#3858](https://github.com/ossrs/srs/pull/3858): Support build without cache to test if actions fail. v5.0.196 (#3858)
 * v5.0, 2023-10-25, Merge [#3845](https://github.com/ossrs/srs/pull/3845): RTC: Fix FFmpeg opus audio noisy issue. v5.0.195 (#3845)
 * v5.0, 2023-10-21, Merge [#3847](https://github.com/ossrs/srs/pull/3847): WebRTC: TCP transport should use read_fully instead of read. v5.0.194 (#3847)

--- a/trunk/research/players/js/srs.page.js
+++ b/trunk/research/players/js/srs.page.js
@@ -13,7 +13,6 @@ function srs_get_player_height() { return srs_get_player_width() * 9 / 19; }
 * update the navigator, add same query string.
 */
 function update_nav() {
-    $("#srs_index").attr("href", "index.html" + window.location.search);
     $("#nav_srs_player").attr("href", "srs_player.html" + window.location.search);
     $("#nav_rtc_player").attr("href", "rtc_player.html" + window.location.search);
     $("#nav_rtc_publisher").attr("href", "rtc_publisher.html" + window.location.search);

--- a/trunk/research/players/srs_player.html
+++ b/trunk/research/players/srs_player.html
@@ -15,7 +15,7 @@
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">
-            <a id="srs_index" class="brand" href="#">SRS</a>
+            <a class="brand" href="https://github.com/ossrs/srs" target="_blank">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
                     <li class="active"><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
@@ -29,11 +29,11 @@
                     <!--<li><a id="nav_srs_bwt" href="srs_bwt.html">SRS测网速</a></li>-->
                     <!--li><a id="nav_vlc" href="vlc.html">VLC播放器</a></li>-->
                     <!--<li><a id="nav_gb28181" href="srs_gb28181.html">GB28181</a></li>-->
-                    <li>
+                    <!--<li>
                         <a href="https://github.com/ossrs/srs">
                             <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/ossrs/srs?style=social">
                         </a>
-                    </li>
+                    </li>-->
                 </ul>
             </div>
         </div>

--- a/trunk/research/players/whep.html
+++ b/trunk/research/players/whep.html
@@ -20,7 +20,7 @@
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">
-            <a id="srs_index" class="brand" href="https://github.com/ossrs/srs">SRS</a>
+            <a class="brand" href="https://github.com/ossrs/srs" target="_blank">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
                     <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
@@ -34,11 +34,11 @@
                     <!--<li><a id="nav_srs_bwt" href="srs_bwt.html">SRS测网速</a></li>-->
                     <!--<li><a id="nav_vlc" href="vlc.html">VLC播放器</a></li>-->
                     <!--<li><a id="nav_gb28181" href="srs_gb28181.html">GB28181</a></li>-->
-                    <li>
+                    <!--<li>
                         <a href="https://github.com/ossrs/srs">
                             <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/ossrs/srs?style=social">
                         </a>
-                    </li>
+                    </li>-->
                 </ul>
             </div>
         </div>

--- a/trunk/research/players/whip.html
+++ b/trunk/research/players/whip.html
@@ -20,7 +20,7 @@
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">
-            <a id="srs_index" class="brand" href="https://github.com/ossrs/srs">SRS</a>
+            <a class="brand" href="https://github.com/ossrs/srs" target="_blank">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
                     <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
@@ -34,11 +34,11 @@
                     <!--<li><a id="nav_srs_bwt" href="srs_bwt.html">SRS测网速</a></li>-->
                     <!--<li><a id="nav_vlc" href="vlc.html">VLC播放器</a></li>-->
                     <!--<li><a id="nav_gb28181" href="srs_gb28181.html">GB28181</a></li>-->
-                    <li>
+                    <!--<li>
                         <a href="https://github.com/ossrs/srs">
                             <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/ossrs/srs?style=social">
                         </a>
-                    </li>
+                    </li>-->
                 </ul>
             </div>
         </div>

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    196
+#define VERSION_REVISION    197
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    96
+#define VERSION_REVISION    97
 
 #endif


### PR DESCRIPTION
### Description

When converting between AAC and Opus formats (aac2opus or opus2aac), the `av_frame_get_buffer` API is frequently called.

### Objective

The goal is to optimize the code logic and reduce the frequent allocation and deallocation of memory.

In the case of aac2opus, av_frame_get_buffer is still frequently called.
In the case of opus2aac, the goal is to avoid calling av_frame_get_buffer and reduce memory allocations.

### Additional Note

Before calling the `av_audio_fifo_read` API, use `av_frame_make_writable` to check if the frame is writable. If it is not writable, create a new frame.



---------

`TRANS_BY_GPT4`

---------

Co-authored-by: john <hondaxiao@tencent.com>