### PR TITLE
ST: Add support to save RBP register that allows stack backtrace

### DIFF
--- a/trunk/3rdparty/st-srs/md.h
+++ b/trunk/3rdparty/st-srs/md.h
@@ -181,15 +181,17 @@ extern void _st_md_cxt_restore(_st_jmp_buf_t env, int val);
 
     #if defined(__amd64__) || defined(__x86_64__)
         #define MD_GET_SP(_t) *((long *)&((_t)->context[0].__jmpbuf[6]))
+        #define MD_GET_BP(_t) *((long *)&((_t)->context[0].__jmpbuf[1]))
     #else
         #error Unknown CPU architecture
     #endif
 
-    #define MD_INIT_CONTEXT(_thread, _sp, _main) \
+    #define MD_INIT_CONTEXT(_thread, _sp, _bp, _main) \
         ST_BEGIN_MACRO                             \
         if (MD_SETJMP((_thread)->context))         \
             _main();                                 \
         MD_GET_SP(_thread) = (long) (_sp);         \
+        MD_GET_BP(_thread) = (long) (_bp);         \
         ST_END_MACRO
 
     #define MD_GET_UTIME()            \

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -323,7 +323,7 @@ cp -rf $SRS_WORKDIR/research/players ${SRS_OBJS}/nginx/html/ &&
 
 # for favicon.ico
 rm -rf ${SRS_OBJS}/nginx/html/favicon.ico &&
-cp -f $SRS_WORKDIR/research/api-server/static-dir/favicon.ico ${SRS_OBJS}/nginx/html/favicon.ico &&
+cp -f $SRS_WORKDIR/research/favicon.ico ${SRS_OBJS}/nginx/html/favicon.ico &&
 
 # For srs-console.
 rm -rf ${SRS_OBJS}/nginx/html/console &&
@@ -335,7 +335,7 @@ cp -rf $SRS_WORKDIR/3rdparty/signaling/www/demos ${SRS_OBJS}/nginx/html/ &&
 
 # For home page index.html
 rm -rf ${SRS_OBJS}/nginx/html/index.html &&
-cp -f $SRS_WORKDIR/research/api-server/static-dir/index.html ${SRS_OBJS}/nginx/html/index.html &&
+cp -f $SRS_WORKDIR/research/index.html ${SRS_OBJS}/nginx/html/index.html &&
 
 # nginx.html to detect whether nginx is alive
 echo "Nginx is ok." > ${SRS_OBJS}/nginx/html/nginx.html

--- a/trunk/research/st/backtrace.cpp
+++ b/trunk/research/st/backtrace.cpp
@@ -1,0 +1,29 @@
+/*
+g++ backtrace.cpp ../../objs/st/libst.a -g -O0 -o backtrace && ./backtrace
+*/
+#include <stdio.h>
+#include "../../objs/st/st.h"
+
+void* pfn(void* arg) {
+    for (;;) {
+        printf("Hello, coroutine\n");
+        st_sleep(1);
+    }
+    return NULL;
+}
+
+int bar(int argc) {
+    st_thread_create(pfn, NULL, 0, 0);
+    return argc + 1;
+}
+
+int foo(int argc) {
+    return bar(argc);
+}
+
+int main(int argc, char** argv) {
+    st_init();
+    foo(argc);
+    st_thread_exit(NULL);
+    return 0;
+}


### PR DESCRIPTION
Duplicate the entire stack (backtrace) during coroutine creation, store the RBP in the jmpbuf, and replicate the parent RBP and stack home space containing local variables from the parent function.

Keep in mind that local variables might be freed after coroutine creation and should be freed while the coroutine is running. Please be caution with these variables; they only serve as backtrace hints and do not guarantee the validity of all local variables.

This Pull Request primarily serves as a helpful debugging tool for tracking the stack, with limited but valuable utility, particularly for identifying the creators of the current coroutine.

I have tested it in cygwin, before this patch, the backtrace is bellow:

```
(gdb) bt
#0  pfn (arg=0x0) at backtrace.cpp:9
#1  0x0000000100401cea in _st_thread_main () at sched.c:380
#2  0x000000010040265f in st_thread_create (start=0x7ffffcbc0, arg=0x100401b0d <st_thread_exit+588>, joinable=19616, stk_size=131072) at sched.c:666
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
```

After this patch, the backtrace is:

```bash
(gdb) bt
#0  pfn (arg=0x0) at backtrace.cpp:9
#1  0x0000000100401cea in _st_thread_main () at sched.c:380
#2  0x00000001004027f0 in st_thread_create (start=0x100401080 <pfn(void*)>, arg=0x0, joinable=0, stk_size=131072) at sched.c:698
#3  0x00000001004010d2 in bar (argc=0) at backtrace.cpp:16
#4  0x00000001004010f1 in foo (argc=0) at backtrace.cpp:21
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
```

Because only save the parent RBP, so only trace some levels of backtrace.