### PR TITLE
Debug: reuse endpoint with RTC and server error.

### DIFF
--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -1196,7 +1196,7 @@ srs_error_t SrsServer::do_on_tcp_client(ISrsListener* listener, srs_netfd_t& stf
             // TODO: FIXME: Should manage this connection by _srs_rtc_manager
             resource = new SrsRtcTcpConn(io, ip, port, this);
         } else {
-            resource = new SrsHttpxConn(listener == http_listener_, this, io, http_server, ip, port);
+            resource = new SrsHttpxConn(listener == https_listener_, this, io, http_server, ip, port);
         }
     }
 #endif


### PR DESCRIPTION
https://github.com/ossrs/srs/blob/427104f1dab86f5afc7d7b49b02ed27d03ef9346/trunk/src/app/srs_app_server.cpp#L1197-L1201

I believe this is a mistake, if reuse the RTC and http server listener, then Http Server connection will be created with incorrect SSL options.