### PR TITLE
Transcode: More generic h264/h265 codec support. v7.0.1

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-08-12, Merge [#4131](https://github.com/ossrs/srs/pull/4131): Transcode: More generic h264/h265 codec support. v6.0.146 (#4131)
 * v6.0, 2024-07-27, Merge [#4127](https://github.com/ossrs/srs/pull/4127): Transcode: Support video codec such as h264_qsv and libx265. v6.0.145 (#4127)
 * v6.0, 2024-07-27, Merge [#4101](https://github.com/ossrs/srs/pull/4101): GB28181: Support external SIP server. v6.0.144 (#4101)
 * v6.0, 2024-07-24, Merge [#4115](https://github.com/ossrs/srs/pull/4115): HLS: Add missing newline to end of session manifest. v6.0.143 (#4115)

--- a/trunk/src/app/srs_app_ffmpeg.cpp
+++ b/trunk/src/app/srs_app_ffmpeg.cpp
@@ -33,10 +33,9 @@ using namespace std;
 #define SRS_RTMP_ENCODER_COPY "copy"
 #define SRS_RTMP_ENCODER_NO_VIDEO "vn"
 #define SRS_RTMP_ENCODER_NO_AUDIO "an"
-// only support libx264, libx265 and h264_qsv encoder.
-#define SRS_RTMP_ENCODER_VCODEC_LIBX264 "libx264"
-#define SRS_RTMP_ENCODER_VCODEC_LIBX265 "libx265"
-#define SRS_RTMP_ENCODER_VCODEC_H264QSV "h264_qsv"
+// only support encoder: h264, h265 and other variants like libx264 etc.
+#define SRS_RTMP_ENCODER_VCODEC_264 "264"
+#define SRS_RTMP_ENCODER_VCODEC_265 "265"
 #define SRS_RTMP_ENCODER_VCODEC_PNG "png"
 // any aac encoder is ok which contains the aac,
 // for example, libaacplus, aac, fdkaac
@@ -125,10 +124,8 @@ srs_error_t SrsFFMPEG::initialize_transcode(SrsConfDirective* engine)
     }
 
     if (vcodec != SRS_RTMP_ENCODER_COPY && vcodec != SRS_RTMP_ENCODER_NO_VIDEO && vcodec != SRS_RTMP_ENCODER_VCODEC_PNG) {
-        if (vcodec != SRS_RTMP_ENCODER_VCODEC_LIBX264 && vcodec != SRS_RTMP_ENCODER_VCODEC_LIBX265 && vcodec != SRS_RTMP_ENCODER_VCODEC_H264QSV) {
-            return srs_error_new(
-                ERROR_ENCODER_VCODEC, "invalid vcodec, must be %s, %s or %s, actual %s",
-                SRS_RTMP_ENCODER_VCODEC_LIBX264, SRS_RTMP_ENCODER_VCODEC_LIBX265, SRS_RTMP_ENCODER_VCODEC_H264QSV, vcodec.c_str());
+        if (vcodec.find(SRS_RTMP_ENCODER_VCODEC_264) != string::npos && vcodec.find(SRS_RTMP_ENCODER_VCODEC_265) != string::npos) {
+            return srs_error_new(ERROR_ENCODER_VCODEC, "invalid vcodec, must be h264 or h265, actual %s", vcodec.c_str());
         }
         if (vbitrate < 0) {
             return srs_error_new(ERROR_ENCODER_VBITRATE, "invalid vbitrate: %d", vbitrate);

--- a/trunk/src/app/srs_app_ffmpeg.cpp
+++ b/trunk/src/app/srs_app_ffmpeg.cpp
@@ -34,8 +34,8 @@ using namespace std;
 #define SRS_RTMP_ENCODER_NO_VIDEO "vn"
 #define SRS_RTMP_ENCODER_NO_AUDIO "an"
 // only support encoder: h264, h265 and other variants like libx264 etc.
-#define SRS_RTMP_ENCODER_VCODEC_264 "264"
-#define SRS_RTMP_ENCODER_VCODEC_265 "265"
+#define SRS_RTMP_ENCODER_VCODEC_H264 "264"
+#define SRS_RTMP_ENCODER_VCODEC_H265 "265"
 #define SRS_RTMP_ENCODER_VCODEC_PNG "png"
 // any aac encoder is ok which contains the aac,
 // for example, libaacplus, aac, fdkaac
@@ -124,8 +124,8 @@ srs_error_t SrsFFMPEG::initialize_transcode(SrsConfDirective* engine)
     }
 
     if (vcodec != SRS_RTMP_ENCODER_COPY && vcodec != SRS_RTMP_ENCODER_NO_VIDEO && vcodec != SRS_RTMP_ENCODER_VCODEC_PNG) {
-        if (vcodec.find(SRS_RTMP_ENCODER_VCODEC_264) != string::npos && vcodec.find(SRS_RTMP_ENCODER_VCODEC_265) != string::npos) {
-            return srs_error_new(ERROR_ENCODER_VCODEC, "invalid vcodec, must be h264 or h265, actual %s", vcodec.c_str());
+        if (vcodec.find(SRS_RTMP_ENCODER_VCODEC_H264) != string::npos && vcodec.find(SRS_RTMP_ENCODER_VCODEC_H265) != string::npos) {
+            return srs_error_new(ERROR_ENCODER_VCODEC, "invalid vcodec, must be h264, h265 or one of its variants, actual %s", vcodec.c_str());
         }
         if (vbitrate < 0) {
             return srs_error_new(ERROR_ENCODER_VBITRATE, "invalid vbitrate: %d", vbitrate);

--- a/trunk/src/app/srs_app_ffmpeg.cpp
+++ b/trunk/src/app/srs_app_ffmpeg.cpp
@@ -125,7 +125,7 @@ srs_error_t SrsFFMPEG::initialize_transcode(SrsConfDirective* engine)
 
     if (vcodec != SRS_RTMP_ENCODER_COPY && vcodec != SRS_RTMP_ENCODER_NO_VIDEO && vcodec != SRS_RTMP_ENCODER_VCODEC_PNG) {
         if (vcodec.find(SRS_RTMP_ENCODER_VCODEC_H264) != string::npos && vcodec.find(SRS_RTMP_ENCODER_VCODEC_H265) != string::npos) {
-            return srs_error_new(ERROR_ENCODER_VCODEC, "invalid vcodec, must be h264, h265 or one of its variants, actual %s", vcodec.c_str());
+            return srs_error_new(ERROR_ENCODER_VCODEC, "invalid vcodec, must be h264, h265 or one of their variants, actual %s", vcodec.c_str());
         }
         if (vbitrate < 0) {
             return srs_error_new(ERROR_ENCODER_VBITRATE, "invalid vbitrate: %d", vbitrate);

--- a/trunk/src/app/srs_app_ffmpeg.cpp
+++ b/trunk/src/app/srs_app_ffmpeg.cpp
@@ -36,6 +36,7 @@ using namespace std;
 // only support encoder: h264, h265 and other variants like libx264 etc.
 #define SRS_RTMP_ENCODER_VCODEC_H264 "264"
 #define SRS_RTMP_ENCODER_VCODEC_H265 "265"
+#define SRS_RTMP_ENCODER_VCODEC_HEVC "hevc"
 #define SRS_RTMP_ENCODER_VCODEC_PNG "png"
 // any aac encoder is ok which contains the aac,
 // for example, libaacplus, aac, fdkaac
@@ -124,7 +125,7 @@ srs_error_t SrsFFMPEG::initialize_transcode(SrsConfDirective* engine)
     }
 
     if (vcodec != SRS_RTMP_ENCODER_COPY && vcodec != SRS_RTMP_ENCODER_NO_VIDEO && vcodec != SRS_RTMP_ENCODER_VCODEC_PNG) {
-        if (vcodec.find(SRS_RTMP_ENCODER_VCODEC_H264) != string::npos && vcodec.find(SRS_RTMP_ENCODER_VCODEC_H265) != string::npos) {
+        if (vcodec.find(SRS_RTMP_ENCODER_VCODEC_H264) != string::npos && vcodec.find(SRS_RTMP_ENCODER_VCODEC_H265) != string::npos && vcodec.find(SRS_RTMP_ENCODER_VCODEC_HEVC) != string::npos) {
             return srs_error_new(ERROR_ENCODER_VCODEC, "invalid vcodec, must be h264, h265 or one of their variants, actual %s", vcodec.c_str());
         }
         if (vbitrate < 0) {

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    145
+#define VERSION_REVISION    146
 
 #endif


### PR DESCRIPTION
Sorry this is another pull request with same intention. But there is more variants of h264 und h265 codecs and I think it is good to support them all.