### PR TITLE
RTC: Support OPUS stereo SDP option. v5.0.203 v6.0.105

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-12-14, Merge [#3910](https://github.com/ossrs/srs/pull/3910): RTC: Support OPUS stereo SDP option. v6.0.105 (#3910)
 * v6.0, 2023-12-14, Merge [#3902](https://github.com/ossrs/srs/pull/3902): Security: Support IP whitelist for HTTP-FLV, HLS, WebRTC, and SRT. v6.0.104 (#3902)
 * v6.0, 2023-11-22, Merge [#3891](https://github.com/ossrs/srs/pull/3891): fix 'sed' error in options.sh. v6.0.103 (#3891)
 * v6.0, 2023-11-22, Merge [#3883](https://github.com/ossrs/srs/pull/3883): Fix opus delay options, use ffmpeg-opus in docker test. v6.0.102 (#3883)
@@ -116,6 +117,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-12-14, Merge [#3910](https://github.com/ossrs/srs/pull/3910): RTC: Support OPUS stereo SDP option. v5.0.203 (#3910)
 * v5.0, 2023-12-14, Merge [#3902](https://github.com/ossrs/srs/pull/3902): Security: Support IP whitelist for HTTP-FLV, HLS, WebRTC, and SRT. v5.0.202 (#3902)
 * v5.0, 2023-11-22, Merge [#3891](https://github.com/ossrs/srs/pull/3891): fix 'sed' error in options.sh. v5.0.201 (#3891)
 * v5.0, 2023-11-19, Merge [#3886](https://github.com/ossrs/srs/pull/3886): Change the hls_aof_ratio to 2.1. v5.0.200 (#3886)

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -1968,6 +1968,7 @@ SrsAudioPayload::SrsAudioPayload(uint8_t pt, std::string encode_name, int sample
     channel_ = channel;
     opus_param_.minptime = 0;
     opus_param_.use_inband_fec = false;
+    opus_param_.stereo = false;
     opus_param_.usedtx = false;
 }
 
@@ -2009,6 +2010,9 @@ SrsMediaPayloadType SrsAudioPayload::generate_media_payload_type()
     if (opus_param_.use_inband_fec) {
         format_specific_param << ";useinbandfec=1";
     }
+    if (opus_param_.stereo) {
+        format_specific_param << ";stereo=1";
+    }
     if (opus_param_.usedtx) {
         format_specific_param << ";usedtx=1";
     }
@@ -2028,6 +2032,8 @@ srs_error_t SrsAudioPayload::set_opus_param_desc(std::string fmtp)
                 opus_param_.minptime = (int)::atol(kv[1].c_str());
             } else if (kv[0] == "useinbandfec") {
                 opus_param_.use_inband_fec = (kv[1] == "1") ? true : false;
+            } else if (kv[0] == "stereo") {
+                opus_param_.stereo = (kv[1] == "1") ? true : false;
             } else if (kv[0] == "usedtx") {
                 opus_param_.usedtx = (kv[1] == "1") ? true : false;
             }

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -389,11 +389,13 @@ class SrsAudioPayload : public SrsCodecPayload
     {
         int minptime;
         bool use_inband_fec;
+        bool stereo;
         bool usedtx;
 
         SrsOpusParameter() {
             minptime = 0;
             use_inband_fec = false;
+            stereo = false;
             usedtx = false;
         }
     };

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023-2023 The SRS Authors
+// Copyright (c) 2033-2033 The SRS Authors
 //
 // SPDX-License-Identifier: MIT
 //
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    202
+#define VERSION_REVISION    203
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    104
+#define VERSION_REVISION    105
 
 #endif


### PR DESCRIPTION
In an SDK that supports RTC Opus stereo, the parameter "stereo=1" may appear. SRS (Spatial Reference System) needs to handle this correctly and return an answer to enable WebRTC stereo support.



---------

`TRANS_BY_GPT4`