### PR TITLE
Live: Crash for invalid live stream state when unmount HTTP. v6.0.146 v7.0.3

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2024-08-14, Merge [#4141](https://github.com/ossrs/srs/pull/4141): Live: Crash for invalid live stream state when unmount HTTP. v7.0.3 (#4141)
 * v7.0, 2024-08-13, Merge [#4092](https://github.com/ossrs/srs/pull/4092): Config: Improve env config to support multi values. v7.0.2 (#4092)
 * v7.0, 2024-08-12, Merge [#4131](https://github.com/ossrs/srs/pull/4131): Transcode: More generic h264/h265 codec support. v7.0.1 (#4131)
 * v7.0, 2024-08-12, Init SRS 7 branch. v7.0.0
@@ -14,6 +15,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-08-14, Merge [#4141](https://github.com/ossrs/srs/pull/4141): Live: Crash for invalid live stream state when unmount HTTP. v6.0.146 (#4141)
 * v6.0, 2024-07-27, Merge [#4127](https://github.com/ossrs/srs/pull/4127): Transcode: Support video codec such as h264_qsv and libx265. v6.0.145 (#4127)
 * v6.0, 2024-07-27, Merge [#4101](https://github.com/ossrs/srs/pull/4101): GB28181: Support external SIP server. v6.0.144 (#4101)
 * v6.0, 2024-07-24, Merge [#4115](https://github.com/ossrs/srs/pull/4115): HLS: Add missing newline to end of session manifest. v6.0.143 (#4115)

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -2632,8 +2632,7 @@ void SrsLiveSource::on_unpublish()
     meta->update_previous_ash();
 
     srs_trace("cleanup when unpublish");
-    
-    _can_publish = true;
+
     if (!_source_id.empty()) {
         _pre_source_id = _source_id;
     }
@@ -2655,6 +2654,8 @@ void SrsLiveSource::on_unpublish()
     if (consumers.empty()) {
         stream_die_at_ = srs_get_system_time();
     }
+
+    _can_publish = true;
 }
 
 srs_error_t SrsLiveSource::create_consumer(SrsLiveConsumer*& consumer)

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    145
+#define VERSION_REVISION    146
 
 #endif

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       7
 #define VERSION_MINOR       0
-#define VERSION_REVISION    2
+#define VERSION_REVISION    3
 
 #endif


### PR DESCRIPTION
When unpublishing, the handler callback that will stop the coroutine:

```cpp
_can_publish = true;
handler->on_unpublish(req);
```

In this handler, the `http_unmount` will be called:

```cpp
void SrsHttpStreamServer::http_unmount(SrsRequest* r)
    cache->stop();
```

In this `http_unmount` function, there could be context switching. In such a situation, a new connection might publish the stream while the unpublish process is freeing the stream, leading to a crash.

To prevent a new publisher, we should change the state only after all handlers and hooks are completed.