### PR TITLE
Support build without cache to test if actions fail. v5.0.196 v6.0.96

### DIFF
--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -189,7 +189,7 @@ fi
 #####################################################################################
 # Use srs-cache from base image. See https://github.com/ossrs/dev-docker/blob/ubuntu20-cache/Dockerfile
 # Note that the cache for cygwin is not under /usr/local, but copy to objs instead.
-if [[ -d /usr/local/srs-cache/srs/trunk/objs && $(pwd) != "/usr/local/srs-cache/srs/trunk" ]]; then
+if [[ -d /usr/local/srs-cache/srs/trunk/objs && $(pwd) != "/usr/local/srs-cache/srs/trunk" && $SRS_BUILD_CACHE == YES ]]; then
     SOURCE_DIR=$(ls -d /usr/local/srs-cache/srs/trunk/objs/Platform-SRS${SRS_MAJOR}-* 2>/dev/null|head -n 1)
     if [[ -d $SOURCE_DIR ]]; then
         TARGET_DIR=${SRS_OBJS}/${SRS_PLATFORM} &&

--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -37,7 +37,7 @@ SRS_FFMPEG_TOOL=NO
 # FFmpeg fit is the source code for RTC, to transcode audio or video in SRS.
 SRS_FFMPEG_FIT=RESERVED
 # Whether use FFmpeg native opus codec for RTC. If not, use libopus instead.
-SRS_FFMPEG_OPUS=YES
+SRS_FFMPEG_OPUS=NO
 # arguments
 SRS_PREFIX=/usr/local/srs
 SRS_DEFAULT_CONFIG=conf/srs.conf

--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -109,7 +109,7 @@ SRS_CROSS_BUILD_HOST=
 # For cross build, the cross prefix, for example(FFmpeg), --cross-prefix=aarch64-linux-gnu-
 SRS_CROSS_BUILD_PREFIX=
 # For cache build
-SRS_BUILD_CACHE=NO
+SRS_BUILD_CACHE=YES
 #
 #####################################################################################
 # Toolchain for cross-build on Ubuntu for ARM or MIPS.

--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -37,7 +37,7 @@ SRS_FFMPEG_TOOL=NO
 # FFmpeg fit is the source code for RTC, to transcode audio or video in SRS.
 SRS_FFMPEG_FIT=RESERVED
 # Whether use FFmpeg native opus codec for RTC. If not, use libopus instead.
-SRS_FFMPEG_OPUS=NO
+SRS_FFMPEG_OPUS=YES
 # arguments
 SRS_PREFIX=/usr/local/srs
 SRS_DEFAULT_CONFIG=conf/srs.conf

--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -108,6 +108,8 @@ SRS_CROSS_BUILD_ARCH=
 SRS_CROSS_BUILD_HOST=
 # For cross build, the cross prefix, for example(FFmpeg), --cross-prefix=aarch64-linux-gnu-
 SRS_CROSS_BUILD_PREFIX=
+# For cache build
+SRS_BUILD_CACHE=NO
 #
 #####################################################################################
 # Toolchain for cross-build on Ubuntu for ARM or MIPS.
@@ -447,6 +449,10 @@ function parse_user_option() {
         --without-ffmpeg)               SRS_FFMPEG_TOOL=NO          ;;
         --ffmpeg)                       SRS_FFMPEG_TOOL=$(switch2value $value) ;;
         --ffmpeg-tool)                  SRS_FFMPEG_TOOL=$(switch2value $value) ;;
+
+        # use cache for build.
+        --build-cache)                  SRS_BUILD_CACHE=YES         ;;
+        --without-build-cache)          SRS_BUILD_CACHE=NO          ;;
 
         *)
             echo "$0: error: invalid option \"$option\""

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-11-01, Merge [#3858](https://github.com/ossrs/srs/pull/3858): Support build without cache to test if actions fail. v6.0.96 (#3858)
 * v6.0, 2023-10-25, Merge [#3845](https://github.com/ossrs/srs/pull/3845): RTC: Fix FFmpeg opus audio noisy issue. v6.0.95 (#3845)
 * v6.0, 2023-10-21, Merge [#3847](https://github.com/ossrs/srs/pull/3847): WebRTC: TCP transport should use read_fully instead of read. v6.0.94 (#3847)
 * v6.0, 2023-10-20, Merge [#3846](https://github.com/ossrs/srs/pull/3846): Added system library option for ffmpeg, srtp, srt libraries. v6.0.93 (#3846)
@@ -107,6 +108,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-11-01, Merge [#3858](https://github.com/ossrs/srs/pull/3858): Support build without cache to test if actions fail. v5.0.196 (#3858)
 * v5.0, 2023-10-25, Merge [#3845](https://github.com/ossrs/srs/pull/3845): RTC: Fix FFmpeg opus audio noisy issue. v5.0.195 (#3845)
 * v5.0, 2023-10-21, Merge [#3847](https://github.com/ossrs/srs/pull/3847): WebRTC: TCP transport should use read_fully instead of read. v5.0.194 (#3847)
 * v5.0, 2023-10-20, Merge [#3846](https://github.com/ossrs/srs/pull/3846): Added system library option for ffmpeg, srtp, srt libraries. v5.0.193 (#3846)

--- a/trunk/research/players/rtc_player.html
+++ b/trunk/research/players/rtc_player.html
@@ -23,7 +23,7 @@
             <a id="srs_index" class="brand" href="https://github.com/ossrs/srs">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
+                    <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
                     <li class="active"><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
                     <li><a id="nav_whip" href="whip.html">WHIP</a></li>

--- a/trunk/research/players/rtc_publisher.html
+++ b/trunk/research/players/rtc_publisher.html
@@ -23,7 +23,7 @@
             <a id="srs_index" class="brand" href="https://github.com/ossrs/srs">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
+                    <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
                     <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li class="active"><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
                     <li><a id="nav_whip" href="whip.html">WHIP</a></li>

--- a/trunk/research/players/srs_bwt.html
+++ b/trunk/research/players/srs_bwt.html
@@ -22,7 +22,7 @@
             <a id="srs_index" class="brand" href="#">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
+                    <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
                     <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
                     <li><a id="nav_srs_publisher" href="srs_publisher.html">SRS编码器</a></li>

--- a/trunk/research/players/srs_chat.html
+++ b/trunk/research/players/srs_chat.html
@@ -21,7 +21,7 @@
             <a id="srs_index" class="brand" href="#">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
+                    <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
                     <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
                     <li><a id="nav_srs_publisher" href="srs_publisher.html">SRS编码器</a></li>

--- a/trunk/research/players/srs_gb28181.html
+++ b/trunk/research/players/srs_gb28181.html
@@ -35,7 +35,7 @@
             <a id="srs_index" class="brand" href="#">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
+                    <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
                     <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
                     <li><a  href="http://ossrs.net/srs.release/releases/app.html">iOS/Andriod</a></li>

--- a/trunk/research/players/srs_player.html
+++ b/trunk/research/players/srs_player.html
@@ -18,9 +18,9 @@
             <a id="srs_index" class="brand" href="#">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li class="active"><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
-                    <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
-                    <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
+                    <li class="active"><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
+                    <!--<li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>-->
+                    <!--<li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>-->
                     <li><a id="nav_whip" href="whip.html">WHIP</a></li>
                     <li><a id="nav_whep" href="whip.html">WHEP</a></li>
                     <li><a  href="http://ossrs.net/srs.release/releases/app.html">iOS/Andriod</a></li>
@@ -44,13 +44,13 @@
     <div id="main_content">
         <div id="main_info" class="alert alert-info fade in">
             <button type="button" class="close" data-dismiss="alert">×</button>
-            <strong><span>Usage:</span></strong> <span>输入HTTP-FLV/HLS地址后点击“播放视频”即可播放视频</span>
+            <strong><span>Usage:</span></strong> <span>Enter the HTTP-FLV/HLS URL and click "Play" to start playing the video.</span>
         </div>
         <div class="form-inline">
             <div>
                 URL:
                 <input type="text" id="txt_url" class="input-xxlarge" value="">
-                <button class="btn btn-primary" id="btn_play">播放视频</button>
+                <button class="btn btn-primary" id="btn_play">Play</button>
             </div>
             <p></p>
             <div>
@@ -58,17 +58,17 @@
                 <audio id="audio_player" width="100%" autoplay controls></audio>
             </div>
             <p>
-                分享：<a href="#" id="link_url" target="_blank">请右键拷贝此链接</a>
+                Share: <a href="#" id="link_url" target="_blank">Please right-click and copy this link.</a>
             </p>
             <div id="main_tips">
                 <p></p>
                 <p>
-                    推荐的其他播放器：
+                    Recommended other players:
                     <ul>
-                        <li><a href="https://github.com/xqq/mpegts.js">flv.js</a>，H5/MSE播放HTTP-FLV</li>
-                        <li><a href="https://github.com/xqq/mpegts.js">mpegts.js</a>，H5/MSE播放HTTP-TS</li>
-                        <li><a href="https://github.com/video-dev/hls.js/">hls.js</a>，H5/MSE播放HLS</li>
-                        <li><a href="https://github.com/Dash-Industry-Forum/dash.js">dash.js</a>，H5/MSE播放MPEG-DASH</li>
+                        <li><a href="https://github.com/xqq/mpegts.js">flv.js</a>, HTML5/MSE for playing HTTP-FLV</li>
+                        <li><a href="https://github.com/xqq/mpegts.js">mpegts.js</a>, HTML5/MSE for playing HTTP-TS</li>
+                        <li><a href="https://github.com/video-dev/hls.js/">hls.js</a>, HTML5/MSE for playing HLS</li>
+                        <li><a href="https://github.com/Dash-Industry-Forum/dash.js">dash.js</a>, HTML5/MSE for playing MPEG-DASH</li>
                     </ul>
                 </p>
             </div>
@@ -79,14 +79,14 @@
         <div id="main_flash_alert" class="alert alert-danger fade in hide">
             <button type="button" class="close" data-dismiss="alert">×</button>
             <p>
-                <a href="https://www.adobe.com/products/flashplayer/end-of-life.html" target="_blank">Flash已死</a>，
-                无法播放RTMP流，可用ffplay或VLC播放器播放。
+                <a href="https://www.adobe.com/products/flashplayer/end-of-life.html" target="_blank">Flash is dead</a>，
+                Unable to play RTMP streams, you can use ffplay or VLC player to play.
             </p>
             <ul>
-                <li>若希望做低延迟直播（3-5秒），可用HTTP-FLV，播放器用<a href="https://github.com/xqq/mpegts.js">flv.js</a>，H5/MSE播放HTTP-FLV</li>
-                <li>若希望做低延迟直播（3-5秒），可用HTTP-TS，播放器用<a href="https://github.com/xqq/mpegts.js">mpegts.js</a>，H5/MSE播放HTTP-TS</li>
-                <li>若对延迟不敏感（5-10秒），跨平台比较好，可用HLS，播放器用<a href="https://github.com/video-dev/hls.js/">hls.js</a>，H5/MSE播放HLS</li>
-                <li>若希望超低延迟（1秒内），只需要支持主流的浏览器，可用WebRTC，播放器用<a href="rtc_player.html">RTC播放器</a></li>
+                <li>If you want low-latency live streaming (3-5 seconds), you can use HTTP-FLV with the <a href="https://github.com/xqq/mpegts.js">flv.js</a> player for H5/MSE playback of HTTP-FLV.</li>
+                <li>If you want low-latency live streaming (3-5 seconds), you can use HTTP-TS with the <a href="https://github.com/xqq/mpegts.js">mpegts.js</a> player for H5/MSE playback of HTTP-TS.</li>
+                <li>If you are not sensitive to latency (5-10 seconds) and want better cross-platform compatibility, you can use HLS with the <a href="https://github.com/video-dev/hls.js/">hls.js</a> player for H5/MSE playback of HLS.</li>
+                <li>If you want ultra-low latency (within 1 second) and only need to support mainstream browsers, you can use WebRTC with the <a href="rtc_player.html">RTC player</a>.</li>
             </ul>
             <p>
                 更多信息，参考<a href="https://mp.weixin.qq.com/s/oYn5q4fF9afaged23Ueudg" target="_blank">没有Flash如何做直播？</a>

--- a/trunk/research/players/srs_player_deprecated.html
+++ b/trunk/research/players/srs_player_deprecated.html
@@ -32,7 +32,7 @@
             <a id="srs_index" class="brand" href="#">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li class="active"><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
+                    <li class="active"><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
                     <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
                     <li><a  href="http://ossrs.net/srs.release/releases/app.html">iOS/Andriod</a></li>

--- a/trunk/research/players/srs_publisher.html
+++ b/trunk/research/players/srs_publisher.html
@@ -21,7 +21,7 @@
             <a id="srs_index" class="brand" href="#">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
+                    <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
                     <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
                 </ul>

--- a/trunk/research/players/srs_publisher_flash.html
+++ b/trunk/research/players/srs_publisher_flash.html
@@ -18,7 +18,7 @@
             <a id="srs_index" class="brand" href="#">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
+                    <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
                 </ul>
             </div>
         </div>

--- a/trunk/research/players/vlc.html
+++ b/trunk/research/players/vlc.html
@@ -18,7 +18,7 @@
             <a id="srs_index" class="brand" href="#">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
+                    <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
                     <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
                     <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
                     <li><a id="nav_srs_publisher" href="srs_publisher.html">SRS编码器</a></li>

--- a/trunk/research/players/whep.html
+++ b/trunk/research/players/whep.html
@@ -23,9 +23,9 @@
             <a id="srs_index" class="brand" href="https://github.com/ossrs/srs">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
-                    <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
-                    <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
+                    <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
+                    <!--<li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>-->
+                    <!--<li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>-->
                     <li><a id="nav_whip" href="whip.html">WHIP</a></li>
                     <li class="active"><a id="nav_whep" href="whip.html">WHEP</a></li>
                     <li><a  href="http://ossrs.net/srs.release/releases/app.html">iOS/Andriod</a></li>
@@ -45,6 +45,10 @@
     </div>
 </div>
 <div class="container">
+    <div id="main_info" class="alert alert-info fade in">
+        <button type="button" class="close" data-dismiss="alert">×</button>
+        <strong><span>Usage:</span></strong> <span>Enter the WebRTC WHEP URL and click "Play" to start playing.</span>
+    </div>
     <div class="form-inline">
         URL:
         <input type="text" id="txt_url" class="input-xxlarge" value="">

--- a/trunk/research/players/whip.html
+++ b/trunk/research/players/whip.html
@@ -23,9 +23,9 @@
             <a id="srs_index" class="brand" href="https://github.com/ossrs/srs">SRS</a>
             <div class="nav-collapse collapse">
                 <ul class="nav">
-                    <li><a id="nav_srs_player" href="srs_player.html">SRS播放器</a></li>
-                    <li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>
-                    <li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>
+                    <li><a id="nav_srs_player" href="srs_player.html">LivePlayer</a></li>
+                    <!--<li><a id="nav_rtc_player" href="rtc_player.html">RTC播放器</a></li>-->
+                    <!--<li><a id="nav_rtc_publisher" href="rtc_publisher.html">RTC推流</a></li>-->
                     <li class="active"><a id="nav_whip" href="whip.html">WHIP</a></li>
                     <li><a id="nav_whep" href="whip.html">WHEP</a></li>
                     <li><a  href="http://ossrs.net/srs.release/releases/app.html">iOS/Andriod</a></li>
@@ -45,6 +45,10 @@
     </div>
 </div>
 <div class="container">
+    <div id="main_info" class="alert alert-info fade in">
+        <button type="button" class="close" data-dismiss="alert">×</button>
+        <strong><span>Usage:</span></strong> <span>Enter the WebRTC WHIP URL and click "Publish" to start publishing.</span>
+    </div>
     <div class="form-inline">
         URL:
         <input type="text" id="txt_url" class="input-xxlarge" value="">

--- a/trunk/src/app/srs_app_rtc_codec.cpp
+++ b/trunk/src/app/srs_app_rtc_codec.cpp
@@ -390,6 +390,8 @@ srs_error_t SrsAudioTranscoder::encode(std::vector<SrsAudioFrame*> &pkts)
 
     int frame_cnt = 0;
     while (av_audio_fifo_size(fifo_) >= enc_->frame_size) {
+        // here if error occurs.
+
         /* Read as many samples from the FIFO buffer as required to fill the frame.
         * The samples are stored in the frame temporarily. */
         if (av_audio_fifo_read(fifo_, (void **)enc_frame_->data, enc_->frame_size) < enc_->frame_size) {

--- a/trunk/src/app/srs_app_rtc_codec.cpp
+++ b/trunk/src/app/srs_app_rtc_codec.cpp
@@ -388,8 +388,6 @@ srs_error_t SrsAudioTranscoder::encode(std::vector<SrsAudioFrame*> &pkts)
         }
     }
 
-    // here if error occurs.
-
     int frame_cnt = 0;
     while (av_audio_fifo_size(fifo_) >= enc_->frame_size) {
         /* Read as many samples from the FIFO buffer as required to fill the frame.

--- a/trunk/src/app/srs_app_rtc_codec.cpp
+++ b/trunk/src/app/srs_app_rtc_codec.cpp
@@ -388,10 +388,10 @@ srs_error_t SrsAudioTranscoder::encode(std::vector<SrsAudioFrame*> &pkts)
         }
     }
 
+    // here if error occurs.
+
     int frame_cnt = 0;
     while (av_audio_fifo_size(fifo_) >= enc_->frame_size) {
-        // here if error occurs.
-
         /* Read as many samples from the FIFO buffer as required to fill the frame.
         * The samples are stored in the frame temporarily. */
         if (av_audio_fifo_read(fifo_, (void **)enc_frame_->data, enc_->frame_size) < enc_->frame_size) {

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    195
+#define VERSION_REVISION    196
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    95
+#define VERSION_REVISION    96
 
 #endif


### PR DESCRIPTION
By default, caching is enabled during compilation, which means that data is cached in Docker. This helps to avoid compiling third-party dependency libraries. However, sometimes when updating third-party libraries, it's necessary to disable caching to temporarily verify if the pipeline can succeed. Therefore, a configure option should be added. When this option is enabled, the compilation cache will not be used, and all third-party libraries will be compiled from scratch.