### PR TITLE
Config: Improve env config to support multi values. v7.0.2

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2024-08-13, Merge [#4092](https://github.com/ossrs/srs/pull/4092): Config: Improve env config to support multi values. v7.0.2 (#4092)
 * v7.0, 2024-08-12, Merge [#4131](https://github.com/ossrs/srs/pull/4131): Transcode: More generic h264/h265 codec support. v7.0.1 (#4131)
 * v7.0, 2024-08-12, Init SRS 7 branch. v7.0.0
 

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -68,15 +68,17 @@ const char* _srs_version = "XCORE-" RTMP_SIG_SRS_SERVER;
 #define SRS_OVERWRITE_BY_ENV_MILLISECONDS(key) if (!srs_getenv(key).empty()) return (srs_utime_t)(::atoi(srs_getenv(key).c_str()) * SRS_UTIME_MILLISECONDS)
 #define SRS_OVERWRITE_BY_ENV_FLOAT_SECONDS(key) if (!srs_getenv(key).empty()) return srs_utime_t(::atof(srs_getenv(key).c_str()) * SRS_UTIME_SECONDS)
 #define SRS_OVERWRITE_BY_ENV_FLOAT_MILLISECONDS(key) if (!srs_getenv(key).empty()) return srs_utime_t(::atof(srs_getenv(key).c_str()) * SRS_UTIME_MILLISECONDS)
-#define SRS_OVERWRITE_BY_ENV_DIRECTIVE(key) { \
-        static SrsConfDirective* dir = NULL;      \
-        if (!dir && !srs_getenv(key).empty()) {   \
-            string v = srs_getenv(key);           \
-            dir = new SrsConfDirective();         \
-            dir->name = key;                      \
-            dir->args.push_back(v);               \
-        }                                         \
-        if (dir) return dir;                      \
+#define SRS_OVERWRITE_BY_ENV_DIRECTIVE(key) {                                 \
+        static SrsConfDirective* dir = NULL;                                  \
+        if (!dir && !srs_getenv(key).empty()) {                               \
+            std::vector<string> vec = srs_string_split(srs_getenv(key), " "); \
+            dir = new SrsConfDirective();                                     \
+            dir->name = key;                                                  \
+            for (size_t i = 0; i < vec.size(); ++i) {                         \
+                dir->args.push_back(vec[i]);                                  \
+            }                                                                 \
+        }                                                                     \
+        if (dir) return dir;                                                  \
     }
 
 /**

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       7
 #define VERSION_MINOR       0
-#define VERSION_REVISION    1
+#define VERSION_REVISION    2
 
 #endif


### PR DESCRIPTION
1. add on_connect & on_close directives to conf/full.conf;
2. let http_hooks env overwrite support multi values; e.g. SRS_VHOST_HTTP_HOOKS_ON_CONNECT="http://127.0.0.1/api/connect http://localhost/api/connect"

related to https://github.com/ossrs/srs/issues/1222#issuecomment-2170424703
Above comments said `http_hook` env may not works as expected, as I found there are still has some issue in `http_hooks` env configuration, but this PR may not target above problem.
