### PR TITLE
Build: Fix module failed for  main_ingest_hls and mp4_parser. v6.0.119

### DIFF
--- a/trunk/configure
+++ b/trunk/configure
@@ -510,7 +510,7 @@ mv ${SRS_MAKEFILE} ${SRS_MAKEFILE}.bk
 
 # generate phony header
 cat << END > ${SRS_MAKEFILE}
-.PHONY: default all _default install help clean destroy server srs_ingest_hls utest _prepare_dir $__mphonys
+.PHONY: default all _default install help clean destroy server utest _prepare_dir $__mphonys
 .PHONY: clean_srs clean_modules clean_openssl clean_srtp2 clean_opus clean_ffmpeg clean_st
 .PHONY: st ffmpeg
 
@@ -543,7 +543,7 @@ default: server
 
 all: _default
 
-_default: server srs_ingest_hls utest $__mdefaults
+_default: server utest $__mdefaults
 
 help:
 	@echo "Usage: make <help>|<clean>|<destroy>|<server>|<utest>|<install>|<uninstall>"

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-03-26, Merge [#4005](https://github.com/ossrs/srs/pull/4005): Build: Fix module failed for  main_ingest_hls and mp4_parser. v6.0.119 (#4005)
 * v6.0, 2024-03-24, Merge [#3989](https://github.com/ossrs/srs/pull/3989): ST: Research adds examples that demos pthread and helloworld. v6.0.118 (#3989)
 * v6.0, 2024-03-19, Merge [#3958](https://github.com/ossrs/srs/pull/3958): Add a TCP proxy for debugging. v6.0.117 (#3958)
 * v6.0, 2024-03-20, Merge [#3964](https://github.com/ossrs/srs/pull/3964): WebRTC: Add support for A/V only WHEP/WHEP player. v6.0.116 (#3964)

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    118
+#define VERSION_REVISION    119
 
 #endif

--- a/trunk/src/main/srs_main_mp4_parser.cpp
+++ b/trunk/src/main/srs_main_mp4_parser.cpp
@@ -13,6 +13,7 @@
 #include <srs_kernel_stream.hpp>
 #include <srs_core_autofree.hpp>
 #include <srs_app_config.hpp>
+#include <srs_protocol_kbps.hpp>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,8 +31,13 @@ SrsConfig* _srs_config = new SrsConfig();
 // @global Other variables.
 bool _srs_in_docker = false;
 
+// Whether setup config by environment variables, see https://github.com/ossrs/srs/issues/2277
+bool _srs_config_by_env = false;
+
 // The binary name of SRS.
 const char* _srs_binary = NULL;
+
+extern SrsPps* _srs_pps_cids_get;
 
 srs_error_t parse(std::string mp4_file, bool verbose)
 {
@@ -88,6 +94,8 @@ srs_error_t parse(std::string mp4_file, bool verbose)
 
 int main(int argc, char** argv)
 {
+    _srs_pps_cids_get = new SrsPps();
+
     printf("SRS MP4 parser/%d.%d.%d, parse and show the mp4 boxes structure.\n",
            VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
 


### PR DESCRIPTION
1. fix src/main/srs_main_ingest_hls.cpp compiling error;
2. fix src/main/srs_main_mp4_parser.cpp compiling error;
3. remove empty target srs_ingest_hls;