### PR TITLE
WIP: debug segment fault problem when SRS quit.

### DIFF
--- a/trunk/src/app/srs_app_hourglass.cpp
+++ b/trunk/src/app/srs_app_hourglass.cpp
@@ -155,6 +155,11 @@ srs_error_t SrsFastTimer::start()
     return err;
 }
 
+void SrsFastTimer::stop()
+{
+    trd_->stop();
+}
+
 void SrsFastTimer::subscribe(ISrsFastTimer* timer)
 {
     if (std::find(handlers_.begin(), handlers_.end(), timer) == handlers_.end()) {
@@ -168,6 +173,11 @@ void SrsFastTimer::unsubscribe(ISrsFastTimer* timer)
     if (it != handlers_.end()) {
         handlers_.erase(it);
     }
+}
+
+void SrsFastTimer::clear()
+{
+    handlers_.clear();
 }
 
 srs_error_t SrsFastTimer::cycle()
@@ -241,3 +251,7 @@ srs_error_t SrsClockWallMonitor::on_timer(srs_utime_t interval)
     return err;
 }
 
+SrsFastTimer* _timer20ms = NULL;
+SrsFastTimer* _timer100ms = NULL;
+SrsFastTimer* _timer1s = NULL;
+SrsFastTimer* _timer5s = NULL;

--- a/trunk/src/app/srs_app_hourglass.hpp
+++ b/trunk/src/app/srs_app_hourglass.hpp
@@ -114,9 +114,12 @@ public:
     virtual ~SrsFastTimer();
 public:
     srs_error_t start();
+    void stop();
 public:
     void subscribe(ISrsFastTimer* timer);
     void unsubscribe(ISrsFastTimer* timer);
+    void clear();
+
 // Interface ISrsCoroutineHandler
 private:
     // Cycle the hourglass, which will sleep resolution every time.

--- a/trunk/src/app/srs_app_http_static.cpp
+++ b/trunk/src/app/srs_app_http_static.cpp
@@ -41,6 +41,8 @@ using namespace std;
 
 #define SRS_CONTEXT_IN_HLS "hls_ctx"
 
+extern SrsFastTimer* _timer5s;
+
 SrsHlsVirtualConn::SrsHlsVirtualConn()
 {
     req = NULL;
@@ -63,13 +65,13 @@ void SrsHlsVirtualConn::expire()
 
 SrsHlsStream::SrsHlsStream()
 {
-    _srs_hybrid->timer5s()->subscribe(this);
+    _timer5s->subscribe(this);
     security_ = new SrsSecurity();
 }
 
 SrsHlsStream::~SrsHlsStream()
 {
-    _srs_hybrid->timer5s()->unsubscribe(this);
+    _timer5s->unsubscribe(this);
 
     std::map<std::string, SrsHlsVirtualConn*>::iterator it;
     for (it = map_ctx_info_.begin(); it != map_ctx_info_.end(); ++it) {

--- a/trunk/src/app/srs_app_hybrid.hpp
+++ b/trunk/src/app/srs_app_hybrid.hpp
@@ -37,10 +37,6 @@ class SrsHybridServer : public ISrsFastTimer
 {
 private:
     std::vector<ISrsHybridServer*> servers;
-    SrsFastTimer* timer20ms_;
-    SrsFastTimer* timer100ms_;
-    SrsFastTimer* timer1s_;
-    SrsFastTimer* timer5s_;
     SrsClockWallMonitor* clock_monitor_;
 public:
     SrsHybridServer();
@@ -53,10 +49,7 @@ public:
     virtual void stop();
 public:
     virtual SrsServerAdapter* srs();
-    SrsFastTimer* timer20ms();
-    SrsFastTimer* timer100ms();
-    SrsFastTimer* timer1s();
-    SrsFastTimer* timer5s();
+
 // interface ISrsFastTimer
 private:
     srs_error_t on_timer(srs_utime_t interval);

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -69,6 +69,10 @@ extern SrsPps* _srs_pps_rnack2;
 extern SrsPps* _srs_pps_pub;
 extern SrsPps* _srs_pps_conn;
 
+extern SrsFastTimer* _timer1s;
+extern SrsFastTimer* _timer100ms;
+extern SrsFastTimer* _timer20ms;
+
 ISrsRtcTransport::ISrsRtcTransport()
 {
 }
@@ -945,12 +949,12 @@ srs_error_t SrsRtcPlayStream::do_request_keyframe(uint32_t ssrc, SrsContextId ci
 
 SrsRtcPublishRtcpTimer::SrsRtcPublishRtcpTimer(SrsRtcPublishStream* p) : p_(p)
 {
-    _srs_hybrid->timer1s()->subscribe(this);
+    _timer1s->subscribe(this);
 }
 
 SrsRtcPublishRtcpTimer::~SrsRtcPublishRtcpTimer()
 {
-    _srs_hybrid->timer1s()->unsubscribe(this);
+    _timer1s->unsubscribe(this);
 }
 
 srs_error_t SrsRtcPublishRtcpTimer::on_timer(srs_utime_t interval)
@@ -981,12 +985,12 @@ srs_error_t SrsRtcPublishRtcpTimer::on_timer(srs_utime_t interval)
 
 SrsRtcPublishTwccTimer::SrsRtcPublishTwccTimer(SrsRtcPublishStream* p) : p_(p)
 {
-    _srs_hybrid->timer100ms()->subscribe(this);
+    _timer100ms->subscribe(this);
 }
 
 SrsRtcPublishTwccTimer::~SrsRtcPublishTwccTimer()
 {
-    _srs_hybrid->timer100ms()->unsubscribe(this);
+    _timer100ms->unsubscribe(this);
 }
 
 srs_error_t SrsRtcPublishTwccTimer::on_timer(srs_utime_t interval)
@@ -1739,12 +1743,12 @@ void SrsRtcPublishStream::update_send_report_time(uint32_t ssrc, const SrsNtp& n
 
 SrsRtcConnectionNackTimer::SrsRtcConnectionNackTimer(SrsRtcConnection* p) : p_(p)
 {
-    _srs_hybrid->timer20ms()->subscribe(this);
+    _timer20ms->subscribe(this);
 }
 
 SrsRtcConnectionNackTimer::~SrsRtcConnectionNackTimer()
 {
-    _srs_hybrid->timer20ms()->unsubscribe(this);
+    _timer20ms->unsubscribe(this);
 }
 
 srs_error_t SrsRtcConnectionNackTimer::on_timer(srs_utime_t interval)

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -52,6 +52,7 @@ SrsPps* _srs_pps_rhnack = NULL;
 SrsPps* _srs_pps_rmnack = NULL;
 
 extern SrsPps* _srs_pps_aloss2;
+extern SrsFastTimer* _timer100ms;
 
 const int kAudioChannel         = 2;
 const int kAudioSamplerate      = 48000;
@@ -643,7 +644,7 @@ srs_error_t SrsRtcSource::on_publish()
         pli_for_rtmp_ = _srs_config->get_rtc_pli_for_rtmp(req->vhost);
 
         // @see SrsRtcSource::on_timer()
-        _srs_hybrid->timer100ms()->subscribe(this);
+        _timer100ms->subscribe(this);
     }
 
     SrsStatistic* stat = SrsStatistic::instance();
@@ -677,7 +678,7 @@ void SrsRtcSource::on_unpublish()
     //free bridge resource
     if (bridge_) {
         // For SrsRtcSource::on_timer()
-        _srs_hybrid->timer100ms()->unsubscribe(this);
+        _timer100ms->unsubscribe(this);
 
 #ifdef SRS_FFMPEG_FIT
         frame_builder_->on_unpublish();


### PR DESCRIPTION
related to #4102 

# Env
mac os

# How to reproduce the segment fault error?
1. `./objs/srs -c conf/rtmp2rtc.conf`
2. push a stream, use RTC in web browser.
3. send QUIT signal to srs process: `kill -3 [pid]` or `ctrl-\` if process in foreground. 

# Still need to fix
crash when release or stop `_timer100ms`.