### PR TITLE
fix 'sed' error in options.sh. v5.0.201 v6.0.103

### DIFF
--- a/trunk/auto/options.sh
+++ b/trunk/auto/options.sh
@@ -446,7 +446,7 @@ function parse_user_option_to_value_and_option() {
     case "$option" in
         -*=*) 
             value=`echo "$option" | sed -e 's|[-_a-zA-Z0-9/]*=||'`
-            option=`echo "$option" | sed -e 's|=[,-_a-zA-Z0-9/. +]*||'`
+            option=`echo "$option" | sed -e 's|=[-_a-zA-Z0-9/. +,]*||'`
         ;;
            *) value="" ;;
     esac

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-11-22, Merge [#3891](https://github.com/ossrs/srs/pull/3891): fix 'sed' error in options.sh. v6.0.103 (#3891)
 * v6.0, 2023-11-22, Merge [#3883](https://github.com/ossrs/srs/pull/3883): Fix opus delay options, use ffmpeg-opus in docker test. v6.0.102 (#3883)
 * v6.0, 2023-11-19, Merge [#3886](https://github.com/ossrs/srs/pull/3886): Change the hls_aof_ratio to 2.1. v6.0.101 (#3886)
 * v6.0, 2023-11-16, Merge [#3868](https://github.com/ossrs/srs/pull/3868): Fix the test fail when enable ffmpeg-opus. v6.0.100 (#3868)
@@ -114,6 +115,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-11-22, Merge [#3891](https://github.com/ossrs/srs/pull/3891): fix 'sed' error in options.sh. v5.0.201 (#3891)
 * v5.0, 2023-11-19, Merge [#3886](https://github.com/ossrs/srs/pull/3886): Change the hls_aof_ratio to 2.1. v5.0.200 (#3886)
 * v5.0, 2023-11-15, Merge [#3879](https://github.com/ossrs/srs/pull/3879): Add --extra-ldflags. v5.0.199 (#3879)
 * v5.0, 2023-11-06, Merge [#3851](https://github.com/ossrs/srs/pull/3851): donot compile libopus when enable sys-ffmpeg. v5.0.198 (#3851)

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    200
+#define VERSION_REVISION    201
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    102
+#define VERSION_REVISION    103
 
 #endif


### PR DESCRIPTION
The `-` character, when placed in the middle of a regular expression, is interpreted as a range. It must be placed at the beginning or end to be interpreted as a literal character.



---------

`TRANS_BY_GPT4`

---------

Co-authored-by: john <hondaxiao@tencent.com>