### PR TITLE
Player: Fix empty img tag occupy 20px size in safari. v6.0.142

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-07-24, Merge [#4029](https://github.com/ossrs/srs/pull/4029): Player: Fix empty img tag occupy 20px size in safari. v6.0.142 (#4029)
 * v6.0, 2024-07-24, Merge [#4063](https://github.com/ossrs/srs/pull/4063): let http-remux ts stream support guess_has_av feature;. v6.0.141 (#4063)
 * v6.0, 2024-07-24, Merge [#4116](https://github.com/ossrs/srs/pull/4116): Dockerfile: Consistently use proper ENV syntax using "=". v6.0.140 (#4116)
 * v6.0, 2024-07-24, Merge [#4126](https://github.com/ossrs/srs/pull/4126): Edge: Improve stability for state and fd closing. v6.0.139 (#4126)

--- a/trunk/research/console/en_index.html
+++ b/trunk/research/console/en_index.html
@@ -20,7 +20,7 @@
     <script type="text/javascript" src="js/srs.console.js"></script>
 </head>
 <body ng-controller="CSCMain">
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/console/enindex'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/console/enindex'/>
     <div class="navbar navbar-inverse navbar-fixed-top">
         <div class="navbar-inner">
             <div class="container">

--- a/trunk/research/console/ng_index.html
+++ b/trunk/research/console/ng_index.html
@@ -20,7 +20,7 @@
     <script type="text/javascript" src="js/srs.console.js"></script>
 </head>
 <body ng-controller="CSCMain">
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/console/cnindex'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/console/cnindex'/>
     <div class="navbar navbar-inverse navbar-fixed-top">
         <div class="navbar-inner">
             <div class="container">

--- a/trunk/research/players/rtc_player.html
+++ b/trunk/research/players/rtc_player.html
@@ -16,7 +16,7 @@
     <script type="text/javascript" src="js/srs.page.js"></script>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcplayer'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcplayer'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/rtc_publisher.html
+++ b/trunk/research/players/rtc_publisher.html
@@ -16,7 +16,7 @@
     <script type="text/javascript" src="js/srs.page.js"></script>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcpublisher'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcpublisher'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/srs_bwt.html
+++ b/trunk/research/players/srs_bwt.html
@@ -15,7 +15,7 @@
     </style>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/bwt'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/bwt'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/srs_chat.html
+++ b/trunk/research/players/srs_chat.html
@@ -14,7 +14,7 @@
     </style>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/chat'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/chat'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/srs_gb28181.html
+++ b/trunk/research/players/srs_gb28181.html
@@ -28,7 +28,7 @@
     </style>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/srsplayer'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/srsplayer'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/srs_player.html
+++ b/trunk/research/players/srs_player.html
@@ -11,7 +11,7 @@
     </style>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/srsplayer'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/srsplayer'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/srs_player_deprecated.html
+++ b/trunk/research/players/srs_player_deprecated.html
@@ -25,7 +25,7 @@
     </style>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/srsplayer'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/srsplayer'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/srs_publisher.html
+++ b/trunk/research/players/srs_publisher.html
@@ -14,7 +14,7 @@
     </style>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/obs'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/obs'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/srs_publisher_flash.html
+++ b/trunk/research/players/srs_publisher_flash.html
@@ -11,7 +11,7 @@
     </style>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/srspublisher'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/srspublisher'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/vlc.html
+++ b/trunk/research/players/vlc.html
@@ -11,7 +11,7 @@
     </style>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/vlc'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/vlc'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/whep.html
+++ b/trunk/research/players/whep.html
@@ -16,7 +16,7 @@
     <script type="text/javascript" src="js/srs.page.js"></script>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcpublisher'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcpublisher'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/research/players/whip.html
+++ b/trunk/research/players/whip.html
@@ -16,7 +16,7 @@
     <script type="text/javascript" src="js/srs.page.js"></script>
 </head>
 <body>
-<img src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcpublisher'/>
+<img style="width: 0px; height: 0px;" src='//ossrs.net/gif/v1/sls.gif?site=ossrs.net&path=/player/rtcpublisher'/>
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
         <div class="container">

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    141
+#define VERSION_REVISION    142
 
 #endif


### PR DESCRIPTION
the html img tag occupy 20px size in safari. 
https://github.com/ossrs/srs/blob/427104f1dab86f5afc7d7b49b02ed27d03ef9346/trunk/research/players/rtc_player.html#L19

> <img width="1011" alt="Screenshot 2024-04-17 at 9 17 07 AM" src="https://github.com/ossrs/srs/assets/2757043/79a4edf8-5bbf-4300-8817-039088f13283">


(ignore the img css warning: `auto\9;` it's another problem, I will file another PR.)

but, the empty img tag just occupy 1px size in chrome. So I guess it's a html compatible problem.

> <img width="608" alt="Screenshot 2024-04-17 at 9 46 33 AM" src="https://github.com/ossrs/srs/assets/2757043/40cb2eb6-3a6d-4bb7-9b17-51c5fd6d2272">





---------

`TRANS_BY_GPT4`