### PR TITLE
Reverted: WHIP: Fix bug for converting WHIP to RTMP/HLS. v5.0.204 v6.0.107

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-12-29, Merge [#3911](https://github.com/ossrs/srs/pull/3911): WHIP: Fix bug for converting WHIP to RTMP/HLS. v6.0.107 (#3911)
 * v6.0, 2023-12-15, Merge [#3854](https://github.com/ossrs/srs/pull/3854): Typo: line 263 - srs_app_srt_conn.cpp. v6.0.106 (#3854)
 * v6.0, 2023-12-14, Merge [#3910](https://github.com/ossrs/srs/pull/3910): RTC: Support OPUS stereo SDP option. v6.0.105 (#3910)
 * v6.0, 2023-12-14, Merge [#3902](https://github.com/ossrs/srs/pull/3902): Security: Support IP whitelist for HTTP-FLV, HLS, WebRTC, and SRT. v6.0.104 (#3902)
@@ -118,6 +119,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2023-12-29, Merge [#3911](https://github.com/ossrs/srs/pull/3911): WHIP: Fix bug for converting WHIP to RTMP/HLS. v5.0.204 (#3911)
 * v5.0, 2023-12-14, Merge [#3910](https://github.com/ossrs/srs/pull/3910): RTC: Support OPUS stereo SDP option. v5.0.203 (#3910)
 * v5.0, 2023-12-14, Merge [#3902](https://github.com/ossrs/srs/pull/3902): Security: Support IP whitelist for HTTP-FLV, HLS, WebRTC, and SRT. v5.0.202 (#3902)
 * v5.0, 2023-11-22, Merge [#3891](https://github.com/ossrs/srs/pull/3891): fix 'sed' error in options.sh. v5.0.201 (#3891)

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -1524,7 +1524,7 @@ srs_error_t SrsRtcFrameBuilder::packet_video_key_frame(SrsRtpPacket* pkt)
             obs_whip_pps_ = pkt->copy();
         }
         // Ignore if one of OBS WHIP SPS/PPS is not ready.
-        if ((obs_whip_sps_ && !obs_whip_pps_) || (obs_whip_sps_ && !obs_whip_pps_)) {
+        if (!obs_whip_pps_ || !obs_whip_pps_) {
             return err;
         }
     }
@@ -1543,7 +1543,7 @@ srs_error_t SrsRtcFrameBuilder::packet_video_key_frame(SrsRtpPacket* pkt)
             return srs_error_new(ERROR_RTC_RTP_MUXER, "no sps or pps in stap-a rtp. sps: %p, pps:%p", sps, pps);
         }
 
-        // Reset SPS/PPS cache.
+        // Reset SPS/PPS cache, ensuring that the next SPS/PPS will be handled when both are received.
         SrsAutoFree(SrsRtpPacket, obs_whip_sps_);
         SrsAutoFree(SrsRtpPacket, obs_whip_pps_);
 

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -1547,39 +1547,37 @@ srs_error_t SrsRtcFrameBuilder::packet_video_key_frame(SrsRtpPacket* pkt)
         SrsAutoFree(SrsRtpPacket, obs_whip_sps_);
         SrsAutoFree(SrsRtpPacket, obs_whip_pps_);
 
-        if (true) {
-            // h264 raw to h264 packet.
-            std::string sh;
-            SrsRawH264Stream* avc = new SrsRawH264Stream();
-            SrsAutoFree(SrsRawH264Stream, avc);
+        // h264 raw to h264 packet.
+        std::string sh;
+        SrsRawH264Stream* avc = new SrsRawH264Stream();
+        SrsAutoFree(SrsRawH264Stream, avc);
 
-            if ((err = avc->mux_sequence_header(string(sps->bytes, sps->size), string(pps->bytes, pps->size), sh)) != srs_success) {
-                return srs_error_wrap(err, "mux sequence header");
-            }
+        if ((err = avc->mux_sequence_header(string(sps->bytes, sps->size), string(pps->bytes, pps->size), sh)) != srs_success) {
+            return srs_error_wrap(err, "mux sequence header");
+        }
 
-            // h264 packet to flv packet.
-            char* flv = NULL;
-            int nb_flv = 0;
-            if ((err = avc->mux_avc2flv(sh, SrsVideoAvcFrameTypeKeyFrame, SrsVideoAvcFrameTraitSequenceHeader, pkt->get_avsync_time(),
-                                        pkt->get_avsync_time(), &flv, &nb_flv)) != srs_success) {
-                return srs_error_wrap(err, "avc to flv");
-            }
+        // h264 packet to flv packet.
+        char* flv = NULL;
+        int nb_flv = 0;
+        if ((err = avc->mux_avc2flv(sh, SrsVideoAvcFrameTypeKeyFrame, SrsVideoAvcFrameTraitSequenceHeader, pkt->get_avsync_time(),
+                                    pkt->get_avsync_time(), &flv, &nb_flv)) != srs_success) {
+            return srs_error_wrap(err, "avc to flv");
+        }
 
-            SrsMessageHeader header;
-            header.initialize_video(nb_flv, pkt->get_avsync_time(), 1);
-            SrsCommonMessage rtmp;
-            if ((err = rtmp.create(&header, flv, nb_flv)) != srs_success) {
-                return srs_error_wrap(err, "create rtmp");
-            }
+        SrsMessageHeader header;
+        header.initialize_video(nb_flv, pkt->get_avsync_time(), 1);
+        SrsCommonMessage rtmp;
+        if ((err = rtmp.create(&header, flv, nb_flv)) != srs_success) {
+            return srs_error_wrap(err, "create rtmp");
+        }
 
-            SrsSharedPtrMessage msg;
-            if ((err = msg.create(&rtmp)) != srs_success) {
-                return srs_error_wrap(err, "create message");
-            }
+        SrsSharedPtrMessage msg;
+        if ((err = msg.create(&rtmp)) != srs_success) {
+            return srs_error_wrap(err, "create message");
+        }
 
-            if ((err = bridge_->on_frame(&msg)) != srs_success) {
-                return err;
-            }
+        if ((err = bridge_->on_frame(&msg)) != srs_success) {
+            return err;
         }
     }
 

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -318,8 +318,13 @@ private:
     uint16_t header_sn_;
     uint16_t lost_sn_;
     int64_t rtp_key_frame_ts_;
+private:
     // The state for timestamp sync state. -1 for init. 0 not sync. 1 sync.
     int sync_state_;
+private:
+    // For OBS WHIP, send SPS/PPS in dedicated RTP packet.
+    SrsRtpPacket* obs_whip_sps_;
+    SrsRtpPacket* obs_whip_pps_;
 public:
     SrsRtcFrameBuilder(ISrsStreamBridge* bridge);
     virtual ~SrsRtcFrameBuilder();

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -318,6 +318,8 @@ private:
     uint16_t header_sn_;
     uint16_t lost_sn_;
     int64_t rtp_key_frame_ts_;
+    // The state for timestamp sync state. -1 for init. 0 not sync. 1 sync.
+    int sync_state_;
 public:
     SrsRtcFrameBuilder(ISrsStreamBridge* bridge);
     virtual ~SrsRtcFrameBuilder();

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2033-2033 The SRS Authors
+// Copyright (c) 2043-2043 The SRS Authors
 //
 // SPDX-License-Identifier: MIT
 //
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    203
+#define VERSION_REVISION    204
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    106
+#define VERSION_REVISION    107
 
 #endif

--- a/trunk/src/kernel/srs_kernel_rtc_rtp.cpp
+++ b/trunk/src/kernel/srs_kernel_rtc_rtp.cpp
@@ -970,12 +970,14 @@ SrsRtpRawPayload::SrsRtpRawPayload()
 {
     payload = NULL;
     nn_payload = 0;
+    sample_ = new SrsSample();
 
     ++_srs_pps_objs_rraw->sugar;
 }
 
 SrsRtpRawPayload::~SrsRtpRawPayload()
 {
+    srs_freep(sample_);
 }
 
 uint64_t SrsRtpRawPayload::nb_bytes()
@@ -1007,6 +1009,9 @@ srs_error_t SrsRtpRawPayload::decode(SrsBuffer* buf)
     payload = buf->head();
     nn_payload = buf->left();
 
+    sample_->bytes = payload;
+    sample_->size = nn_payload;
+
     return srs_success;
 }
 
@@ -1016,6 +1021,7 @@ ISrsRtpPayloader* SrsRtpRawPayload::copy()
 
     cp->payload = payload;
     cp->nn_payload = nn_payload;
+    cp->sample_ = sample_->copy();
 
     return cp;
 }

--- a/trunk/src/kernel/srs_kernel_rtc_rtp.hpp
+++ b/trunk/src/kernel/srs_kernel_rtc_rtp.hpp
@@ -349,6 +349,9 @@ public:
     char* payload;
     int nn_payload;
 public:
+    // Use the whole RAW RTP payload as a sample.
+    SrsSample* sample_;
+public:
     SrsRtpRawPayload();
     virtual ~SrsRtpRawPayload();
 // interface ISrsRtpPayloader


### PR DESCRIPTION
1. When converting RTC to RTMP, it is necessary to synchronize the audio and video timestamps. When the synchronization status changes, whether it is unsynchronized or synchronized, print logs to facilitate troubleshooting of such issues.
2. Chrome uses the STAP-A packet, which means a single RTP packet contains SPS/PPS information. OBS WHIP, on the other hand, sends SPS and PPS in separate RTP packets. Therefore, SPS and PPS are in two independent RTP packets, and SRS needs to cache these two packets.

---------

Co-authored-by: john <hondaxiao@tencent.com>