### PR TITLE
SmartPtr: Support shared ptr for live source. v6.0.129

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-06-15, Merge [#4089](https://github.com/ossrs/srs/pull/4089): SmartPtr: Support shared ptr for live source. v6.0.129 (#4089)
 * v6.0, 2024-06-14, Merge [#4085](https://github.com/ossrs/srs/pull/4085): SmartPtr: Support shared ptr for RTC source. v6.0.128 (#4085)
 * v6.0, 2024-06-13, Merge [#4083](https://github.com/ossrs/srs/pull/4083): SmartPtr: Use shared ptr in RTC TCP connection. v6.0.127 (#4083)
 * v6.0, 2024-06-12, Merge [#4080](https://github.com/ossrs/srs/pull/4080): SmartPtr: Use shared ptr to manage GB objects. v6.0.126 (#4080)

--- a/trunk/src/app/srs_app_coworkers.cpp
+++ b/trunk/src/app/srs_app_coworkers.cpp
@@ -122,7 +122,7 @@ SrsRequest* SrsCoWorkers::find_stream_info(string vhost, string app, string stre
     return it->second;
 }
 
-srs_error_t SrsCoWorkers::on_publish(SrsLiveSource* s, SrsRequest* r)
+srs_error_t SrsCoWorkers::on_publish(SrsRequest* r)
 {
     srs_error_t err = srs_success;
     
@@ -140,7 +140,7 @@ srs_error_t SrsCoWorkers::on_publish(SrsLiveSource* s, SrsRequest* r)
     return err;
 }
 
-void SrsCoWorkers::on_unpublish(SrsLiveSource* s, SrsRequest* r)
+void SrsCoWorkers::on_unpublish(SrsRequest* r)
 {
     string url = r->get_stream_url();
     

--- a/trunk/src/app/srs_app_coworkers.hpp
+++ b/trunk/src/app/srs_app_coworkers.hpp
@@ -33,8 +33,8 @@ public:
 private:
     virtual SrsRequest* find_stream_info(std::string vhost, std::string app, std::string stream);
 public:
-    virtual srs_error_t on_publish(SrsLiveSource* s, SrsRequest* r);
-    virtual void on_unpublish(SrsLiveSource* s, SrsRequest* r);
+    virtual srs_error_t on_publish(SrsRequest* r);
+    virtual void on_unpublish(SrsRequest* r);
 };
 
 #endif

--- a/trunk/src/app/srs_app_edge.cpp
+++ b/trunk/src/app/srs_app_edge.cpp
@@ -391,7 +391,7 @@ void SrsEdgeFlvUpstream::kbps_sample(const char* label, srs_utime_t age)
 
 SrsEdgeIngester::SrsEdgeIngester()
 {
-    source = NULL;
+    source_ = NULL;
     edge = NULL;
     req = NULL;
 #ifdef SRS_APM
@@ -417,7 +417,7 @@ SrsEdgeIngester::~SrsEdgeIngester()
 
 srs_error_t SrsEdgeIngester::initialize(SrsLiveSource* s, SrsPlayEdge* e, SrsRequest* r)
 {
-    source = s;
+    source_ = s;
     edge = e;
     req = r;
 
@@ -435,7 +435,7 @@ srs_error_t SrsEdgeIngester::start()
 {
     srs_error_t err = srs_success;
     
-    if ((err = source->on_publish()) != srs_success) {
+    if ((err = source_->on_publish()) != srs_success) {
         return srs_error_wrap(err, "notify source");
     }
     
@@ -455,8 +455,8 @@ void SrsEdgeIngester::stop()
     upstream->close();
 
     // Notify source to un-publish if exists.
-    if (source) {
-        source->on_unpublish();
+    if (source_) {
+        source_->on_unpublish();
     }
 }
 
@@ -549,7 +549,7 @@ srs_error_t SrsEdgeIngester::do_cycle()
             upstream = new SrsEdgeRtmpUpstream(redirect);
         }
         
-        if ((err = source->on_source_id_changed(_srs_context->get_id())) != srs_success) {
+        if ((err = source_->on_source_id_changed(_srs_context->get_id())) != srs_success) {
             return srs_error_wrap(err, "on source id changed");
         }
         
@@ -635,21 +635,21 @@ srs_error_t SrsEdgeIngester::process_publish_message(SrsCommonMessage* msg, stri
     
     // process audio packet
     if (msg->header.is_audio()) {
-        if ((err = source->on_audio(msg)) != srs_success) {
+        if ((err = source_->on_audio(msg)) != srs_success) {
             return srs_error_wrap(err, "source consume audio");
         }
     }
     
     // process video packet
     if (msg->header.is_video()) {
-        if ((err = source->on_video(msg)) != srs_success) {
+        if ((err = source_->on_video(msg)) != srs_success) {
             return srs_error_wrap(err, "source consume video");
         }
     }
     
     // process aggregate packet
     if (msg->header.is_aggregate()) {
-        if ((err = source->on_aggregate(msg)) != srs_success) {
+        if ((err = source_->on_aggregate(msg)) != srs_success) {
             return srs_error_wrap(err, "source consume aggregate");
         }
         return err;
@@ -665,7 +665,7 @@ srs_error_t SrsEdgeIngester::process_publish_message(SrsCommonMessage* msg, stri
         
         if (dynamic_cast<SrsOnMetaDataPacket*>(pkt)) {
             SrsOnMetaDataPacket* metadata = dynamic_cast<SrsOnMetaDataPacket*>(pkt);
-            if ((err = source->on_meta_data(msg, metadata)) != srs_success) {
+            if ((err = source_->on_meta_data(msg, metadata)) != srs_success) {
                 return srs_error_wrap(err, "source consume metadata");
             }
             return err;
@@ -725,7 +725,7 @@ SrsEdgeForwarder::SrsEdgeForwarder()
     edge = NULL;
     req = NULL;
     send_error_code = ERROR_SUCCESS;
-    source = NULL;
+    source_ = NULL;
     
     sdk = NULL;
     lb = new SrsLbRoundRobin();
@@ -749,7 +749,7 @@ void SrsEdgeForwarder::set_queue_size(srs_utime_t queue_size)
 
 srs_error_t SrsEdgeForwarder::initialize(SrsLiveSource* s, SrsPublishEdge* e, SrsRequest* r)
 {
-    source = s;
+    source_ = s;
     edge = e;
     req = r;
 

--- a/trunk/src/app/srs_app_edge.cpp
+++ b/trunk/src/app/srs_app_edge.cpp
@@ -415,9 +415,11 @@ SrsEdgeIngester::~SrsEdgeIngester()
     srs_freep(trd);
 }
 
-srs_error_t SrsEdgeIngester::initialize(SrsLiveSource* s, SrsPlayEdge* e, SrsRequest* r)
+srs_error_t SrsEdgeIngester::initialize(SrsSharedPtr<SrsLiveSource> s, SrsPlayEdge* e, SrsRequest* r)
 {
-    source_ = s;
+    // Because source references to this object, so we should directly use the source ptr.
+    source_ = s.get();
+
     edge = e;
     req = r;
 
@@ -747,9 +749,11 @@ void SrsEdgeForwarder::set_queue_size(srs_utime_t queue_size)
     return queue->set_queue_size(queue_size);
 }
 
-srs_error_t SrsEdgeForwarder::initialize(SrsLiveSource* s, SrsPublishEdge* e, SrsRequest* r)
+srs_error_t SrsEdgeForwarder::initialize(SrsSharedPtr<SrsLiveSource> s, SrsPublishEdge* e, SrsRequest* r)
 {
-    source_ = s;
+    // Because source references to this object, so we should directly use the source ptr.
+    source_ = s.get();
+
     edge = e;
     req = r;
 
@@ -956,7 +960,7 @@ SrsPlayEdge::~SrsPlayEdge()
     srs_freep(ingester);
 }
 
-srs_error_t SrsPlayEdge::initialize(SrsLiveSource* source, SrsRequest* req)
+srs_error_t SrsPlayEdge::initialize(SrsSharedPtr<SrsLiveSource> source, SrsRequest* req)
 {
     srs_error_t err = srs_success;
     
@@ -1048,7 +1052,7 @@ void SrsPublishEdge::set_queue_size(srs_utime_t queue_size)
     return forwarder->set_queue_size(queue_size);
 }
 
-srs_error_t SrsPublishEdge::initialize(SrsLiveSource* source, SrsRequest* req)
+srs_error_t SrsPublishEdge::initialize(SrsSharedPtr<SrsLiveSource> source, SrsRequest* req)
 {
     srs_error_t err = srs_success;
     

--- a/trunk/src/app/srs_app_edge.hpp
+++ b/trunk/src/app/srs_app_edge.hpp
@@ -137,7 +137,9 @@ public:
 class SrsEdgeIngester : public ISrsCoroutineHandler
 {
 private:
+    // Because source references to this object, so we should directly use the source ptr.
     SrsLiveSource* source_;
+private:
     SrsPlayEdge* edge;
     SrsRequest* req;
     SrsCoroutine* trd;
@@ -172,7 +174,9 @@ private:
 class SrsEdgeForwarder : public ISrsCoroutineHandler
 {
 private:
+    // Because source references to this object, so we should directly use the source ptr.
     SrsLiveSource* source_;
+private:
     SrsPublishEdge* edge;
     SrsRequest* req;
     SrsCoroutine* trd;

--- a/trunk/src/app/srs_app_edge.hpp
+++ b/trunk/src/app/srs_app_edge.hpp
@@ -137,7 +137,7 @@ public:
 class SrsEdgeIngester : public ISrsCoroutineHandler
 {
 private:
-    SrsLiveSource* source;
+    SrsLiveSource* source_;
     SrsPlayEdge* edge;
     SrsRequest* req;
     SrsCoroutine* trd;
@@ -172,7 +172,7 @@ private:
 class SrsEdgeForwarder : public ISrsCoroutineHandler
 {
 private:
-    SrsLiveSource* source;
+    SrsLiveSource* source_;
     SrsPublishEdge* edge;
     SrsRequest* req;
     SrsCoroutine* trd;

--- a/trunk/src/app/srs_app_edge.hpp
+++ b/trunk/src/app/srs_app_edge.hpp
@@ -10,6 +10,7 @@
 #include <srs_core.hpp>
 
 #include <srs_app_st.hpp>
+#include <srs_core_autofree.hpp>
 
 #include <string>
 
@@ -152,7 +153,7 @@ public:
     SrsEdgeIngester();
     virtual ~SrsEdgeIngester();
 public:
-    virtual srs_error_t initialize(SrsLiveSource* s, SrsPlayEdge* e, SrsRequest* r);
+    virtual srs_error_t initialize(SrsSharedPtr<SrsLiveSource> s, SrsPlayEdge* e, SrsRequest* r);
     virtual srs_error_t start();
     virtual void stop();
     virtual std::string get_curr_origin();
@@ -195,7 +196,7 @@ public:
 public:
     virtual void set_queue_size(srs_utime_t queue_size);
 public:
-    virtual srs_error_t initialize(SrsLiveSource* s, SrsPublishEdge* e, SrsRequest* r);
+    virtual srs_error_t initialize(SrsSharedPtr<SrsLiveSource> s, SrsPublishEdge* e, SrsRequest* r);
     virtual srs_error_t start();
     virtual void stop();
 // Interface ISrsReusableThread2Handler
@@ -220,7 +221,7 @@ public:
     // Always use the req of source,
     // For we assume all client to edge is invalid,
     // if auth open, edge must valid it from origin, then service it.
-    virtual srs_error_t initialize(SrsLiveSource* source, SrsRequest* req);
+    virtual srs_error_t initialize(SrsSharedPtr<SrsLiveSource> source, SrsRequest* req);
     // When client play stream on edge.
     virtual srs_error_t on_client_play();
     // When all client stopped play, disconnect to origin.
@@ -243,7 +244,7 @@ public:
 public:
     virtual void set_queue_size(srs_utime_t queue_size);
 public:
-    virtual srs_error_t initialize(SrsLiveSource* source, SrsRequest* req);
+    virtual srs_error_t initialize(SrsSharedPtr<SrsLiveSource> source, SrsRequest* req);
     virtual bool can_publish();
     // When client publish stream on edge.
     virtual srs_error_t on_client_publish();

--- a/trunk/src/app/srs_app_http_conn.cpp
+++ b/trunk/src/app/srs_app_http_conn.cpp
@@ -547,13 +547,13 @@ srs_error_t SrsHttpServer::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage
     return http_static->mux.serve_http(w, r);
 }
 
-srs_error_t SrsHttpServer::http_mount(SrsLiveSource* s, SrsRequest* r)
+srs_error_t SrsHttpServer::http_mount(SrsRequest* r)
 {
-    return http_stream->http_mount(s, r);
+    return http_stream->http_mount(r);
 }
 
-void SrsHttpServer::http_unmount(SrsLiveSource* s, SrsRequest* r)
+void SrsHttpServer::http_unmount(SrsRequest* r)
 {
-    http_stream->http_unmount(s, r);
+    http_stream->http_unmount(r);
 }
 

--- a/trunk/src/app/srs_app_http_conn.hpp
+++ b/trunk/src/app/srs_app_http_conn.hpp
@@ -187,8 +187,8 @@ public:
 public:
     virtual srs_error_t serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r);
 public:
-    virtual srs_error_t http_mount(SrsLiveSource* s, SrsRequest* r);
-    virtual void http_unmount(SrsLiveSource* s, SrsRequest* r);
+    virtual srs_error_t http_mount(SrsRequest* r);
+    virtual void http_unmount(SrsRequest* r);
 };
 
 #endif

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -40,10 +40,9 @@ using namespace std;
 #include <srs_app_recv_thread.hpp>
 #include <srs_app_http_hooks.hpp>
 
-SrsBufferCache::SrsBufferCache(SrsLiveSource* s, SrsRequest* r)
+SrsBufferCache::SrsBufferCache(SrsRequest* r)
 {
     req = r->copy()->as_http();
-    source = s;
     queue = new SrsMessageQueue(true);
     trd = new SrsSTCoroutine("http-stream", this);
     
@@ -59,12 +58,11 @@ SrsBufferCache::~SrsBufferCache()
     srs_freep(req);
 }
 
-srs_error_t SrsBufferCache::update_auth(SrsLiveSource* s, SrsRequest* r)
+srs_error_t SrsBufferCache::update_auth(SrsRequest* r)
 {
     srs_freep(req);
     req = r->copy();
-    source = s;
-    
+
     return srs_success;
 }
 
@@ -106,6 +104,11 @@ srs_error_t SrsBufferCache::cycle()
     if (fast_cache <= 0) {
         srs_usleep(SRS_STREAM_CACHE_CYCLE);
         return err;
+    }
+
+    SrsLiveSource* source = _srs_sources->fetch(req);
+    if (!source) {
+        return srs_error_new(ERROR_NO_SOURCE, "no source for %s", req->get_stream_url().c_str());
     }
     
     // the stream cache will create consumer to cache stream,
@@ -553,9 +556,8 @@ srs_error_t SrsBufferWriter::writev(const iovec* iov, int iovcnt, ssize_t* pnwri
     return writer->writev(iov, iovcnt, pnwrite);
 }
 
-SrsLiveStream::SrsLiveStream(SrsLiveSource* s, SrsRequest* r, SrsBufferCache* c)
+SrsLiveStream::SrsLiveStream(SrsRequest* r, SrsBufferCache* c)
 {
-    source = s;
     cache = c;
     req = r->copy()->as_http();
     security_ = new SrsSecurity();
@@ -567,10 +569,8 @@ SrsLiveStream::~SrsLiveStream()
     srs_freep(security_);
 }
 
-srs_error_t SrsLiveStream::update_auth(SrsLiveSource* s, SrsRequest* r)
+srs_error_t SrsLiveStream::update_auth(SrsRequest* r)
 {
-    source = s;
-    
     srs_freep(req);
     req = r->copy()->as_http();
     
@@ -660,6 +660,11 @@ srs_error_t SrsLiveStream::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMess
 
     // Enter chunked mode, because we didn't set the content-length.
     w->write_header(SRS_CONSTS_HTTP_OK);
+
+    SrsLiveSource* source = _srs_sources->fetch(req);
+    if (!source) {
+        return srs_error_new(ERROR_NO_SOURCE, "no source for %s", req->get_stream_url().c_str());
+    }
     
     // create consumer of souce, ignore gop cache, use the audio gop cache.
     SrsLiveConsumer* consumer = NULL;
@@ -876,7 +881,6 @@ SrsLiveEntry::SrsLiveEntry(std::string m)
     cache = NULL;
     
     req = NULL;
-    source = NULL;
     
     std::string ext = srs_path_filext(m);
     _is_flv = (ext == ".flv");
@@ -954,7 +958,7 @@ srs_error_t SrsHttpStreamServer::initialize()
 }
 
 // TODO: FIXME: rename for HTTP FLV mount.
-srs_error_t SrsHttpStreamServer::http_mount(SrsLiveSource* s, SrsRequest* r)
+srs_error_t SrsHttpStreamServer::http_mount(SrsRequest* r)
 {
     srs_error_t err = srs_success;
     
@@ -982,10 +986,9 @@ srs_error_t SrsHttpStreamServer::http_mount(SrsLiveSource* s, SrsRequest* r)
         
         entry = new SrsLiveEntry(mount);
 
-        entry->source = s;
         entry->req = r->copy()->as_http();
-        entry->cache = new SrsBufferCache(s, r);
-        entry->stream = new SrsLiveStream(s, r, entry->cache);
+        entry->cache = new SrsBufferCache(r);
+        entry->stream = new SrsLiveStream(r, entry->cache);
         
         // TODO: FIXME: maybe refine the logic of http remux service.
         // if user push streams followed:
@@ -994,8 +997,7 @@ srs_error_t SrsHttpStreamServer::http_mount(SrsLiveSource* s, SrsRequest* r)
         // and they will using the same template, such as: [vhost]/[app]/[stream].flv
         // so, need to free last request object, otherwise, it will cause memory leak.
         srs_freep(tmpl->req);
-        
-        tmpl->source = s;
+
         tmpl->req = r->copy()->as_http();
         
         sflvs[sid] = entry;
@@ -1015,8 +1017,8 @@ srs_error_t SrsHttpStreamServer::http_mount(SrsLiveSource* s, SrsRequest* r)
     } else {
         // The entry exists, we reuse it and update the request of stream and cache.
         entry = sflvs[sid];
-        entry->stream->update_auth(s, r);
-        entry->cache->update_auth(s, r);
+        entry->stream->update_auth(r);
+        entry->cache->update_auth(r);
     }
     
     if (entry->stream) {
@@ -1027,7 +1029,7 @@ srs_error_t SrsHttpStreamServer::http_mount(SrsLiveSource* s, SrsRequest* r)
     return err;
 }
 
-void SrsHttpStreamServer::http_unmount(SrsLiveSource* s, SrsRequest* r)
+void SrsHttpStreamServer::http_unmount(SrsRequest* r)
 {
     std::string sid = r->get_stream_url();
     
@@ -1133,7 +1135,7 @@ srs_error_t SrsHttpStreamServer::hijack(ISrsHttpMessage* request, ISrsHttpHandle
             }
         }
     }
-    
+
     SrsLiveSource* s = NULL;
     if ((err = _srs_sources->fetch_or_create(r, server, &s)) != srs_success) {
         return srs_error_wrap(err, "source create");
@@ -1146,7 +1148,7 @@ srs_error_t SrsHttpStreamServer::hijack(ISrsHttpMessage* request, ISrsHttpHandle
     s->set_gop_cache_max_frames(gcmf);
 
     // create http streaming handler.
-    if ((err = http_mount(s, r)) != srs_success) {
+    if ((err = http_mount(r)) != srs_success) {
         return srs_error_wrap(err, "http mount");
     }
     

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -106,8 +106,8 @@ srs_error_t SrsBufferCache::cycle()
         return err;
     }
 
-    SrsLiveSource* live_source = _srs_sources->fetch(req);
-    if (!live_source) {
+    SrsSharedPtr<SrsLiveSource> live_source = _srs_sources->fetch(req);
+    if (!live_source.get()) {
         return srs_error_new(ERROR_NO_SOURCE, "no source for %s", req->get_stream_url().c_str());
     }
     
@@ -661,8 +661,8 @@ srs_error_t SrsLiveStream::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMess
     // Enter chunked mode, because we didn't set the content-length.
     w->write_header(SRS_CONSTS_HTTP_OK);
 
-    SrsLiveSource* live_source = _srs_sources->fetch(req);
-    if (!live_source) {
+    SrsSharedPtr<SrsLiveSource> live_source = _srs_sources->fetch(req);
+    if (!live_source.get()) {
         return srs_error_new(ERROR_NO_SOURCE, "no source for %s", req->get_stream_url().c_str());
     }
     
@@ -1136,11 +1136,11 @@ srs_error_t SrsHttpStreamServer::hijack(ISrsHttpMessage* request, ISrsHttpHandle
         }
     }
 
-    SrsLiveSource* live_source = NULL;
-    if ((err = _srs_sources->fetch_or_create(r, server, &live_source)) != srs_success) {
+    SrsSharedPtr<SrsLiveSource> live_source;
+    if ((err = _srs_sources->fetch_or_create(r, server, live_source)) != srs_success) {
         return srs_error_wrap(err, "source create");
     }
-    srs_assert(live_source != NULL);
+    srs_assert(live_source.get() != NULL);
     
     bool enabled_cache = _srs_config->get_gop_cache(r->vhost);
     int gcmf = _srs_config->get_gop_cache_max_frames(r->vhost);

--- a/trunk/src/app/srs_app_http_stream.hpp
+++ b/trunk/src/app/srs_app_http_stream.hpp
@@ -23,13 +23,12 @@ private:
     srs_utime_t fast_cache;
 private:
     SrsMessageQueue* queue;
-    SrsLiveSource* source;
     SrsRequest* req;
     SrsCoroutine* trd;
 public:
-    SrsBufferCache(SrsLiveSource* s, SrsRequest* r);
+    SrsBufferCache(SrsRequest* r);
     virtual ~SrsBufferCache();
-    virtual srs_error_t update_auth(SrsLiveSource* s, SrsRequest* r);
+    virtual srs_error_t update_auth(SrsRequest* r);
 public:
     virtual srs_error_t start();
     virtual srs_error_t dump_cache(SrsLiveConsumer* consumer, SrsRtmpJitterAlgorithm jitter);
@@ -178,13 +177,12 @@ class SrsLiveStream : public ISrsHttpHandler
 {
 private:
     SrsRequest* req;
-    SrsLiveSource* source;
     SrsBufferCache* cache;
     SrsSecurity* security_;
 public:
-    SrsLiveStream(SrsLiveSource* s, SrsRequest* r, SrsBufferCache* c);
+    SrsLiveStream(SrsRequest* r, SrsBufferCache* c);
     virtual ~SrsLiveStream();
-    virtual srs_error_t update_auth(SrsLiveSource* s, SrsRequest* r);
+    virtual srs_error_t update_auth(SrsRequest* r);
 public:
     virtual srs_error_t serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r);
 private:
@@ -205,8 +203,6 @@ private:
 public:
     // We will free the request.
     SrsRequest* req;
-    // Shared source.
-    SrsLiveSource* source;
 public:
     // For template, the mount contains variables.
     // For concrete stream, the mount is url to access.
@@ -244,8 +240,8 @@ public:
     virtual srs_error_t initialize();
 public:
     // HTTP flv/ts/mp3/aac stream
-    virtual srs_error_t http_mount(SrsLiveSource* s, SrsRequest* r);
-    virtual void http_unmount(SrsLiveSource* s, SrsRequest* r);
+    virtual srs_error_t http_mount(SrsRequest* r);
+    virtual void http_unmount(SrsRequest* r);
 // Interface ISrsHttpMatchHijacker
 public:
     virtual srs_error_t hijack(ISrsHttpMessage* request, ISrsHttpHandler** ph);

--- a/trunk/src/app/srs_app_recv_thread.cpp
+++ b/trunk/src/app/srs_app_recv_thread.cpp
@@ -265,7 +265,7 @@ SrsPublishRecvThread::SrsPublishRecvThread(SrsRtmpServer* rtmp_sdk, SrsRequest* 
     rtmp = rtmp_sdk;
     
     _conn = conn;
-    _source = source;
+    source_ = source;
 
     nn_msgs_for_yield_ = 0;
     recv_error = srs_success;
@@ -370,7 +370,7 @@ srs_error_t SrsPublishRecvThread::consume(SrsCommonMessage* msg)
                 srs_update_system_time(), msg->header.timestamp, msg->size);
     
     // the rtmp connection will handle this message
-    err = _conn->handle_publish_message(_source, msg);
+    err = _conn->handle_publish_message(source_, msg);
     
     // must always free it,
     // the source will copy it if need to use.

--- a/trunk/src/app/srs_app_recv_thread.cpp
+++ b/trunk/src/app/srs_app_recv_thread.cpp
@@ -259,7 +259,7 @@ void SrsQueueRecvThread::on_stop()
 }
 
 SrsPublishRecvThread::SrsPublishRecvThread(SrsRtmpServer* rtmp_sdk, SrsRequest* _req,
-	int mr_sock_fd, srs_utime_t tm, SrsRtmpConn* conn, SrsLiveSource* source, SrsContextId parent_cid)
+	int mr_sock_fd, srs_utime_t tm, SrsRtmpConn* conn, SrsSharedPtr<SrsLiveSource> source, SrsContextId parent_cid)
     : trd(this, rtmp_sdk, tm, parent_cid)
 {
     rtmp = rtmp_sdk;

--- a/trunk/src/app/srs_app_recv_thread.hpp
+++ b/trunk/src/app/srs_app_recv_thread.hpp
@@ -146,7 +146,7 @@ private:
     srs_error_t recv_error;
     SrsRtmpConn* _conn;
     // The params for conn callback.
-    SrsLiveSource* _source;
+    SrsLiveSource* source_;
     // The error timeout cond
     srs_cond_t error;
     // The merged context id.

--- a/trunk/src/app/srs_app_recv_thread.hpp
+++ b/trunk/src/app/srs_app_recv_thread.hpp
@@ -16,6 +16,7 @@
 #include <srs_protocol_stream.hpp>
 #include <srs_core_performance.hpp>
 #include <srs_app_reload.hpp>
+#include <srs_core_autofree.hpp>
 
 class SrsRtmpServer;
 class SrsCommonMessage;
@@ -146,7 +147,7 @@ private:
     srs_error_t recv_error;
     SrsRtmpConn* _conn;
     // The params for conn callback.
-    SrsLiveSource* source_;
+    SrsSharedPtr<SrsLiveSource> source_;
     // The error timeout cond
     srs_cond_t error;
     // The merged context id.
@@ -154,7 +155,7 @@ private:
     SrsContextId ncid;
 public:
     SrsPublishRecvThread(SrsRtmpServer* rtmp_sdk, SrsRequest* _req,
-        int mr_sock_fd, srs_utime_t tm, SrsRtmpConn* conn, SrsLiveSource* source, SrsContextId parent_cid);
+        int mr_sock_fd, srs_utime_t tm, SrsRtmpConn* conn, SrsSharedPtr<SrsLiveSource> source, SrsContextId parent_cid);
     virtual ~SrsPublishRecvThread();
 public:
     // Wait for error for some timeout.

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -224,8 +224,8 @@ srs_error_t SrsGoApiRtcPlay::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
 
     // For RTMP to RTC, fail if disabled and RTMP is active, see https://github.com/ossrs/srs/issues/2728
     if (!is_rtc_stream_active && !_srs_config->get_rtc_from_rtmp(ruc->req_->vhost)) {
-        SrsLiveSource* rtmp = _srs_sources->fetch(ruc->req_);
-        if (rtmp && !rtmp->inactive()) {
+        SrsLiveSource* live_source = _srs_sources->fetch(ruc->req_);
+        if (live_source && !live_source->inactive()) {
             return srs_error_new(ERROR_RTC_DISABLED, "Disabled rtmp_to_rtc of %s, see #2728", ruc->req_->vhost.c_str());
         }
     }

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -224,8 +224,8 @@ srs_error_t SrsGoApiRtcPlay::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessa
 
     // For RTMP to RTC, fail if disabled and RTMP is active, see https://github.com/ossrs/srs/issues/2728
     if (!is_rtc_stream_active && !_srs_config->get_rtc_from_rtmp(ruc->req_->vhost)) {
-        SrsLiveSource* live_source = _srs_sources->fetch(ruc->req_);
-        if (live_source && !live_source->inactive()) {
+        SrsSharedPtr<SrsLiveSource> live_source = _srs_sources->fetch(ruc->req_);
+        if (live_source.get() && !live_source->inactive()) {
             return srs_error_new(ERROR_RTC_DISABLED, "Disabled rtmp_to_rtc of %s, see #2728", ruc->req_->vhost.c_str());
         }
     }

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -1202,8 +1202,8 @@ srs_error_t SrsRtcPublishStream::initialize(SrsRequest* r, SrsRtcSourceDescripti
     source_->set_publish_stream(this);
 
     // TODO: FIMXE: Check it in SrsRtcConnection::add_publisher?
-    SrsLiveSource *rtmp = _srs_sources->fetch(r);
-    if (rtmp && !rtmp->can_publish(false)) {
+    SrsLiveSource* live_source = _srs_sources->fetch(r);
+    if (live_source && !live_source->can_publish(false)) {
         return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "rtmp stream %s busy", r->get_stream_url().c_str());
     }
 
@@ -1227,16 +1227,16 @@ srs_error_t SrsRtcPublishStream::initialize(SrsRequest* r, SrsRtcSourceDescripti
 #if defined(SRS_RTC) && defined(SRS_FFMPEG_FIT)
     bool rtc_to_rtmp = _srs_config->get_rtc_to_rtmp(req_->vhost);
     if (rtc_to_rtmp) {
-        if ((err = _srs_sources->fetch_or_create(r, _srs_hybrid->srs()->instance(), &rtmp)) != srs_success) {
+        if ((err = _srs_sources->fetch_or_create(r, _srs_hybrid->srs()->instance(), &live_source)) != srs_success) {
             return srs_error_wrap(err, "create source");
         }
 
         // Disable GOP cache for RTC2RTMP bridge, to keep the streams in sync,
         // especially for stream merging.
-        rtmp->set_cache(false);
+        live_source->set_cache(false);
 
         SrsCompositeBridge* bridge = new SrsCompositeBridge();
-        bridge->append(new SrsFrameToRtmpBridge(rtmp));
+        bridge->append(new SrsFrameToRtmpBridge(live_source));
 
         if ((err = bridge->initialize(r)) != srs_success) {
             srs_freep(bridge);

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -646,7 +646,7 @@ srs_error_t SrsRtcPlayStream::cycle()
 
     SrsRtcConsumer* consumer = NULL;
     SrsAutoFree(SrsRtcConsumer, consumer);
-    if ((err = source->create_consumer(source_, consumer)) != srs_success) {
+    if ((err = source->create_consumer(consumer)) != srs_success) {
         return srs_error_wrap(err, "create consumer, source=%s", req_->get_stream_url().c_str());
     }
 

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -1202,8 +1202,8 @@ srs_error_t SrsRtcPublishStream::initialize(SrsRequest* r, SrsRtcSourceDescripti
     source_->set_publish_stream(this);
 
     // TODO: FIMXE: Check it in SrsRtcConnection::add_publisher?
-    SrsLiveSource* live_source = _srs_sources->fetch(r);
-    if (live_source && !live_source->can_publish(false)) {
+    SrsSharedPtr<SrsLiveSource> live_source = _srs_sources->fetch(r);
+    if (live_source.get() && !live_source->can_publish(false)) {
         return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "rtmp stream %s busy", r->get_stream_url().c_str());
     }
 
@@ -1227,7 +1227,7 @@ srs_error_t SrsRtcPublishStream::initialize(SrsRequest* r, SrsRtcSourceDescripti
 #if defined(SRS_RTC) && defined(SRS_FFMPEG_FIT)
     bool rtc_to_rtmp = _srs_config->get_rtc_to_rtmp(req_->vhost);
     if (rtc_to_rtmp) {
-        if ((err = _srs_sources->fetch_or_create(r, _srs_hybrid->srs()->instance(), &live_source)) != srs_success) {
+        if ((err = _srs_sources->fetch_or_create(r, _srs_hybrid->srs()->instance(), live_source)) != srs_success) {
             return srs_error_wrap(err, "create source");
         }
 

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -154,7 +154,7 @@ ISrsRtcSourceChangeCallback::~ISrsRtcSourceChangeCallback()
 {
 }
 
-SrsRtcConsumer::SrsRtcConsumer(SrsSharedPtr<SrsRtcSource> s)
+SrsRtcConsumer::SrsRtcConsumer(SrsRtcSource* s)
 {
     source_ = s;
     should_update_source_id = false;
@@ -486,11 +486,11 @@ void SrsRtcSource::set_bridge(ISrsStreamBridge* bridge)
 #endif
 }
 
-srs_error_t SrsRtcSource::create_consumer(SrsSharedPtr<SrsRtcSource> source, SrsRtcConsumer*& consumer)
+srs_error_t SrsRtcSource::create_consumer(SrsRtcConsumer*& consumer)
 {
     srs_error_t err = srs_success;
 
-    consumer = new SrsRtcConsumer(source);
+    consumer = new SrsRtcConsumer(this);
     consumers.push_back(consumer);
 
     // TODO: FIXME: Implements edge cluster.

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -80,7 +80,9 @@ public:
 class SrsRtcConsumer
 {
 private:
-    SrsSharedPtr<SrsRtcSource> source_;
+    // Because source references to this object, so we should directly use the source ptr.
+    SrsRtcSource* source_;
+private:
     std::vector<SrsRtpPacket*> queue;
     // when source id changed, notice all consumers
     bool should_update_source_id;
@@ -92,7 +94,7 @@ private:
     // The callback for stream change event.
     ISrsRtcSourceChangeCallback* handler_;
 public:
-    SrsRtcConsumer(SrsSharedPtr<SrsRtcSource> s);
+    SrsRtcConsumer(SrsRtcSource* s);
     virtual ~SrsRtcConsumer();
 public:
     // When source id changed, notice client to print.
@@ -215,7 +217,7 @@ public:
 public:
     // Create consumer
     // @param consumer, output the create consumer.
-    virtual srs_error_t create_consumer(SrsSharedPtr<SrsRtcSource> source, SrsRtcConsumer*& consumer);
+    virtual srs_error_t create_consumer(SrsRtcConsumer*& consumer);
     // Dumps packets in cache to consumer.
     // @param ds, whether dumps the sequence header.
     // @param dm, whether dumps the metadata.

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -571,11 +571,11 @@ srs_error_t SrsRtmpConn::stream_service_cycle()
     rtmp->set_send_timeout(SRS_CONSTS_RTMP_TIMEOUT);
     
     // find a source to serve.
-    SrsLiveSource* live_source = NULL;
-    if ((err = _srs_sources->fetch_or_create(req, server, &live_source)) != srs_success) {
+    SrsSharedPtr<SrsLiveSource> live_source;
+    if ((err = _srs_sources->fetch_or_create(req, server, live_source)) != srs_success) {
         return srs_error_wrap(err, "rtmp: fetch source");
     }
-    srs_assert(live_source != NULL);
+    srs_assert(live_source.get() != NULL);
 
     bool enabled_cache = _srs_config->get_gop_cache(req->vhost);
     int gcmf = _srs_config->get_gop_cache_max_frames(req->vhost);
@@ -699,7 +699,7 @@ srs_error_t SrsRtmpConn::check_vhost(bool try_default_vhost)
     return err;
 }
 
-srs_error_t SrsRtmpConn::playing(SrsLiveSource* source)
+srs_error_t SrsRtmpConn::playing(SrsSharedPtr<SrsLiveSource> source)
 {
     srs_error_t err = srs_success;
     
@@ -786,7 +786,7 @@ srs_error_t SrsRtmpConn::playing(SrsLiveSource* source)
     return err;
 }
 
-srs_error_t SrsRtmpConn::do_playing(SrsLiveSource* source, SrsLiveConsumer* consumer, SrsQueueRecvThread* rtrd)
+srs_error_t SrsRtmpConn::do_playing(SrsSharedPtr<SrsLiveSource> source, SrsLiveConsumer* consumer, SrsQueueRecvThread* rtrd)
 {
     srs_error_t err = srs_success;
     
@@ -923,7 +923,7 @@ srs_error_t SrsRtmpConn::do_playing(SrsLiveSource* source, SrsLiveConsumer* cons
     return err;
 }
 
-srs_error_t SrsRtmpConn::publishing(SrsLiveSource* source)
+srs_error_t SrsRtmpConn::publishing(SrsSharedPtr<SrsLiveSource> source)
 {
     srs_error_t err = srs_success;
     
@@ -969,7 +969,7 @@ srs_error_t SrsRtmpConn::publishing(SrsLiveSource* source)
     return err;
 }
 
-srs_error_t SrsRtmpConn::do_publishing(SrsLiveSource* source, SrsPublishRecvThread* rtrd)
+srs_error_t SrsRtmpConn::do_publishing(SrsSharedPtr<SrsLiveSource> source, SrsPublishRecvThread* rtrd)
 {
     srs_error_t err = srs_success;
     
@@ -1073,7 +1073,7 @@ srs_error_t SrsRtmpConn::do_publishing(SrsLiveSource* source, SrsPublishRecvThre
     return err;
 }
 
-srs_error_t SrsRtmpConn::acquire_publish(SrsLiveSource* source)
+srs_error_t SrsRtmpConn::acquire_publish(SrsSharedPtr<SrsLiveSource> source)
 {
     srs_error_t err = srs_success;
     
@@ -1141,7 +1141,7 @@ srs_error_t SrsRtmpConn::acquire_publish(SrsLiveSource* source)
     return err;
 }
 
-void SrsRtmpConn::release_publish(SrsLiveSource* source)
+void SrsRtmpConn::release_publish(SrsSharedPtr<SrsLiveSource> source)
 {
     // when edge, notice edge to change state.
     // when origin, notice all service to unpublish.
@@ -1152,7 +1152,7 @@ void SrsRtmpConn::release_publish(SrsLiveSource* source)
     }
 }
 
-srs_error_t SrsRtmpConn::handle_publish_message(SrsLiveSource* source, SrsCommonMessage* msg)
+srs_error_t SrsRtmpConn::handle_publish_message(SrsSharedPtr<SrsLiveSource>& source, SrsCommonMessage* msg)
 {
     srs_error_t err = srs_success;
     
@@ -1193,7 +1193,7 @@ srs_error_t SrsRtmpConn::handle_publish_message(SrsLiveSource* source, SrsCommon
     return err;
 }
 
-srs_error_t SrsRtmpConn::process_publish_message(SrsLiveSource* source, SrsCommonMessage* msg)
+srs_error_t SrsRtmpConn::process_publish_message(SrsSharedPtr<SrsLiveSource>& source, SrsCommonMessage* msg)
 {
     srs_error_t err = srs_success;
     

--- a/trunk/src/app/srs_app_rtmp_conn.hpp
+++ b/trunk/src/app/srs_app_rtmp_conn.hpp
@@ -16,6 +16,7 @@
 #include <srs_app_reload.hpp>
 #include <srs_protocol_rtmp_stack.hpp>
 #include <srs_protocol_rtmp_conn.hpp>
+#include <srs_core_autofree.hpp>
 
 class SrsServer;
 class SrsRtmpServer;
@@ -145,14 +146,14 @@ private:
     // The stream(play/publish) service cycle, identify client first.
     virtual srs_error_t stream_service_cycle();
     virtual srs_error_t check_vhost(bool try_default_vhost);
-    virtual srs_error_t playing(SrsLiveSource* source);
-    virtual srs_error_t do_playing(SrsLiveSource* source, SrsLiveConsumer* consumer, SrsQueueRecvThread* trd);
-    virtual srs_error_t publishing(SrsLiveSource* source);
-    virtual srs_error_t do_publishing(SrsLiveSource* source, SrsPublishRecvThread* trd);
-    virtual srs_error_t acquire_publish(SrsLiveSource* source);
-    virtual void release_publish(SrsLiveSource* source);
-    virtual srs_error_t handle_publish_message(SrsLiveSource* source, SrsCommonMessage* msg);
-    virtual srs_error_t process_publish_message(SrsLiveSource* source, SrsCommonMessage* msg);
+    virtual srs_error_t playing(SrsSharedPtr<SrsLiveSource> source);
+    virtual srs_error_t do_playing(SrsSharedPtr<SrsLiveSource> source, SrsLiveConsumer* consumer, SrsQueueRecvThread* trd);
+    virtual srs_error_t publishing(SrsSharedPtr<SrsLiveSource> source);
+    virtual srs_error_t do_publishing(SrsSharedPtr<SrsLiveSource> source, SrsPublishRecvThread* trd);
+    virtual srs_error_t acquire_publish(SrsSharedPtr<SrsLiveSource> source);
+    virtual void release_publish(SrsSharedPtr<SrsLiveSource> source);
+    virtual srs_error_t handle_publish_message(SrsSharedPtr<SrsLiveSource>& source, SrsCommonMessage* msg);
+    virtual srs_error_t process_publish_message(SrsSharedPtr<SrsLiveSource>& source, SrsCommonMessage* msg);
     virtual srs_error_t process_play_control_msg(SrsLiveConsumer* consumer, SrsCommonMessage* msg);
     virtual void set_sock_options();
 private:

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -1302,28 +1302,28 @@ srs_error_t SrsServer::on_reload_listen()
     return err;
 }
 
-srs_error_t SrsServer::on_publish(SrsLiveSource* s, SrsRequest* r)
+srs_error_t SrsServer::on_publish(SrsRequest* r)
 {
     srs_error_t err = srs_success;
 
-    if ((err = http_server->http_mount(s, r)) != srs_success) {
+    if ((err = http_server->http_mount(r)) != srs_success) {
         return srs_error_wrap(err, "http mount");
     }
     
     SrsCoWorkers* coworkers = SrsCoWorkers::instance();
-    if ((err = coworkers->on_publish(s, r)) != srs_success) {
+    if ((err = coworkers->on_publish(r)) != srs_success) {
         return srs_error_wrap(err, "coworkers");
     }
     
     return err;
 }
 
-void SrsServer::on_unpublish(SrsLiveSource* s, SrsRequest* r)
+void SrsServer::on_unpublish(SrsRequest* r)
 {
-    http_server->http_unmount(s, r);
+    http_server->http_unmount(r);
     
     SrsCoWorkers* coworkers = SrsCoWorkers::instance();
-    coworkers->on_unpublish(s, r);
+    coworkers->on_unpublish(r);
 }
 
 SrsServerAdapter::SrsServerAdapter()

--- a/trunk/src/app/srs_app_server.hpp
+++ b/trunk/src/app/srs_app_server.hpp
@@ -234,8 +234,8 @@ public:
     virtual srs_error_t on_reload_listen();
 // Interface ISrsLiveSourceHandler
 public:
-    virtual srs_error_t on_publish(SrsLiveSource* s, SrsRequest* r);
-    virtual void on_unpublish(SrsLiveSource* s, SrsRequest* r);
+    virtual srs_error_t on_publish(SrsRequest* r);
+    virtual void on_unpublish(SrsRequest* r);
 };
 
 // The SRS server adapter, the master server.

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -288,9 +288,9 @@ public:
     virtual ~ISrsLiveSourceHandler();
 public:
     // when stream start publish, mount stream.
-    virtual srs_error_t on_publish(SrsLiveSource* s, SrsRequest* r) = 0;
+    virtual srs_error_t on_publish(SrsRequest* r) = 0;
     // when stream stop publish, unmount stream.
-    virtual void on_unpublish(SrsLiveSource* s, SrsRequest* r) = 0;
+    virtual void on_unpublish(SrsRequest* r) = 0;
 };
 
 // The mix queue to correct the timestamp for mix_correct algorithm.

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -170,7 +170,7 @@ class SrsLiveConsumer : public ISrsWakable
 {
 private:
     SrsRtmpJitter* jitter;
-    SrsLiveSource* source;
+    SrsLiveSource* source_;
     SrsMessageQueue* queue;
     bool paused;
     // when source id changed, notice all consumers
@@ -315,7 +315,7 @@ public:
 class SrsOriginHub : public ISrsReloadHandler
 {
 private:
-    SrsLiveSource* source;
+    SrsLiveSource* source_;
     SrsRequest* req_;
     bool is_active;
 private:

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -169,8 +169,10 @@ public:
 class SrsLiveConsumer : public ISrsWakable
 {
 private:
-    SrsRtmpJitter* jitter;
+    // Because source references to this object, so we should directly use the source ptr.
     SrsLiveSource* source_;
+private:
+    SrsRtmpJitter* jitter;
     SrsMessageQueue* queue;
     bool paused;
     // when source id changed, notice all consumers
@@ -315,7 +317,9 @@ public:
 class SrsOriginHub : public ISrsReloadHandler
 {
 private:
+    // Because source references to this object, so we should directly use the source ptr.
     SrsLiveSource* source_;
+private:
     SrsRequest* req_;
     bool is_active;
 private:

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -19,6 +19,7 @@
 #include <srs_protocol_st.hpp>
 #include <srs_app_hourglass.hpp>
 #include <srs_app_stream_bridge.hpp>
+#include <srs_core_autofree.hpp>
 
 class SrsFormat;
 class SrsRtmpFormat;
@@ -345,7 +346,7 @@ public:
 public:
     // Initialize the hub with source and request.
     // @param r The request object, managed by source.
-    virtual srs_error_t initialize(SrsLiveSource* s, SrsRequest* r);
+    virtual srs_error_t initialize(SrsSharedPtr<SrsLiveSource> s, SrsRequest* r);
     // Dispose the hub, release utilities resource,
     // For example, delete all HLS pieces.
     virtual void dispose();
@@ -447,7 +448,7 @@ class SrsLiveSourceManager : public ISrsHourGlass
 {
 private:
     srs_mutex_t lock;
-    std::map<std::string, SrsLiveSource*> pool;
+    std::map< std::string, SrsSharedPtr<SrsLiveSource> > pool;
     SrsHourGlass* timer_;
 public:
     SrsLiveSourceManager();
@@ -458,10 +459,10 @@ public:
     // @param r the client request.
     // @param h the event handler for source.
     // @param pps the matched source, if success never be NULL.
-    virtual srs_error_t fetch_or_create(SrsRequest* r, ISrsLiveSourceHandler* h, SrsLiveSource** pps);
+    virtual srs_error_t fetch_or_create(SrsRequest* r, ISrsLiveSourceHandler* h, SrsSharedPtr<SrsLiveSource>& pps);
 public:
     // Get the exists source, NULL when not exists.
-    virtual SrsLiveSource* fetch(SrsRequest* r);
+    virtual SrsSharedPtr<SrsLiveSource> fetch(SrsRequest* r);
 public:
     // dispose and cycle all sources.
     virtual void dispose();
@@ -543,7 +544,7 @@ public:
     bool publisher_is_idle_for(srs_utime_t timeout);
 public:
     // Initialize the hls with handlers.
-    virtual srs_error_t initialize(SrsRequest* r, ISrsLiveSourceHandler* h);
+    virtual srs_error_t initialize(SrsSharedPtr<SrsLiveSource> wrapper, SrsRequest* r, ISrsLiveSourceHandler* h);
     // Bridge to other source, forward packets to it.
     void set_bridge(ISrsStreamBridge* v);
 // Interface ISrsReloadHandler

--- a/trunk/src/app/srs_app_srt_conn.cpp
+++ b/trunk/src/app/srs_app_srt_conn.cpp
@@ -489,7 +489,7 @@ srs_error_t SrsMpegtsSrtConn::do_playing()
 
     SrsSrtConsumer* consumer = NULL;
     SrsAutoFree(SrsSrtConsumer, consumer);
-    if ((err = srt_source_->create_consumer(srt_source_, consumer)) != srs_success) {
+    if ((err = srt_source_->create_consumer(consumer)) != srs_success) {
         return srs_error_wrap(err, "create consumer, ts source=%s", req_->get_stream_url().c_str());
     }
     srs_assert(consumer);

--- a/trunk/src/app/srs_app_srt_conn.cpp
+++ b/trunk/src/app/srs_app_srt_conn.cpp
@@ -368,16 +368,16 @@ srs_error_t SrsMpegtsSrtConn::acquire_publish()
     }
 
     // Check rtmp stream is busy.
-    SrsLiveSource* live_source = _srs_sources->fetch(req_);
-    if (live_source && !live_source->can_publish(false)) {
+    SrsSharedPtr<SrsLiveSource> live_source = _srs_sources->fetch(req_);
+    if (live_source.get() && !live_source->can_publish(false)) {
         return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "live_source stream %s busy", req_->get_stream_url().c_str());
     }
 
-    if ((err = _srs_sources->fetch_or_create(req_, _srs_hybrid->srs()->instance(), &live_source)) != srs_success) {
+    if ((err = _srs_sources->fetch_or_create(req_, _srs_hybrid->srs()->instance(), live_source)) != srs_success) {
         return srs_error_wrap(err, "create source");
     }
 
-    srs_assert(live_source != NULL);
+    srs_assert(live_source.get() != NULL);
 
     bool enabled_cache = _srs_config->get_gop_cache(req_->vhost);
     int gcmf = _srs_config->get_gop_cache_max_frames(req_->vhost);

--- a/trunk/src/app/srs_app_srt_conn.cpp
+++ b/trunk/src/app/srs_app_srt_conn.cpp
@@ -368,7 +368,7 @@ srs_error_t SrsMpegtsSrtConn::acquire_publish()
     }
 
     // Check rtmp stream is busy.
-    SrsLiveSource *live_source = _srs_sources->fetch(req_);
+    SrsLiveSource* live_source = _srs_sources->fetch(req_);
     if (live_source && !live_source->can_publish(false)) {
         return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "live_source stream %s busy", req_->get_stream_url().c_str());
     }

--- a/trunk/src/app/srs_app_srt_source.cpp
+++ b/trunk/src/app/srs_app_srt_source.cpp
@@ -152,7 +152,7 @@ void SrsSrtSourceManager::eliminate(SrsRequest* r)
 
 SrsSrtSourceManager* _srs_srt_sources = NULL;
 
-SrsSrtConsumer::SrsSrtConsumer(SrsSharedPtr<SrsSrtSource> s)
+SrsSrtConsumer::SrsSrtConsumer(SrsSrtSource* s)
 {
     source_ = s;
     should_update_source_id = false;
@@ -942,11 +942,11 @@ void SrsSrtSource::set_bridge(ISrsStreamBridge* bridge)
     frame_builder_ = new SrsSrtFrameBuilder(bridge);
 }
 
-srs_error_t SrsSrtSource::create_consumer(SrsSharedPtr<SrsSrtSource> source, SrsSrtConsumer*& consumer)
+srs_error_t SrsSrtSource::create_consumer(SrsSrtConsumer*& consumer)
 {
     srs_error_t err = srs_success;
 
-    consumer = new SrsSrtConsumer(source);
+    consumer = new SrsSrtConsumer(this);
     consumers.push_back(consumer);
 
     return err;

--- a/trunk/src/app/srs_app_srt_source.hpp
+++ b/trunk/src/app/srs_app_srt_source.hpp
@@ -70,10 +70,12 @@ extern SrsSrtSourceManager* _srs_srt_sources;
 class SrsSrtConsumer
 {
 public:
-    SrsSrtConsumer(SrsSharedPtr<SrsSrtSource> source);
+    SrsSrtConsumer(SrsSrtSource* source);
     virtual ~SrsSrtConsumer();
 private:
-    SrsSharedPtr<SrsSrtSource> source_;
+    // Because source references to this object, so we should directly use the source ptr.
+    SrsSrtSource* source_;
+private:
     std::vector<SrsSrtPacket*> queue;
     // when source id changed, notice all consumers
     bool should_update_source_id;
@@ -167,7 +169,7 @@ public:
 public:
     // Create consumer
     // @param consumer, output the create consumer.
-    virtual srs_error_t create_consumer(SrsSharedPtr<SrsSrtSource> source, SrsSrtConsumer*& consumer);
+    virtual srs_error_t create_consumer(SrsSrtConsumer*& consumer);
     // Dumps packets in cache to consumer.
     virtual srs_error_t consumer_dumps(SrsSrtConsumer* consumer);
     virtual void on_consumer_destroy(SrsSrtConsumer* consumer);

--- a/trunk/src/app/srs_app_stream_bridge.cpp
+++ b/trunk/src/app/srs_app_stream_bridge.cpp
@@ -25,9 +25,9 @@ ISrsStreamBridge::~ISrsStreamBridge()
 {
 }
 
-SrsFrameToRtmpBridge::SrsFrameToRtmpBridge(SrsLiveSource *src)
+SrsFrameToRtmpBridge::SrsFrameToRtmpBridge(SrsLiveSource* source)
 {
-    source_ = src;
+    source_ = source;
 }
 
 SrsFrameToRtmpBridge::~SrsFrameToRtmpBridge()

--- a/trunk/src/app/srs_app_stream_bridge.cpp
+++ b/trunk/src/app/srs_app_stream_bridge.cpp
@@ -25,7 +25,7 @@ ISrsStreamBridge::~ISrsStreamBridge()
 {
 }
 
-SrsFrameToRtmpBridge::SrsFrameToRtmpBridge(SrsLiveSource* source)
+SrsFrameToRtmpBridge::SrsFrameToRtmpBridge(SrsSharedPtr<SrsLiveSource> source)
 {
     source_ = source;
 }

--- a/trunk/src/app/srs_app_stream_bridge.hpp
+++ b/trunk/src/app/srs_app_stream_bridge.hpp
@@ -42,9 +42,9 @@ public:
 class SrsFrameToRtmpBridge : public ISrsStreamBridge
 {
 private:
-    SrsLiveSource *source_;
+    SrsLiveSource* source_;
 public:
-    SrsFrameToRtmpBridge(SrsLiveSource *src);
+    SrsFrameToRtmpBridge(SrsLiveSource* source);
     virtual ~SrsFrameToRtmpBridge();
 public:
     srs_error_t initialize(SrsRequest* r);

--- a/trunk/src/app/srs_app_stream_bridge.hpp
+++ b/trunk/src/app/srs_app_stream_bridge.hpp
@@ -42,9 +42,9 @@ public:
 class SrsFrameToRtmpBridge : public ISrsStreamBridge
 {
 private:
-    SrsLiveSource* source_;
+    SrsSharedPtr<SrsLiveSource> source_;
 public:
-    SrsFrameToRtmpBridge(SrsLiveSource* source);
+    SrsFrameToRtmpBridge(SrsSharedPtr<SrsLiveSource> source);
     virtual ~SrsFrameToRtmpBridge();
 public:
     srs_error_t initialize(SrsRequest* r);

--- a/trunk/src/core/srs_core_autofree.hpp
+++ b/trunk/src/core/srs_core_autofree.hpp
@@ -11,6 +11,9 @@
 
 #include <stdlib.h>
 
+// The auto free helper, which is actually the unique ptr, without the move feature,
+// see https://github.com/ossrs/srs/discussions/3667#discussioncomment-8969107
+//
 // To free the instance in the current scope, for instance, MyClass* ptr,
 // which is a ptr and this class will:
 //       1. free the ptr.
@@ -81,7 +84,9 @@ public:
     }
 };
 
-// Shared ptr smart pointer, see https://github.com/ossrs/srs/discussions/3667#discussioncomment-8969107
+// Shared ptr smart pointer, only support shared ptr, no weak ptr, no shared from this, no inheritance,
+// no comparing, see https://github.com/ossrs/srs/discussions/3667#discussioncomment-8969107
+//
 // Usage:
 //      SrsSharedPtr<MyClass> ptr(new MyClass());
 //      ptr->do_something();

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    128
+#define VERSION_REVISION    129
 
 #endif

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -107,6 +107,7 @@
     XX(ERROR_BACKTRACE_ADDR2LINE           , 1094, "BacktraceAddr2Line", "Backtrace addr2line failed") \
     XX(ERROR_SYSTEM_FILE_NOT_OPEN          , 1095, "FileNotOpen", "File is not opened") \
     XX(ERROR_SYSTEM_FILE_SETVBUF           , 1096, "FileSetVBuf", "Failed to set file vbuf") \
+    XX(ERROR_NO_SOURCE                     , 1097, "NoSource", "No source found")
 
 /**************************************************/
 /* RTMP protocol error. */
@@ -334,7 +335,7 @@
     XX(ERROR_STREAM_CASTER_HEVC_FORMAT     , 4057, "CasterTsHevcFormat", "Invalid ts HEVC Format for stream caster") \
     XX(ERROR_HTTP_JSONP                    , 4058, "HttpJsonp", "Invalid callback for JSONP")   \
     XX(ERROR_HEVC_NALU_UEV                 , 4059, "HevcNaluUev", "Failed to read UEV for HEVC NALU") \
-    XX(ERROR_HEVC_NALU_SEV                 , 4060, "HevcNaluSev", "Failed to read SEV for HEVC NALU") \
+    XX(ERROR_HEVC_NALU_SEV                 , 4060, "HevcNaluSev", "Failed to read SEV for HEVC NALU")
 
 
 /**************************************************/

--- a/trunk/src/utest/srs_utest_core.cpp
+++ b/trunk/src/utest/srs_utest_core.cpp
@@ -139,6 +139,17 @@ VOID TEST(CoreLogger, SharedPtrReset)
     }
 }
 
+SrsSharedPtr<int> mock_create_from_ptr(SrsSharedPtr<int> p) {
+    return p;
+}
+
+VOID TEST(CoreLogger, SharedPtrContructor)
+{
+    int* p = new int(100);
+    SrsSharedPtr<int> q = mock_create_from_ptr(p);
+    EXPECT_EQ(100, *q);
+}
+
 VOID TEST(CoreLogger, SharedPtrObject)
 {
     SrsSharedPtr<MyNormalObject> p(new MyNormalObject(100));


### PR DESCRIPTION
Detail change log:

1. [Simple,Refactor] Remove member fields of http entry, etc. https://github.com/ossrs/srs/pull/4089/commits/e34b3d3aa44f56b49c5c0b8e58c0285c4d9094d4
2. [Ignore] Rename source to live_source. https://github.com/ossrs/srs/pull/4089/commits/846f95ec96f183909070c4b3f5ef0e9dd7d5448d
3. [Ignore] Use directly ptr in consumer. https://github.com/ossrs/srs/pull/4089/commits/d38af021ad532ed9b4043c529dd5e54b9cbf5c01
4. [Complex, Important] Use shared ptr for live source. https://github.com/ossrs/srs/pull/4089/commits/88f922413a1fb5cb920ab64f8b3805420932602a 

The object relationship:

![live-source](https://github.com/ossrs/srs/assets/2777660/1adb59af-6e7a-40f3-9a4a-1cc849d7dae1)
