### PR TITLE
Forward: when unpublish crash caused by uninitialized forward connection. v6.0.107

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2023-12-30, Merge [#3914](https://github.com/ossrs/srs/pull/3914): Forward: when unpublish crash caused by uninitialized forward connection. v6.0.107 (#3914)
 * v6.0, 2023-12-15, Merge [#3854](https://github.com/ossrs/srs/pull/3854): Typo: line 263 - srs_app_srt_conn.cpp. v6.0.106 (#3854)
 * v6.0, 2023-12-14, Merge [#3910](https://github.com/ossrs/srs/pull/3910): RTC: Support OPUS stereo SDP option. v6.0.105 (#3910)
 * v6.0, 2023-12-14, Merge [#3902](https://github.com/ossrs/srs/pull/3902): Security: Support IP whitelist for HTTP-FLV, HLS, WebRTC, and SRT. v6.0.104 (#3902)

--- a/trunk/src/app/srs_app_forward.cpp
+++ b/trunk/src/app/srs_app_forward.cpp
@@ -94,7 +94,7 @@ srs_error_t SrsForwarder::on_publish()
 void SrsForwarder::on_unpublish()
 {
     trd->stop();
-    sdk->close();
+    if (sdk) sdk->close();
 }
 
 srs_error_t SrsForwarder::on_meta_data(SrsSharedPtrMessage* shared_metadata)

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    106
+#define VERSION_REVISION    107
 
 #endif


### PR DESCRIPTION
Description
A crash occurs when a forward relay connection has not been established and an unpublish event is triggered simultaneously. For instance, if DVR and forward are configured with a specified DVR path that already exists, initiating a stream will trigger a crash.

Objective
Fix the crash caused by the forward mechanism.

Additional Information
For detailed reproduction steps, please refer to issue #3901.



---------

`TRANS_BY_GPT4`

---------

Co-authored-by: john <hondaxiao@tencent.com>