### PR TITLE
Transcode: Support video codec such as h264_qsv and libx265. v6.0.145

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-07-27, Merge [#4127](https://github.com/ossrs/srs/pull/4127): Transcode: Support video codec such as h264_qsv and libx265. v6.0.145 (#4127)
 * v6.0, 2024-07-27, Merge [#4101](https://github.com/ossrs/srs/pull/4101): GB28181: Support external SIP server. v6.0.144 (#4101)
 * v6.0, 2024-07-24, Merge [#4115](https://github.com/ossrs/srs/pull/4115): HLS: Add missing newline to end of session manifest. v6.0.143 (#4115)
 * v6.0, 2024-07-24, Merge [#4029](https://github.com/ossrs/srs/pull/4029): Player: Fix empty img tag occupy 20px size in safari. v6.0.142 (#4029)

--- a/trunk/src/app/srs_app_ffmpeg.cpp
+++ b/trunk/src/app/srs_app_ffmpeg.cpp
@@ -33,8 +33,9 @@ using namespace std;
 #define SRS_RTMP_ENCODER_COPY "copy"
 #define SRS_RTMP_ENCODER_NO_VIDEO "vn"
 #define SRS_RTMP_ENCODER_NO_AUDIO "an"
-// only support libx264 encoder.
+// only support libx264 and h264_qsv encoder.
 #define SRS_RTMP_ENCODER_VCODEC_LIBX264 "libx264"
+#define SRS_RTMP_ENCODER_VCODEC_H264QSV "h264_qsv"
 #define SRS_RTMP_ENCODER_VCODEC_PNG "png"
 // any aac encoder is ok which contains the aac,
 // for example, libaacplus, aac, fdkaac
@@ -123,8 +124,8 @@ srs_error_t SrsFFMPEG::initialize_transcode(SrsConfDirective* engine)
     }
     
     if (vcodec != SRS_RTMP_ENCODER_COPY && vcodec != SRS_RTMP_ENCODER_NO_VIDEO && vcodec != SRS_RTMP_ENCODER_VCODEC_PNG) {
-        if (vcodec != SRS_RTMP_ENCODER_VCODEC_LIBX264) {
-            return srs_error_new(ERROR_ENCODER_VCODEC, "invalid vcodec, must be %s, actual %s", SRS_RTMP_ENCODER_VCODEC_LIBX264, vcodec.c_str());
+        if (vcodec != SRS_RTMP_ENCODER_VCODEC_LIBX264 && vcodec != SRS_RTMP_ENCODER_VCODEC_H264QSV) {
+            return srs_error_new(ERROR_ENCODER_VCODEC, "invalid vcodec, must be %s or %s, actual %s", SRS_RTMP_ENCODER_VCODEC_LIBX264, SRS_RTMP_ENCODER_VCODEC_H264QSV, vcodec.c_str());
         }
         if (vbitrate < 0) {
             return srs_error_new(ERROR_ENCODER_VBITRATE, "invalid vbitrate: %d", vbitrate);

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    144
+#define VERSION_REVISION    145
 
 #endif


### PR DESCRIPTION
Currently only libx264 ffmpeg encoder is supported. This pull request add also h264_qsv. But maybe a more generic solution with oder encoders would be useful to.