### PR TITLE
RTC: Fix video and audio track pt_ is not change in player before publisher. v5.0.207 v6.0.111

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-02-05, Merge [#3925](https://github.com/ossrs/srs/pull/3925): RTC: Fix video and audio track pt_ is not change in player before publisher. v6.0.111 (#3925)
 * v6.0, 2024-02-05, Merge [#3923](https://github.com/ossrs/srs/pull/3923): Configure: print enabled/disable sanitizer. v6.0.110 (#3923)
 * v6.0, 2023-12-30, Merge [#3916](https://github.com/ossrs/srs/pull/3916): Enhancing the compatibility of options.sh. v6.0.108 (#3916)
 * v6.0, 2023-12-30, Merge [#3914](https://github.com/ossrs/srs/pull/3914): Forward: when unpublish crash caused by uninitialized forward connection. v6.0.107 (#3914)
@@ -121,6 +122,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2024-02-05, Merge [#3925](https://github.com/ossrs/srs/pull/3925): RTC: Fix video and audio track pt_ is not change in player before publisher. v5.0.207 (#3925)
 * v5.0, 2024-02-05, Merge [#3923](https://github.com/ossrs/srs/pull/3923): Configure: print enabled/disable sanitizer. v5.0.206 (#3923)
 * v5.0, 2023-12-30, Merge [#3916](https://github.com/ossrs/srs/pull/3916): Enhancing the compatibility of options.sh. v5.0.204 (#3916)
 * v5.0, 2023-12-14, Merge [#3910](https://github.com/ossrs/srs/pull/3910): RTC: Support OPUS stereo SDP option. v5.0.203 (#3910)

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -534,15 +534,13 @@ void SrsRtcPlayStream::on_stream_change(SrsRtcSourceDescription* desc)
             uint32_t ssrc = desc->audio_track_desc_->ssrc_;
             SrsRtcAudioSendTrack* track = audio_tracks_.begin()->second;
 
-            if(track->track_desc_->media_->pt_of_publisher_ != desc->audio_track_desc_->media_->pt_){
+            if (track->track_desc_->media_->pt_of_publisher_ != desc->audio_track_desc_->media_->pt_) {
                 track->track_desc_->media_->pt_of_publisher_ = desc->audio_track_desc_->media_->pt_;
             }
-            if(desc->audio_track_desc_->red_){
-                if(track->track_desc_->red_){
-                    if(track->track_desc_->red_->pt_of_publisher_ != desc->audio_track_desc_->red_->pt_){
-                        track->track_desc_->red_->pt_of_publisher_ = desc->audio_track_desc_->red_->pt_;
-                    }
-                }
+
+            if (desc->audio_track_desc_->red_ && track->track_desc_->red_ && 
+                    track->track_desc_->red_->pt_of_publisher_ != desc->audio_track_desc_->red_->pt_) {
+                track->track_desc_->red_->pt_of_publisher_ = desc->audio_track_desc_->red_->pt_;
             }
 
             audio_tracks_.clear();
@@ -558,15 +556,13 @@ void SrsRtcPlayStream::on_stream_change(SrsRtcSourceDescription* desc)
             uint32_t ssrc = vdesc->ssrc_;
             SrsRtcVideoSendTrack* track = video_tracks_.begin()->second;
 
-            if(track->track_desc_->media_->pt_of_publisher_ != vdesc->media_->pt_){
+            if (track->track_desc_->media_->pt_of_publisher_ != vdesc->media_->pt_) {
                 track->track_desc_->media_->pt_of_publisher_ = vdesc->media_->pt_;
             }
-            if(vdesc->red_){
-                if(track->track_desc_->red_){
-                    if(track->track_desc_->red_->pt_of_publisher_ != vdesc->red_->pt_){
-                        track->track_desc_->red_->pt_of_publisher_ = vdesc->red_->pt_;
-                    }
-                }
+
+            if (vdesc->red_ && track->track_desc_->red_ && 
+                    track->track_desc_->red_->pt_of_publisher_ != vdesc->red_->pt_) {
+                track->track_desc_->red_->pt_of_publisher_ = vdesc->red_->pt_;
             }
 
             video_tracks_.clear();

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -534,6 +534,17 @@ void SrsRtcPlayStream::on_stream_change(SrsRtcSourceDescription* desc)
             uint32_t ssrc = desc->audio_track_desc_->ssrc_;
             SrsRtcAudioSendTrack* track = audio_tracks_.begin()->second;
 
+            if(track->track_desc_->media_->pt_of_publisher_ != desc->audio_track_desc_->media_->pt_){
+                track->track_desc_->media_->pt_of_publisher_ = desc->audio_track_desc_->media_->pt_;
+            }
+            if(desc->audio_track_desc_->red_){
+                if(track->track_desc_->red_){
+                    if(track->track_desc_->red_->pt_of_publisher_ != desc->audio_track_desc_->red_->pt_){
+                        track->track_desc_->red_->pt_of_publisher_ = desc->audio_track_desc_->red_->pt_;
+                    }
+                }
+            }
+
             audio_tracks_.clear();
             audio_tracks_.insert(make_pair(ssrc, track));
         }
@@ -546,6 +557,17 @@ void SrsRtcPlayStream::on_stream_change(SrsRtcSourceDescription* desc)
             SrsRtcTrackDescription* vdesc = desc->video_track_descs_.at(0);
             uint32_t ssrc = vdesc->ssrc_;
             SrsRtcVideoSendTrack* track = video_tracks_.begin()->second;
+
+            if(track->track_desc_->media_->pt_of_publisher_ != vdesc->media_->pt_){
+                track->track_desc_->media_->pt_of_publisher_ = vdesc->media_->pt_;
+            }
+            if(vdesc->red_){
+                if(track->track_desc_->red_){
+                    if(track->track_desc_->red_->pt_of_publisher_ != vdesc->red_->pt_){
+                        track->track_desc_->red_->pt_of_publisher_ = vdesc->red_->pt_;
+                    }
+                }
+            }
 
             video_tracks_.clear();
             video_tracks_.insert(make_pair(ssrc, track));

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    206
+#define VERSION_REVISION    207
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    110
+#define VERSION_REVISION    111
 
 #endif


### PR DESCRIPTION
For WebRTC:
when player before publisher, it will happen track pt didn't change.

 - At source change step, change track pt 

---------

Co-authored-by: john <hondaxiao@tencent.com>