### PR TITLE
Change the hls_aof_ratio to 2.1. v5.0.200 v6.0.101

### DIFF
--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -1772,8 +1772,8 @@ vhost hls.srs.com {
         # for example, the hls_fragment is 10s, hls_aof_ratio is 1.2,
         # the segment will reap to 12s for pure audio.
         # Overwrite by env SRS_VHOST_HLS_HLS_AOF_RATIO for all vhosts.
-        # default: 1.2
-        hls_aof_ratio 1.2;
+        # default: 2.1
+        hls_aof_ratio 2.1;
         # the hls window in seconds, the number of ts in m3u8.
         # Overwrite by env SRS_VHOST_HLS_HLS_WINDOW for all vhosts.
         # default: 60

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-11-19, Merge [#3886](https://github.com/ossrs/srs/pull/3886): Change the hls_aof_ratio to 2.1. v6.0.101 (#3886)
 * v6.0, 2023-11-16, Merge [#3868](https://github.com/ossrs/srs/pull/3868): Fix the test fail when enable ffmpeg-opus. v6.0.100 (#3868)
 * v6.0, 2023-11-15, Merge [#3879](https://github.com/ossrs/srs/pull/3879): Add --extra-ldflags. v6.0.99 (#3879)
 * v6.0, 2023-11-06, Merge [#3851](https://github.com/ossrs/srs/pull/3851): donot compile libopus when enable sys-ffmpeg. v6.0.98 (#3851)
@@ -112,6 +113,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-11-19, Merge [#3886](https://github.com/ossrs/srs/pull/3886): Change the hls_aof_ratio to 2.1. v5.0.200 (#3886)
 * v5.0, 2023-11-15, Merge [#3879](https://github.com/ossrs/srs/pull/3879): Add --extra-ldflags. v5.0.199 (#3879)
 * v5.0, 2023-11-06, Merge [#3851](https://github.com/ossrs/srs/pull/3851): donot compile libopus when enable sys-ffmpeg. v5.0.198 (#3851)
 * v5.0, 2023-11-04, Merge [#3852](https://github.com/ossrs/srs/pull/3852): RTC: Refine FFmpeg opus audio noisy issue. v5.0.197 (#3852)

--- a/trunk/ide/srs_clion/CMakeLists.txt
+++ b/trunk/ide/srs_clion/CMakeLists.txt
@@ -45,6 +45,7 @@ set(DEPS_LIBS ${SRS_DIR}/objs/st/libst.a
         ${SRS_DIR}/objs/ffmpeg/lib/libavcodec.a
         ${SRS_DIR}/objs/ffmpeg/lib/libavutil.a
         ${SRS_DIR}/objs/ffmpeg/lib/libswresample.a
+        ${SRS_DIR}/objs/opus/lib/libopus.a
         ${SRS_DIR}/objs/srt/lib/libsrt.a)
 foreach(DEPS_LIB ${DEPS_LIBS})
     IF (NOT EXISTS ${DEPS_LIB})

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -7035,7 +7035,7 @@ double SrsConfig::get_hls_aof_ratio(string vhost)
 {
     SRS_OVERWRITE_BY_ENV_FLOAT("srs.vhost.hls.hls_aof_ratio"); // SRS_VHOST_HLS_HLS_AOF_RATIO
 
-    static double DEFAULT = 1.2;
+    static double DEFAULT = 2.1;
     
     SrsConfDirective* conf = get_hls(vhost);
     if (!conf) {

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    199
+#define VERSION_REVISION    200
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    100
+#define VERSION_REVISION    101
 
 #endif


### PR DESCRIPTION
In pure audio mode, there are no keyframes. Therefore, we can only rely on the length of the slice to determine whether it should be output. `hls_aof_ratio` is the coefficient that, once reached, will generate a new slice.

In scenarios with video, if the `hls_aof_ratio` is too small, for example 1.2, and the GOP (Group of Pictures) is 10 seconds, then a slice will definitely be generated at 12 seconds. At this point, if there are no keyframes, it will cause the next slice to start with a non-keyframe.

A safer coefficient is twice the GOP (Group of Pictures). This way, it won't trigger incorrectly and prevent the individual transcoding of a ts segment file.



---------

`TRANS_BY_GPT4`

---------

Co-authored-by: Haibo Chen <495810242@qq.com>