### PR TITLE
Support configure with --extra-ldflags. v5.0.199 v6.0.99

### DIFF
--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -119,6 +119,7 @@ SRS_TOOL_AR=ar
 SRS_TOOL_LD=ld
 SRS_TOOL_RANDLIB=randlib
 SRS_EXTRA_FLAGS=
+SRS_EXTRA_LDFLAGS=
 #
 #####################################################################################
 # Performance optimize.
@@ -209,6 +210,7 @@ Toolchain options:
   --ld=<LD>                 Toolchain: Use linker tool LD. Default: $SRS_TOOL_CXX
   --randlib=<RANDLIB>       Toolchain: Use randlib tool RANDLIB. Default: $SRS_TOOL_CXX
   --extra-flags=<EFLAGS>    Set EFLAGS as CFLAGS and CXXFLAGS. Also passed to ST as EXTRA_CFLAGS.
+  --extra-ldflags=<ELDFLAGS> Set ELDFLAGS as LDFLAGS.
 
 Cross Build options:        @see https://ossrs.net/lts/zh-cn/docs/v4/doc/arm#ubuntu-cross-build-srs
   --cross=on|off            Enable cross-build, please set bellow Toolchain also. Default: $(value2switch $SRS_CROSS_BUILD)
@@ -313,6 +315,7 @@ function parse_user_option() {
         --ld)                           SRS_TOOL_LD=${value}        ;;
         --randlib)                      SRS_TOOL_RANDLIB=${value}   ;;
         --extra-flags)                  SRS_EXTRA_FLAGS=${value}    ;;
+        --extra-ldflags)                SRS_EXTRA_LDFLAGS=${value}  ;;
         --build-tag)                    SRS_BUILD_TAG=${value}      ;;
 
         --srtp-nasm)                    SRS_SRTP_ASM=$(switch2value $value) ;;
@@ -442,7 +445,7 @@ function parse_user_option_to_value_and_option() {
     case "$option" in
         -*=*) 
             value=`echo "$option" | sed -e 's|[-_a-zA-Z0-9/]*=||'`
-            option=`echo "$option" | sed -e 's|=[-_a-zA-Z0-9/. +]*||'`
+            option=`echo "$option" | sed -e 's|=[,-_a-zA-Z0-9/. +]*||'`
         ;;
            *) value="" ;;
     esac
@@ -684,6 +687,7 @@ function regenerate_options() {
     if [[ $SRS_CROSS_BUILD_HOST != "" ]]; then SRS_AUTO_CONFIGURE="$SRS_AUTO_CONFIGURE --host=$SRS_CROSS_BUILD_HOST"; fi
     if [[ $SRS_CROSS_BUILD_PREFIX != "" ]]; then SRS_AUTO_CONFIGURE="$SRS_AUTO_CONFIGURE --cross-prefix=$SRS_CROSS_BUILD_PREFIX"; fi
     if [[ $SRS_EXTRA_FLAGS != '' ]]; then   SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --extra-flags=\\\"$SRS_EXTRA_FLAGS\\\""; fi
+    if [[ $SRS_EXTRA_LDFLAGS != '' ]]; then SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --extra-ldflags=\\\"$SRS_EXTRA_LDFLAGS\\\""; fi
     if [[ $SRS_BUILD_TAG != '' ]]; then     SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --build-tag=\\\"$SRS_BUILD_TAG\\\""; fi
     if [[ $SRS_TOOL_CC != '' ]]; then       SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --cc=$SRS_TOOL_CC"; fi
     if [[ $SRS_TOOL_CXX != '' ]]; then      SRS_AUTO_CONFIGURE="${SRS_AUTO_CONFIGURE} --cxx=$SRS_TOOL_CXX"; fi

--- a/trunk/configure
+++ b/trunk/configure
@@ -145,6 +145,10 @@ END
 # header(.h): add to ModuleLibIncs if need the specified library. for example, LibSTRoot
 # library(.a): add to ModuleLibFiles if binary need the specifeid library. for example, LibSTfile
 #
+
+# the link options, always use static link
+SrsLinkOptions="-ldl -lpthread";
+
 # st(state-threads) the basic network library for SRS.
 LibSTRoot="${SRS_OBJS}/st"; LibSTfile="${LibSTRoot}/libst.a"
 if [[ $SRS_SHARED_ST == YES ]]; then LibSTfile="-L${LibSTRoot} -lst"; fi
@@ -154,7 +158,10 @@ if [[ $SRS_RTC == YES ]]; then
   LibSrtpRoot="${SRS_OBJS}/srtp2/include"; LibSrtpFile="${SRS_OBJS}/srtp2/lib/libsrtp2.a"
   if [[ $SRS_USE_SYS_SRTP == YES ]]; then
       LibSrtpRoot=""; LibSrtpFile="libsrtp2.a"
-      if [[ $SRS_SHARED_SRTP == YES ]]; then LibSrtpFile="-lsrtp2"; fi
+      if [[ $SRS_SHARED_SRTP == YES ]]; then
+          LibSrtpFile=""; 
+          SrsLinkOptions="${SrsLinkOptions} -lsrtp2";
+      fi
   fi
 fi
 
@@ -175,7 +182,8 @@ if [[ $SRS_FFMPEG_FIT == YES ]]; then
         LibFfmpegRoot=""
         LibFfmpegFile="libavcodec.a libswresample.a libavutil.a libopus.a";
         if [[ $SRS_SHARED_FFMPEG == YES ]]; then
-            LibFfmpegFile="-lavcodec -lswresample -lavutil -lopus"
+            LibFfmpegFile=""
+            SrsLinkOptions="${SrsLinkOptions} -lavcodec -lswresample -lavutil -lopus";
         fi
     fi
 fi
@@ -201,12 +209,13 @@ if [[ $SRS_SRT == YES ]]; then
     if [[ $SRS_SHARED_SRT == YES ]]; then LibSRTfile="-L${SRS_OBJS}/srt/lib -lsrt"; fi
     if [[ $SRS_USE_SYS_SRT == YES ]]; then
         LibSRTRoot=""; LibSRTfile="libsrt.a"
-        if [[ $SRS_SHARED_SRT == YES ]]; then LibSRTfile="-lsrt"; fi
+        if [[ $SRS_SHARED_SRT == YES ]]; then 
+            LibSRTfile=""; 
+            SrsLinkOptions="${SrsLinkOptions} -lsrt";
+        fi
     fi
 fi
 
-# the link options, always use static link
-SrsLinkOptions="-ldl -lpthread";
 if [[ $SRS_SSL == YES && $SRS_USE_SYS_SSL == YES ]]; then
     SrsLinkOptions="${SrsLinkOptions} -lssl -lcrypto";
 fi
@@ -245,6 +254,11 @@ fi
 # For FFMPEG/RTC on windows.
 if [[ $SRS_CYGWIN64 == YES && $SRS_FFMPEG_FIT == YES ]]; then
     SrsLinkOptions="${SrsLinkOptions} -lbcrypt";
+fi
+
+# User configed options.
+if [[ $SRS_EXTRA_LDFLAGS != '' ]]; then
+    SrsLinkOptions="${SrsLinkOptions} $SRS_EXTRA_LDFLAGS";
 fi
 
 #####################################################################################
@@ -415,7 +429,7 @@ if [[ $SRS_SRT == YES ]]; then
     ModuleLibIncs+=(${LibSRTRoot})
     MODULE_OBJS="${MODULE_OBJS} ${SRT_OBJS[@]}"
 fi
-LINK_OPTIONS="${SrsLinkOptions}${SrsGprofLink}${SrsGperfLink}"
+LINK_OPTIONS="${LDFLAGS} ${SrsLinkOptions}${SrsGprofLink}${SrsGperfLink}"
 #
 # srs: srs(simple rtmp server) over st(state-threads)
 BUILD_KEY="srs" APP_MAIN="srs_main_server" APP_NAME="srs" . $SRS_WORKDIR/auto/apps.sh
@@ -479,7 +493,7 @@ if [[ $SRS_UTEST == YES ]]; then
     fi
     MODULE_DEPENDS=("CORE" "KERNEL" "PROTOCOL" "APP")
     MODULE_OBJS="${CORE_OBJS[@]} ${KERNEL_OBJS[@]} ${PROTOCOL_OBJS[@]} ${APP_OBJS[@]} ${SRT_OBJS[@]}"
-    LINK_OPTIONS="-lpthread ${SrsLinkOptions}" MODULE_DIR="src/utest" APP_NAME="srs_utest" . $SRS_WORKDIR/auto/utest.sh
+    LINK_OPTIONS="${LDFLAGS} -lpthread ${SrsLinkOptions}" MODULE_DIR="src/utest" APP_NAME="srs_utest" . $SRS_WORKDIR/auto/utest.sh
 fi
 
 #####################################################################################
@@ -506,6 +520,7 @@ AR = ${SRS_TOOL_AR}
 LINK = ${SRS_TOOL_LD}
 RANDLIB = ${SRS_TOOL_RANDLIB}
 CXXFLAGS = ${CXXFLAGS}
+LDFLAGS = ${LDFLAGS}
 
 # install prefix.
 SRS_PREFIX=${SRS_PREFIX}

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-11-15, Merge [#3879](https://github.com/ossrs/srs/pull/3879): Add --extra-ldflags. v6.0.99 (#3879)
 * v6.0, 2023-11-06, Merge [#3851](https://github.com/ossrs/srs/pull/3851): donot compile libopus when enable sys-ffmpeg. v6.0.98 (#3851)
 * v6.0, 2023-11-04, Merge [#3852](https://github.com/ossrs/srs/pull/3852): RTC: Refine FFmpeg opus audio noisy issue. v6.0.97 (#3852)
 * v6.0, 2023-11-01, Merge [#3858](https://github.com/ossrs/srs/pull/3858): Support build without cache to test if actions fail. v6.0.96 (#3858)
@@ -110,6 +111,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-11-15, Merge [#3879](https://github.com/ossrs/srs/pull/3879): Add --extra-ldflags. v5.0.199 (#3879)
 * v5.0, 2023-11-06, Merge [#3851](https://github.com/ossrs/srs/pull/3851): donot compile libopus when enable sys-ffmpeg. v5.0.198 (#3851)
 * v5.0, 2023-11-04, Merge [#3852](https://github.com/ossrs/srs/pull/3852): RTC: Refine FFmpeg opus audio noisy issue. v5.0.197 (#3852)
 * v5.0, 2023-11-01, Merge [#3858](https://github.com/ossrs/srs/pull/3858): Support build without cache to test if actions fail. v5.0.196 (#3858)

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    198
+#define VERSION_REVISION    199
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    98
+#define VERSION_REVISION    99
 
 #endif


### PR DESCRIPTION
1. add --extra-ldflags
2. support  commas in configure file
3. support link system library for utest

```
./configure --extra-ldflags=-Wl,-z,now
```