### PR TITLE
Fix security scan problems. v6.0.131

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-06-21, Merge [#4100](https://github.com/ossrs/srs/pull/4100): Fix security scan problems. v6.0.131 (#4100)
 * v6.0, 2024-06-21, Merge [#4097](https://github.com/ossrs/srs/pull/4097): SmartPtr: Support load test for source by srs-bench. v6.0.130 (#4097)
 * v6.0, 2024-06-15, Merge [#4089](https://github.com/ossrs/srs/pull/4089): SmartPtr: Support shared ptr for live source. v6.0.129 (#4089)
 * v6.0, 2024-06-14, Merge [#4085](https://github.com/ossrs/srs/pull/4085): SmartPtr: Support shared ptr for RTC source. v6.0.128 (#4085)

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -1204,11 +1204,9 @@ srs_error_t SrsHttpStreamServer::hijack(ISrsHttpMessage* request, ISrsHttpHandle
     }
     
     // use the handler if exists.
-    if (ph) {
-        if (streamHandlers.find(sid) != streamHandlers.end()) {
-            entry = streamHandlers[sid];
-            *ph = entry->stream;
-        }
+    if (streamHandlers.find(sid) != streamHandlers.end()) {
+        entry = streamHandlers[sid];
+        *ph = entry->stream;
     }
     
     // trigger edge to fetch from origin.

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -199,15 +199,15 @@ void SrsFastVector::push_back(SrsSharedPtrMessage* msg)
     // increase vector.
     if (count >= nb_msgs) {
         int size = srs_max(SRS_PERF_MW_MSGS * 8, nb_msgs * 2);
-        SrsSharedPtrMessage** buf = new SrsSharedPtrMessage*[size];
+        SrsSharedPtrMessage** buf = msgs;
+        msgs = new SrsSharedPtrMessage*[size];
         for (int i = 0; i < nb_msgs; i++) {
-            buf[i] = msgs[i];
+            msgs[i] = buf[i];
         }
         srs_info("fast vector incrase %d=>%d", nb_msgs, size);
         
         // use new array.
-        srs_freepa(msgs);
-        msgs = buf;
+        srs_freepa(buf);
         nb_msgs = size;
     }
     

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    130
+#define VERSION_REVISION    131
 
 #endif


### PR DESCRIPTION
1. fix redundant null check, there is no potential risks by the way, just redundant null check.
2. Potential use pointer after free, that's not true. So we can ignore this one, or find a way to make stupid security tool happy.