### PR TITLE
Fix opus delay options, use ffmpeg-opus in docker test. v6.0.102

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,7 +1,7 @@
 # These are supported funding model platforms
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
+patreon: ossrs
 open_collective: srs-server
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
           echo "SRS_TAG=${{ needs.envs.outputs.SRS_TAG }}" >> $GITHUB_ENV
           echo "SRS_VERSION=${{ needs.envs.outputs.SRS_VERSION }}" >> $GITHUB_ENV
           echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
-          echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_XYZ }}" >> $GITHUB_ENV
+          echo "SRS_XYZ=${{ needs.envs.outputs.SRS_XYZ }}" >> $GITHUB_ENV
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
@@ -304,7 +304,7 @@ jobs:
           echo "SRS_TAG=${{ needs.envs.outputs.SRS_TAG }}" >> $GITHUB_ENV
           echo "SRS_VERSION=${{ needs.envs.outputs.SRS_VERSION }}" >> $GITHUB_ENV
           echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
-          echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_XYZ }}" >> $GITHUB_ENV
+          echo "SRS_XYZ=${{ needs.envs.outputs.SRS_XYZ }}" >> $GITHUB_ENV
       # Aliyun ACR
       # TODO: FIXME: If stable, please set the latest from 5.0 to 6.0
       - name: Login aliyun hub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Run SRS regression-test
         run: |
           docker run --rm srs:test bash -c './objs/srs -c conf/regression-test.conf && \
-              cd 3rdparty/srs-bench && (./objs/srs_test -test.v || (cat ../../objs/srs.log && exit 1)) && cat ../../objs/srs.log && \
+              cd 3rdparty/srs-bench && (./objs/srs_test -test.v || (cat ../../objs/srs.log && exit 1)) && \
               ./objs/srs_gb28181_test -test.v'
     runs-on: ubuntu-20.04
 

--- a/trunk/Dockerfile.test
+++ b/trunk/Dockerfile.test
@@ -16,8 +16,9 @@ COPY . /srs
 WORKDIR /srs/trunk
 
 # Note that we must enable the gcc7 or link failed.
-# Note that we must disable the build-cache, or it will failed, but donot know why.
-RUN ./configure --srt=on --gb28181=on --srt=on --apm=on --h265=on --utest=on --ffmpeg-opus=on --build-cache=off
+# Please note that we must disable the ffmpeg-opus, as it negatively impacts performance. We may consider
+# enabling it in the future when support for multi-threading transcoding is available.
+RUN ./configure --srt=on --gb28181=on --srt=on --apm=on --h265=on --utest=on --ffmpeg-opus=off --build-cache=on
 RUN make utest ${MAKEARGS}
 
 # Build benchmark tool.

--- a/trunk/Dockerfile.test
+++ b/trunk/Dockerfile.test
@@ -17,7 +17,7 @@ WORKDIR /srs/trunk
 
 # Note that we must enable the gcc7 or link failed.
 # Note that we must disable the build-cache, or it will failed, but donot know why.
-RUN ./configure --srt=on --gb28181=on --srt=on --apm=on --h265=on --utest=on --ffmpeg-opus=off --build-cache=on
+RUN ./configure --srt=on --gb28181=on --srt=on --apm=on --h265=on --utest=on --ffmpeg-opus=on --build-cache=off
 RUN make utest ${MAKEARGS}
 
 # Build benchmark tool.

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-11-22, Merge [#3883](https://github.com/ossrs/srs/pull/3883): Fix opus delay options, use ffmpeg-opus in docker test. v6.0.102 (#3883)
 * v6.0, 2023-11-19, Merge [#3886](https://github.com/ossrs/srs/pull/3886): Change the hls_aof_ratio to 2.1. v6.0.101 (#3886)
 * v6.0, 2023-11-16, Merge [#3868](https://github.com/ossrs/srs/pull/3868): Fix the test fail when enable ffmpeg-opus. v6.0.100 (#3868)
 * v6.0, 2023-11-15, Merge [#3879](https://github.com/ossrs/srs/pull/3879): Add --extra-ldflags. v6.0.99 (#3879)

--- a/trunk/src/app/srs_app_rtc_codec.cpp
+++ b/trunk/src/app/srs_app_rtc_codec.cpp
@@ -249,7 +249,7 @@ srs_error_t SrsAudioTranscoder::init_enc(SrsAudioCodecId dst_codec, int dst_chan
         enc_->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
 
 #ifdef SRS_FFMPEG_OPUS
-        av_opt_set(enc_->priv_data, "opus_delay", "2.5", 0);
+        av_opt_set(enc_->priv_data, "opus_delay", "25", 0);
 #endif
     } else if (dst_codec == SrsAudioCodecIdAAC) {
         enc_->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    101
+#define VERSION_REVISION    102
 
 #endif


### PR DESCRIPTION
The `ffmpeg-opus` tool allows you to control the delay using the `opus_delay` option. The minimum delay can be set to 2.5ms. However, in practice, you cannot set it this low. You need to set at least 10 frames to allow the audio encoder to lookahead. Otherwise, the sound will be distorted.

`TRANS_BY_GPT4`

---------

Co-authored-by: chundonglinlin <chundonglinlin@163.com>