### PR TITLE
improve http response when err happens.

### DIFF
--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -645,7 +645,13 @@ srs_error_t SrsGoApiRtcWhip::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
 
     SrsRtcUserConfig ruc;
     if ((err = do_serve_http(w, r, &ruc)) != srs_success) {
-        return srs_error_wrap(err, "serve");
+        if (srs_error_code(err) == ERROR_RTC_SDP_EXCHANGE) {
+            srs_warn("RTC error %s", srs_error_desc(err).c_str());
+            srs_freep(err);
+            return srs_api_response_code(w, r, SRS_CONSTS_HTTP_BadRequest);
+        } else {
+            return srs_error_wrap(err, "serve");
+        }
     }
     if (ruc.local_sdp_str_.empty()) {
         return srs_go_http_error(w, SRS_CONSTS_HTTP_InternalServerError);

--- a/trunk/src/protocol/srs_protocol_http_stack.cpp
+++ b/trunk/src/protocol/srs_protocol_http_stack.cpp
@@ -765,7 +765,9 @@ srs_error_t SrsHttpServeMux::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
     
     srs_assert(h);
     if ((err = h->serve_http(w, r)) != srs_success) {
-        return srs_error_wrap(err, "serve http");
+        srs_error("serve_http %s", srs_error_desc(err).c_str());
+        srs_freep(err);
+        return srs_go_http_error(w, SRS_CONSTS_HTTP_InternalServerError);
     }
     
     return err;


### PR DESCRIPTION
1. response 200 with code when rtc/v1 remote sdp parse error;
2. response 500 when no handled err.

Try to improve two problem:

1. let `rtc/v1/[whep|whip]` response 200 with body `{code : 400}` when `remote_sdp` parse error happen by follow `rtc/v1/[play | publish]` api's response. The current behavior in this scenario is close the connection without response anything. 

2. Let `SrsHttpServeMux` response 500 when err not handled, the current behavior is also to close the socket connection without response anything.