### PR TITLE
Issue/4052 fix http_remux can't play dji drone video source 

### DIFF
--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -1530,6 +1530,15 @@ vhost http.remux.srs.com {
         # Overwrite by env SRS_VHOST_HTTP_REMUX_GUESS_HAS_AV for all vhosts.
         # Default: on
         guess_has_av on;
+
+        # Whether to keep the h.264 SEI type NALU packet.
+        # DJI drone M30T will send many SEI type NALU packet, while iOS hardware decoder (Video Toolbox)
+        # dislike to feed it so many SEI NALU between NonIDR and IDR NALU packets.
+        # @see https://github.com/ossrs/srs/issues/4052
+        # Overwrite by env SRS_VHOST_HTTP_REMUX_KEEP_AVC_NALU_SEI for all vhosts.
+        # Default: on
+        keep_avc_nalu_sei on;
+        
         # the stream mount for rtmp to remux to live streaming.
         # typical mount to [vhost]/[app]/[stream].flv
         # the variables:

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2646,7 +2646,8 @@ srs_error_t SrsConfig::check_normal_config()
                 for (int j = 0; j < (int)conf->directives.size(); j++) {
                     string m = conf->at(j)->name;
                     if (m != "enabled" && m != "mount" && m != "fast_cache" && m != "drop_if_not_match"
-                        && m != "has_audio" && m != "has_video" && m != "guess_has_av") {
+                        && m != "has_audio" && m != "has_video" && m != "guess_has_av"
+                        && m != "keep_avc_nalu_sei") {
                         return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal vhost.http_remux.%s of %s", m.c_str(), vhost->arg0().c_str());
                     }
                 }
@@ -8659,6 +8660,30 @@ bool SrsConfig::get_vhost_http_remux_guess_has_av(string vhost)
     }
 
     conf = conf->get("guess_has_av");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
+    return SRS_CONF_PERFER_TRUE(conf->arg0());
+}
+
+bool SrsConfig::get_vhost_http_remux_keep_avc_nalu_sei(string vhost)
+{
+    SRS_OVERWRITE_BY_ENV_BOOL2("srs.vhost.http_remux.keep_avc_nalu_sei"); // SRS_VHOST_HTTP_REMUX_KEEP_AVC_NALU_SEI
+
+    static bool DEFAULT = true;
+
+    SrsConfDirective* conf = get_vhost(vhost);
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("http_remux");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("keep_avc_nalu_sei");
     if (!conf || conf->arg0().empty()) {
         return DEFAULT;
     }

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -1098,6 +1098,7 @@ public:
     bool get_vhost_http_remux_has_video(std::string vhost);
     // Whether guessing stream about audio or video track
     bool get_vhost_http_remux_guess_has_av(std::string vhost);
+    bool get_vhost_http_remux_keep_avc_nalu_sei(std::string vhost);
     // Get the http flv live stream mount point for vhost.
     // used to generate the flv stream mount path.
     virtual std::string get_vhost_http_remux_mount(std::string vhost);

--- a/trunk/src/app/srs_app_http_stream.hpp
+++ b/trunk/src/app/srs_app_http_stream.hpp
@@ -190,6 +190,13 @@ private:
     virtual srs_error_t http_hooks_on_play(ISrsHttpMessage* r);
     virtual void http_hooks_on_stop(ISrsHttpMessage* r);
     virtual srs_error_t streaming_send_messages(ISrsBufferEncoder* enc, SrsSharedPtrMessage** msgs, int nb_msgs);
+    virtual srs_error_t filter_avc_nalu_sei(SrsRtmpFormat& format, SrsSharedPtrMessage** msgs, int& count);
+    virtual srs_error_t has_avc_nalu_sei(SrsRtmpFormat& format, SrsSharedPtrMessage** msgs, int& count, bool& has_sei);
+    virtual srs_error_t remux_avc_nalus(const SrsRtmpFormat& format,
+                                        const SrsSharedPtrMessage* msg,
+                                        SrsSharedPtrMessage** output_msg,
+                                        SrsSample* nalus,
+                                        size_t nalu_cout);
 };
 
 // The Live Entry, to handle HTTP Live Streaming.

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -1363,10 +1363,11 @@ public:
     virtual bool is_mp3_sequence_header();
     virtual bool is_avc_sequence_header();
 private:
-    // Demux the video packet in H.264 codec.
+    // Demux the video packet in H.264|H.265 codec.
     // The packet is muxed in FLV format, defined in flv specification.
     //          Demux the sps/pps from sequence header.
     //          Demux the samples from NALUs.
+    // TODO: rename to video_tag_demux, because it can demux both h265 and h264.
     virtual srs_error_t video_avc_demux(SrsBuffer* stream, int64_t timestamp);
 #ifdef SRS_H265
 private:

--- a/trunk/src/kernel/srs_kernel_flv.cpp
+++ b/trunk/src/kernel/srs_kernel_flv.cpp
@@ -258,6 +258,35 @@ srs_error_t SrsSharedPtrMessage::create(SrsMessageHeader* pheader, char* payload
     return err;
 }
 
+srs_error_t SrsSharedPtrMessage::create(const SrsSharedPtrMessage* msg, char* payload, int size)
+{
+        srs_error_t err = srs_success;
+
+    if (size < 0) {
+        return srs_error_new(ERROR_RTMP_MESSAGE_CREATE, "create message size=%d", size);
+    }
+
+    srs_assert(!ptr);
+    ptr = new SrsSharedPtrPayload();
+    
+    // direct attach the data.
+    if (msg) {
+        ptr->header.message_type = msg->ptr->header.message_type;
+        ptr->header.payload_length = size;
+        ptr->header.perfer_cid = msg->ptr->header.perfer_cid;
+        this->timestamp = msg->timestamp;
+        this->stream_id = msg->stream_id;
+    }
+    ptr->payload = payload;
+    ptr->size = size;
+    
+    // message can access it.
+    this->payload = ptr->payload;
+    this->size = ptr->size;
+    
+    return err;
+}
+
 void SrsSharedPtrMessage::wrap(char* payload, int size)
 {
     srs_assert(!ptr);
@@ -298,18 +327,18 @@ bool SrsSharedPtrMessage::check(int stream_id)
     return false;
 }
 
-bool SrsSharedPtrMessage::is_av()
+bool SrsSharedPtrMessage::is_av() const
 {
     return ptr->header.message_type == RTMP_MSG_AudioMessage
     || ptr->header.message_type == RTMP_MSG_VideoMessage;
 }
 
-bool SrsSharedPtrMessage::is_audio()
+bool SrsSharedPtrMessage::is_audio() const
 {
     return ptr->header.message_type == RTMP_MSG_AudioMessage;
 }
 
-bool SrsSharedPtrMessage::is_video()
+bool SrsSharedPtrMessage::is_video() const
 {
     return ptr->header.message_type == RTMP_MSG_VideoMessage;
 }

--- a/trunk/src/kernel/srs_kernel_flv.hpp
+++ b/trunk/src/kernel/srs_kernel_flv.hpp
@@ -304,6 +304,11 @@ public:
     // @remark user should never free the payload.
     // @param pheader, the header to copy to the message. NULL to ignore.
     virtual srs_error_t create(SrsMessageHeader* pheader, char* payload, int size);
+    // Create shared ptr message,
+    // from another SrsSharedPtrMessage and replace its payload.
+    // @remark user should never free the payload.
+    // @param msg, the SrsSharedPtrMessage to copy its ptr->header to the message. NULL to ignore.
+    virtual srs_error_t create(const SrsSharedPtrMessage* msg, char* payload, int size);
     // Create shared ptr message from RAW payload.
     // @remark Note that the header is set to zero.
     virtual void wrap(char* payload, int size);
@@ -317,9 +322,9 @@ public:
     // @return whether stream id already set.
     virtual bool check(int stream_id);
 public:
-    virtual bool is_av();
-    virtual bool is_audio();
-    virtual bool is_video();
+    virtual bool is_av() const;
+    virtual bool is_audio() const;
+    virtual bool is_video() const;
 public:
     // generate the chunk header to cache.
     // @return the size of header.

--- a/trunk/src/utest/srs_utest_config.cpp
+++ b/trunk/src/utest/srs_utest_config.cpp
@@ -4786,6 +4786,20 @@ VOID TEST(ConfigEnvTest, CheckEnvValuesHttpRemux)
         SrsSetEnvConfig(guess_has_av2, "SRS_VHOST_HTTP_REMUX_GUESS_HAS_AV", "on");
         EXPECT_TRUE(conf.get_vhost_http_remux_guess_has_av("__defaultVhost__"));
     }
+
+    if (true) {
+        EXPECT_TRUE(conf.get_vhost_http_remux_keep_avc_nalu_sei("__defaultVhost__"));
+
+        SrsSetEnvConfig(keep_avc_nalu_sei_false, "SRS_VHOST_HTTP_REMUX_KEEP_AVC_NALU_SEI", "off");
+        EXPECT_FALSE(conf.get_vhost_http_remux_keep_avc_nalu_sei("__defaultVhost__"));
+
+        SrsSetEnvConfig(keep_avc_nalu_sei_true, "SRS_VHOST_HTTP_REMUX_KEEP_AVC_NALU_SEI", "on");
+        EXPECT_TRUE(conf.get_vhost_http_remux_keep_avc_nalu_sei("__defaultVhost__"));
+
+        SrsSetEnvConfig(keep_avc_nalu_sei_default_true, "SRS_VHOST_HTTP_REMUX_KEEP_AVC_NALU_SEI", "offx");
+        EXPECT_TRUE(conf.get_vhost_http_remux_keep_avc_nalu_sei("__defaultVhost__"));
+
+    }
 }
 
 VOID TEST(ConfigEnvTest, CheckEnvValuesDash)


### PR DESCRIPTION
related to #4052 , fix http-flv can not play in mac os safari web browser bug.
use this video sample to reproduce: 
https://drive.google.com/file/d/1UEMoMxv76D9W5pzOE9RQuBQ1bT4qIp06/view?usp=sharing
