### PR TITLE
Let cluster config support overwritten by ENV

### DIFF
--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -999,6 +999,7 @@ vhost cluster.srs.com {
         # The cluster mode, local or remote.
         #       local: It's an origin server, serve streams itself.
         #       remote: It's an edge server, fetch or push stream to origin server.
+        # Overwrite by env SRS_VHOST_CLUSTER_MODE for all vhosts.
         # default: local
         mode remote;
 
@@ -1006,6 +1007,8 @@ vhost cluster.srs.com {
         # format as: <server_name|ip>[:port]
         # @remark user can specifies multiple origin for error backup, by space,
         # for example, 192.168.1.100:1935 192.168.1.101:1935 192.168.1.102:1935
+        # Overwrite by env SRS_VHOST_CLUSTER_ORIGIN for all vhosts.
+        # no default value
         origin 127.0.0.1:1935 localhost:1935;
 
         # For edge(mode remote), whether open the token traverse mode,
@@ -1013,12 +1016,14 @@ vhost cluster.srs.com {
         # it's very important for the edge to do the token auth.
         # the better way is use http callback to do the token auth by the edge,
         # but if user prefer origin check(auth), the token_traverse if better solution.
+        # Overwrite by env SRS_VHOST_CLUSTER_TOKEN_TRAVERSE for all vhosts.
         # default: off
         token_traverse off;
 
         # For edge(mode remote), the vhost to transform for edge,
         # to fetch from the specified vhost at origin,
         # if not specified, use the current vhost of edge in origin, the variable [vhost].
+        # Overwrite by env SRS_VHOST_CLUSTER_EDGE_TRANSFORM_VHOST for all vhosts.
         # default: [vhost]
         vhost same.edge.srs.com;
 
@@ -1027,11 +1032,13 @@ vhost cluster.srs.com {
         # when connect to upnode, it will take the debug info,
         # for example, the id, source id, pid.
         # please see https://ossrs.net/lts/zh-cn/docs/v4/doc/log
+        # Overwrite by env SRS_VHOST_CLUSTER_DEBUG_SRS_UPNODE for all vhosts.
         # default: on
         debug_srs_upnode on;
 
         # For origin(mode local) cluster, turn on the cluster.
         # @remark Origin cluster only supports RTMP, use Edge to transmux RTMP to FLV.
+        # Overwrite by env SRS_VHOST_CLUSTER_ORIGIN_CLUSTER for all vhosts.
         # default: off
         # TODO: FIXME: Support reload.
         origin_cluster off;
@@ -1039,6 +1046,7 @@ vhost cluster.srs.com {
         # For origin (mode local) cluster, the co-worker's HTTP APIs.
         # This origin will connect to co-workers and communicate with them.
         # please see https://ossrs.io/lts/en-us/docs/v4/doc/origin-cluster
+        # Overwrite by env SRS_VHOST_CLUSTER_COWORKERS for all vhosts.
         # TODO: FIXME: Support reload.
         coworkers 127.0.0.1:9091 127.0.0.1:9092;
 
@@ -1046,11 +1054,13 @@ vhost cluster.srs.com {
         #       rtmp, Connect origin by RTMP
         #       flv, Connect origin by HTTP-FLV
         #       flvs, Connect origin by HTTPS-FLV
+        # Overwrite by env SRS_VHOST_CLUSTER_PROTOCOL for all vhosts.
         # Default: rtmp
         protocol rtmp;
 
         # Whether follow client protocol to connect to origin.
         # @remark The FLV might use different signature(in query string) to RTMP.
+        # Overwrite by env SRS_VHOST_CLUSTER_FOLLOW_CLIENT for all vhosts.
         # Default: off
         follow_client off;
     }

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -778,7 +778,7 @@ public:
     virtual bool get_vhost_origin_cluster(SrsConfDirective* conf);
     // Get the co-workers of origin cluster.
     // @see https://ossrs.net/lts/zh-cn/docs/v4/doc/origin-cluster
-    virtual std::vector<std::string> get_vhost_coworkers(std::string vhost);
+    virtual SrsConfDirective* get_vhost_coworkers(std::string vhost);
 // vhost security section
 public:
     // Whether the secrity of vhost enabled.

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -714,7 +714,9 @@ srs_error_t SrsRtmpConn::playing(SrsSharedPtr<SrsLiveSource> source)
     // When origin cluster enabled, try to redirect to the origin which is active.
     // A active origin is a server which is delivering stream.
     if (!info->edge && _srs_config->get_vhost_origin_cluster(req->vhost) && source->inactive()) {
-        vector<string> coworkers = _srs_config->get_vhost_coworkers(req->vhost);
+        SrsConfDirective* conf = _srs_config->get_vhost_coworkers(req->vhost);
+        
+        vector<string> coworkers = conf ? conf->args : vector<string>();
         for (int i = 0; i < (int)coworkers.size(); i++) {
             // TODO: FIXME: User may config the server itself as coworker, we must identify and ignore it.
             string host; int port = 0; string coworker = coworkers.at(i);


### PR DESCRIPTION
The env conf overwrite is convenient and necessary for the container (docker & k8s) deployment. So this commit can let SRS support deployed as edge cluster by containers.