### PR TITLE
Fix hevc test failures

### DIFF
--- a/trunk/3rdparty/srs-bench/blackbox/hevc_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/hevc_test.go
@@ -1007,7 +1007,7 @@ func TestSlow_SrtPublish_HlsPlay_HEVC_Basic(t *testing.T) {
 	case <-ctx.Done():
 		r2 = fmt.Errorf("timeout")
 		return
-	case <-time.After(15 * time.Second):
+	case <-time.After(20 * time.Second):
 	}
 
 	// Start FFprobe to detect and verify stream.

--- a/trunk/3rdparty/srs-bench/blackbox/hevc_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/hevc_test.go
@@ -23,6 +23,8 @@ package blackbox
 import (
 	"context"
 	"fmt"
+	"github.com/ossrs/go-oryx-lib/errors"
+	"github.com/ossrs/go-oryx-lib/logger"
 	"math/rand"
 	"os"
 	"path"
@@ -30,9 +32,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/ossrs/go-oryx-lib/errors"
-	"github.com/ossrs/go-oryx-lib/logger"
 )
 
 func TestSlow_RtmpPublish_RtmpPlay_HEVC_Basic(t *testing.T) {
@@ -913,8 +912,8 @@ func TestSlow_SrtPublish_HttpTsPlay_HEVC_Basic(t *testing.T) {
 		defer wg.Done()
 		<-svr.ReadyCtx().Done()
 
-		// wait for ffmpeg
-		time.Sleep(4 * time.Second)
+		// wait for ffmpeg. Note that need to wait for a longer time.
+		time.Sleep(5 * time.Second)
 
 		r2 = ffprobe.Run(ctx, cancel)
 	}()
@@ -995,11 +994,14 @@ func TestSlow_SrtPublish_HlsPlay_HEVC_Basic(t *testing.T) {
 		defer wg.Done()
 		<-svr.ReadyCtx().Done()
 
+		// wait for ffmpeg
+		time.Sleep(3 * time.Second)
+
 		r1 = ffmpeg.Run(ctx, cancel)
 	}()
 
-	// Start FFprobe to detect and verify stream.
-	duration := time.Duration(*srsFFprobeDuration) * time.Millisecond
+	// Start FFprobe to detect and verify stream. Note that it requires longer duration.
+	duration := time.Duration(*srsFFprobeDuration) * time.Millisecond * 3
 	ffprobe := NewFFprobe(func(v *ffprobeClient) {
 		v.dvrFile = path.Join(svr.WorkDir(), "objs", fmt.Sprintf("srs-ffprobe-%v.ts", streamID))
 		v.streamURL = fmt.Sprintf("http://localhost:%v/live/%v.m3u8", svr.HTTPPort(), streamID)
@@ -1009,8 +1011,6 @@ func TestSlow_SrtPublish_HlsPlay_HEVC_Basic(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-svr.ReadyCtx().Done()
-		// wait for ffmpeg
-		time.Sleep(16 * time.Second)
 		r2 = ffprobe.Run(ctx, cancel)
 	}()
 

--- a/trunk/3rdparty/srs-bench/blackbox/hevc_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/hevc_test.go
@@ -900,6 +900,14 @@ func TestSlow_SrtPublish_HttpTsPlay_HEVC_Basic(t *testing.T) {
 		r1 = ffmpeg.Run(ctx, cancel)
 	}()
 
+	// Should wait for TS to generate the contents.
+	select {
+	case <-ctx.Done():
+		r2 = fmt.Errorf("timeout")
+		return
+	case <-time.After(5 * time.Second):
+	}
+
 	// Start FFprobe to detect and verify stream.
 	duration := time.Duration(*srsFFprobeDuration) * time.Millisecond
 	ffprobe := NewFFprobe(func(v *ffprobeClient) {
@@ -911,9 +919,6 @@ func TestSlow_SrtPublish_HttpTsPlay_HEVC_Basic(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-svr.ReadyCtx().Done()
-
-		// wait for ffmpeg. Note that need to wait for a longer time.
-		time.Sleep(5 * time.Second)
 
 		r2 = ffprobe.Run(ctx, cancel)
 	}()
@@ -994,9 +999,6 @@ func TestSlow_SrtPublish_HlsPlay_HEVC_Basic(t *testing.T) {
 		defer wg.Done()
 		<-svr.ReadyCtx().Done()
 
-		// wait for ffmpeg
-		time.Sleep(3 * time.Second)
-
 		r1 = ffmpeg.Run(ctx, cancel)
 	}()
 
@@ -1005,7 +1007,7 @@ func TestSlow_SrtPublish_HlsPlay_HEVC_Basic(t *testing.T) {
 	case <-ctx.Done():
 		r2 = fmt.Errorf("timeout")
 		return
-	case <-time.After(10 * time.Second):
+	case <-time.After(15 * time.Second):
 	}
 
 	// Start FFprobe to detect and verify stream.

--- a/trunk/3rdparty/srs-bench/blackbox/hevc_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/hevc_test.go
@@ -23,8 +23,6 @@ package blackbox
 import (
 	"context"
 	"fmt"
-	"github.com/ossrs/go-oryx-lib/errors"
-	"github.com/ossrs/go-oryx-lib/logger"
 	"math/rand"
 	"os"
 	"path"
@@ -32,6 +30,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/ossrs/go-oryx-lib/errors"
+	"github.com/ossrs/go-oryx-lib/logger"
 )
 
 func TestSlow_RtmpPublish_RtmpPlay_HEVC_Basic(t *testing.T) {
@@ -913,7 +914,7 @@ func TestSlow_SrtPublish_HttpTsPlay_HEVC_Basic(t *testing.T) {
 		<-svr.ReadyCtx().Done()
 
 		// wait for ffmpeg
-		time.Sleep(3 * time.Second)
+		time.Sleep(4 * time.Second)
 
 		r2 = ffprobe.Run(ctx, cancel)
 	}()
@@ -949,7 +950,6 @@ func TestSlow_SrtPublish_HlsPlay_HEVC_Basic(t *testing.T) {
 	// Setup the max timeout for this case.
 	ctx, cancel := context.WithTimeout(logger.WithContext(context.Background()), time.Duration(*srsTimeout)*time.Millisecond)
 	defer cancel()
-
 	// Check a set of errors.
 	var r0, r1, r2, r3, r4 error
 	defer func(ctx context.Context) {
@@ -995,9 +995,6 @@ func TestSlow_SrtPublish_HlsPlay_HEVC_Basic(t *testing.T) {
 		defer wg.Done()
 		<-svr.ReadyCtx().Done()
 
-		// wait for ffmpeg
-		time.Sleep(3 * time.Second)
-
 		r1 = ffmpeg.Run(ctx, cancel)
 	}()
 
@@ -1012,6 +1009,8 @@ func TestSlow_SrtPublish_HlsPlay_HEVC_Basic(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-svr.ReadyCtx().Done()
+		// wait for ffmpeg
+		time.Sleep(16 * time.Second)
 		r2 = ffprobe.Run(ctx, cancel)
 	}()
 


### PR DESCRIPTION
Try to fix two blackbox test:
1. TestSlow_SrtPublish_HttpTsPlay_HEVC_Basic: fixed by enlarge the wait time from 3 seconds to 4 before run ffprobe task, which will record the stream by ffmpeg first.
2 TestSlow_SrtPublish_HlsPlay_HEVC_Basic: fixed by wait 16 seconds before run ffprobe task.
About the 2 case: it seems ridiculous to add 16 seconds delay before run ffprobe task. 

> So, I start #4088 to check the github action workflow process, I start this branch from a very earlier version `6.0.113 (srs/core/srs_core_version6.hpp)`, what I found it that, inside `SRS blackbox-test`, the srs version `6.0.128`, the latest version, was printed. That's really wired.

I confirmed this is not the SRS source code's problem, check https://github.com/suzp1984/srs/actions/runs/9511600525/job/26218025559
the srs code 6.0.113 was checkout and running actions based on them, still met same problem. 
