### PR TITLE
ST: Replace macros with explicit code for better understanding. v7.0.7

### DIFF
--- a/trunk/3rdparty/st-srs/Makefile
+++ b/trunk/3rdparty/st-srs/Makefile
@@ -46,6 +46,7 @@ VERSION     = 1.9
 ##########################
 
 CC          = cc
+CXX         = g++
 AR          = ar
 LD          = ld
 RANLIB      = ranlib
@@ -270,20 +271,15 @@ $(HEADER): public.h
 	rm -f $@
 	cp public.h $@
 
-$(TARGETDIR)/md_linux.o: md_linux.S
-	$(CC) $(CFLAGS) -c $< -o $@
-
-$(TARGETDIR)/md_linux2.o: md_linux2.S
-	$(CC) $(CFLAGS) -c $< -o $@
-
-$(TARGETDIR)/md_darwin.o: md_darwin.S
-	$(CC) $(CFLAGS) -c $< -o $@
-
-$(TARGETDIR)/md_cygwin64.o: md_cygwin64.S
+$(TARGETDIR)/%.o: %.S
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(TARGETDIR)/%.o: %.c common.h md.h
 	$(CC) $(CFLAGS) -c $< -o $@
+
+# Note that we use C++98 standard for the C++ files.
+$(TARGETDIR)/%.o: %.cc common.h md.h
+	$(CXX) $(CFLAGS) -c $< -o $@ -std=c++98
 
 clean:
 	rm -rf *_OPT *_DBG obj st.pc

--- a/trunk/3rdparty/st-srs/Makefile
+++ b/trunk/3rdparty/st-srs/Makefile
@@ -208,7 +208,8 @@ OBJS        = $(TARGETDIR)/sched.o \
               $(TARGETDIR)/sync.o  \
               $(TARGETDIR)/key.o   \
               $(TARGETDIR)/io.o    \
-              $(TARGETDIR)/event.o
+              $(TARGETDIR)/event.o \
+              $(TARGETDIR)/common.o
 OBJS        += $(EXTRA_OBJS)
 HEADER      = $(TARGETDIR)/st.h
 SLIBRARY    = $(TARGETDIR)/libst.a

--- a/trunk/3rdparty/st-srs/common.c
+++ b/trunk/3rdparty/st-srs/common.c
@@ -35,7 +35,7 @@ void _st_switch_context(_st_thread_t *thread)
 {
     ST_SWITCH_OUT_CB(thread);
 
-    if (!MD_SETJMP((thread)->context)) {
+    if (!_st_md_cxt_save(thread->context)) {
         _st_vp_schedule();
     }
 
@@ -46,6 +46,6 @@ void _st_switch_context(_st_thread_t *thread)
 void _st_restore_context(_st_thread_t *thread)
 {
     _st_this_thread = thread;
-    MD_LONGJMP(thread->context, 1);
+    _st_md_cxt_restore(thread->context, 1);
 }
 

--- a/trunk/3rdparty/st-srs/common.c
+++ b/trunk/3rdparty/st-srs/common.c
@@ -31,3 +31,21 @@ void st_clist_insert_after(_st_clist_t *e, _st_clist_t *l)
     l->next = e;
 }
 
+void _st_switch_context(_st_thread_t *thread)
+{
+    ST_SWITCH_OUT_CB(thread);
+
+    if (!MD_SETJMP((thread)->context)) {
+        _st_vp_schedule();
+    }
+
+    ST_DEBUG_ITERATE_THREADS();
+    ST_SWITCH_IN_CB(thread);
+}
+
+void _st_restore_context(_st_thread_t *thread)
+{
+    _st_this_thread = thread;
+    MD_LONGJMP(thread->context, 1);
+}
+

--- a/trunk/3rdparty/st-srs/common.c
+++ b/trunk/3rdparty/st-srs/common.c
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (c) 2021-2022 The SRS Authors */
+
+#include "common.h"
+
+void st_clist_init(_st_clist_t *l)
+{
+    l->next = l;
+    l->prev = l;
+}
+
+void st_clist_remove(_st_clist_t *e)
+{
+    e->prev->next = e->next;
+    e->next->prev = e->prev;
+}
+
+void st_clist_insert_before(_st_clist_t *e, _st_clist_t *l)
+{
+    e->next = l;
+    e->prev = l->prev;
+    l->prev->next = e;
+    l->prev = e;
+}
+
+void st_clist_insert_after(_st_clist_t *e, _st_clist_t *l)
+{
+    e->next = l->next;
+    e->prev = l;
+    l->next->prev = e;
+    l->next = e;
+}
+

--- a/trunk/3rdparty/st-srs/common.c
+++ b/trunk/3rdparty/st-srs/common.c
@@ -3,34 +3,6 @@
 
 #include "common.h"
 
-void st_clist_init(_st_clist_t *l)
-{
-    l->next = l;
-    l->prev = l;
-}
-
-void st_clist_remove(_st_clist_t *e)
-{
-    e->prev->next = e->next;
-    e->next->prev = e->prev;
-}
-
-void st_clist_insert_before(_st_clist_t *e, _st_clist_t *l)
-{
-    e->next = l;
-    e->prev = l->prev;
-    l->prev->next = e;
-    l->prev = e;
-}
-
-void st_clist_insert_after(_st_clist_t *e, _st_clist_t *l)
-{
-    e->next = l->next;
-    e->prev = l;
-    l->next->prev = e;
-    l->next = e;
-}
-
 void _st_switch_context(_st_thread_t *thread)
 {
     ST_SWITCH_OUT_CB(thread);

--- a/trunk/3rdparty/st-srs/common.h
+++ b/trunk/3rdparty/st-srs/common.h
@@ -332,34 +332,13 @@ extern __thread _st_eventsys_t *_st_eventsys;
  * Switch away from the current thread context by saving its state and
  * calling the thread scheduler
  */
-#define _ST_SWITCH_CONTEXT(_thread)       \
-    ST_BEGIN_MACRO                        \
-    ST_SWITCH_OUT_CB(_thread);            \
-    if (!MD_SETJMP((_thread)->context)) { \
-        _st_vp_schedule();                  \
-    }                                     \
-    ST_DEBUG_ITERATE_THREADS();           \
-    ST_SWITCH_IN_CB(_thread);             \
-    ST_END_MACRO
+void _st_switch_context(_st_thread_t *thread);
 
 /*
- * Restore a thread context that was saved by _ST_SWITCH_CONTEXT or
+ * Restore a thread context that was saved by _st_switch_context or
  * initialized by _ST_INIT_CONTEXT
  */
-#define _ST_RESTORE_CONTEXT(_thread)   \
-    ST_BEGIN_MACRO                     \
-    _st_this_thread = _thread;   \
-    MD_LONGJMP((_thread)->context, 1); \
-    ST_END_MACRO
-
-/*
- * Initialize the thread context preparing it to execute _main
- */
-#ifdef MD_INIT_CONTEXT
-    #define _ST_INIT_CONTEXT MD_INIT_CONTEXT
-#else
-    #error Unknown OS
-#endif
+void _st_restore_context(_st_thread_t *thread);
 
 /*
  * Number of bytes reserved under the stack "bottom"

--- a/trunk/3rdparty/st-srs/common.h
+++ b/trunk/3rdparty/st-srs/common.h
@@ -84,21 +84,21 @@ typedef struct _st_clist {
 } _st_clist_t;
 
 /* Initialize a circular list */
-inline void st_clist_init(_st_clist_t *l)
+static inline void st_clist_init(_st_clist_t *l)
 {
     l->next = l;
     l->prev = l;
 }
 
 /* Remove the element "_e" from it's circular list */
-inline void st_clist_remove(_st_clist_t *e)
+static inline void st_clist_remove(_st_clist_t *e)
 {
     e->prev->next = e->next;
     e->next->prev = e->prev;
 }
 
 /* Insert element "_e" into the list, before "_l" */
-inline void st_clist_insert_before(_st_clist_t *e, _st_clist_t *l)
+static inline void st_clist_insert_before(_st_clist_t *e, _st_clist_t *l)
 {
     e->next = l;
     e->prev = l->prev;
@@ -107,7 +107,7 @@ inline void st_clist_insert_before(_st_clist_t *e, _st_clist_t *l)
 }
 
 /* Insert element "_e" into the list, after "_l" */
-inline void st_clist_insert_after(_st_clist_t *e, _st_clist_t *l)
+static inline void st_clist_insert_after(_st_clist_t *e, _st_clist_t *l)
 {
     e->next = l->next;
     e->prev = l;

--- a/trunk/3rdparty/st-srs/common.h
+++ b/trunk/3rdparty/st-srs/common.h
@@ -235,29 +235,6 @@ extern __thread _st_eventsys_t *_st_eventsys;
 
 
 /*****************************************
- * vp queues operations
- */
-
-#define _ST_ADD_IOQ(_pq)    st_clist_insert_before(&_pq.links, &_st_this_vp.io_q)
-#define _ST_DEL_IOQ(_pq)    st_clist_remove(&_pq.links)
-
-#define _ST_ADD_RUNQ(_thr)  st_clist_insert_before(&(_thr)->links, &_st_this_vp.run_q)
-#define _ST_INSERT_RUNQ(_thr)  st_clist_insert_after(&(_thr)->links, &_st_this_vp.run_q)
-#define _ST_DEL_RUNQ(_thr)  st_clist_remove(&(_thr)->links)
-
-#define _ST_ADD_SLEEPQ(_thr, _timeout)  _st_add_sleep_q(_thr, _timeout)
-#define _ST_DEL_SLEEPQ(_thr)        _st_del_sleep_q(_thr)
-
-#define _ST_ADD_ZOMBIEQ(_thr)  st_clist_insert_before(&(_thr)->links, &_st_this_vp.zombie_q)
-#define _ST_DEL_ZOMBIEQ(_thr)  st_clist_remove(&(_thr)->links)
-
-#ifdef DEBUG
-    #define _ST_ADD_THREADQ(_thr)  st_clist_insert_before(&(_thr)->tlink, &_st_this_vp.thread_q)
-    #define _ST_DEL_THREADQ(_thr)  st_clist_remove(&(_thr)->tlink)
-#endif
-
-
-/*****************************************
  * Thread states and flags
  */
 

--- a/trunk/3rdparty/st-srs/common.h
+++ b/trunk/3rdparty/st-srs/common.h
@@ -73,15 +73,6 @@
 extern "C" {
 #endif
 
-/* merge from https://github.com/toffaletti/state-threads/commit/7f57fc9acc05e657bca1223f1e5b9b1a45ed929b */
-#ifndef MD_VALGRIND
-    #ifndef NVALGRIND
-        #define NVALGRIND
-    #endif
-#else
-    #undef NVALGRIND
-#endif
-
 
 /*****************************************
  * Circular linked list definitions
@@ -121,7 +112,7 @@ typedef struct _st_stack {
     char *stk_top;              /* Highest address of stack's usable portion */
     void *sp;                   /* Stack pointer from C's point of view */
     /* merge from https://github.com/toffaletti/state-threads/commit/7f57fc9acc05e657bca1223f1e5b9b1a45ed929b */
-#ifndef NVALGRIND
+#ifdef MD_VALGRIND
     /* id returned by VALGRIND_STACK_REGISTER */
     /* http://valgrind.org/docs/manual/manual-core-adv.html */
     unsigned long valgrind_stack_id;

--- a/trunk/3rdparty/st-srs/common.h
+++ b/trunk/3rdparty/st-srs/common.h
@@ -343,7 +343,7 @@ void _st_restore_context(_st_thread_t *thread);
 /*
  * Number of bytes reserved under the stack "bottom"
  */
-#define _ST_STACK_PAD_SIZE MD_STACK_PAD_SIZE
+#define _ST_STACK_PAD_SIZE 128
 
 
 /*****************************************

--- a/trunk/3rdparty/st-srs/common.h
+++ b/trunk/3rdparty/st-srs/common.h
@@ -84,16 +84,36 @@ typedef struct _st_clist {
 } _st_clist_t;
 
 /* Initialize a circular list */
-void st_clist_init(_st_clist_t *l);
+inline void st_clist_init(_st_clist_t *l)
+{
+    l->next = l;
+    l->prev = l;
+}
 
 /* Remove the element "_e" from it's circular list */
-void st_clist_remove(_st_clist_t *e);
+inline void st_clist_remove(_st_clist_t *e)
+{
+    e->prev->next = e->next;
+    e->next->prev = e->prev;
+}
 
 /* Insert element "_e" into the list, before "_l" */
-void st_clist_insert_before(_st_clist_t *e, _st_clist_t *l);
+inline void st_clist_insert_before(_st_clist_t *e, _st_clist_t *l)
+{
+    e->next = l;
+    e->prev = l->prev;
+    l->prev->next = e;
+    l->prev = e;
+}
 
 /* Insert element "_e" into the list, after "_l" */
-void st_clist_insert_after(_st_clist_t *e, _st_clist_t *l);
+inline void st_clist_insert_after(_st_clist_t *e, _st_clist_t *l)
+{
+    e->next = l->next;
+    e->prev = l;
+    l->next->prev = e;
+    l->next = e;
+}
 
 
 /*****************************************

--- a/trunk/3rdparty/st-srs/common.h
+++ b/trunk/3rdparty/st-srs/common.h
@@ -233,45 +233,26 @@ extern __thread _st_vp_t        _st_this_vp;
 extern __thread _st_thread_t *_st_this_thread;
 extern __thread _st_eventsys_t *_st_eventsys;
 
-#define _ST_CURRENT_THREAD()            (_st_this_thread)
-#define _ST_SET_CURRENT_THREAD(_thread) (_st_this_thread = (_thread))
-
-#define _ST_LAST_CLOCK                  (_st_this_vp.last_clock)
-
-#define _ST_RUNQ                        (_st_this_vp.run_q)
-#define _ST_IOQ                         (_st_this_vp.io_q)
-#define _ST_ZOMBIEQ                     (_st_this_vp.zombie_q)
-#ifdef DEBUG
-    #define _ST_THREADQ                     (_st_this_vp.thread_q)
-#endif
-
-#define _ST_PAGE_SIZE                   (_st_this_vp.pagesize)
-
-#define _ST_SLEEPQ                      (_st_this_vp.sleep_q)
-#define _ST_SLEEPQ_SIZE                 (_st_this_vp.sleepq_size)
-
-#define _ST_VP_IDLE()                   (*_st_eventsys->dispatch)()
-
 
 /*****************************************
  * vp queues operations
  */
 
-#define _ST_ADD_IOQ(_pq)    st_clist_insert_before(&_pq.links, &_ST_IOQ)
+#define _ST_ADD_IOQ(_pq)    st_clist_insert_before(&_pq.links, &_st_this_vp.io_q)
 #define _ST_DEL_IOQ(_pq)    st_clist_remove(&_pq.links)
 
-#define _ST_ADD_RUNQ(_thr)  st_clist_insert_before(&(_thr)->links, &_ST_RUNQ)
-#define _ST_INSERT_RUNQ(_thr)  st_clist_insert_after(&(_thr)->links, &_ST_RUNQ)
+#define _ST_ADD_RUNQ(_thr)  st_clist_insert_before(&(_thr)->links, &_st_this_vp.run_q)
+#define _ST_INSERT_RUNQ(_thr)  st_clist_insert_after(&(_thr)->links, &_st_this_vp.run_q)
 #define _ST_DEL_RUNQ(_thr)  st_clist_remove(&(_thr)->links)
 
 #define _ST_ADD_SLEEPQ(_thr, _timeout)  _st_add_sleep_q(_thr, _timeout)
 #define _ST_DEL_SLEEPQ(_thr)        _st_del_sleep_q(_thr)
 
-#define _ST_ADD_ZOMBIEQ(_thr)  st_clist_insert_before(&(_thr)->links, &_ST_ZOMBIEQ)
+#define _ST_ADD_ZOMBIEQ(_thr)  st_clist_insert_before(&(_thr)->links, &_st_this_vp.zombie_q)
 #define _ST_DEL_ZOMBIEQ(_thr)  st_clist_remove(&(_thr)->links)
 
 #ifdef DEBUG
-    #define _ST_ADD_THREADQ(_thr)  st_clist_insert_before(&(_thr)->tlink, &_ST_THREADQ)
+    #define _ST_ADD_THREADQ(_thr)  st_clist_insert_before(&(_thr)->tlink, &_st_this_vp.thread_q)
     #define _ST_DEL_THREADQ(_thr)  st_clist_remove(&(_thr)->tlink)
 #endif
 
@@ -390,7 +371,7 @@ extern __thread _st_eventsys_t *_st_eventsys;
  */
 #define _ST_RESTORE_CONTEXT(_thread)   \
     ST_BEGIN_MACRO                     \
-    _ST_SET_CURRENT_THREAD(_thread);   \
+    _st_this_thread = _thread;   \
     MD_LONGJMP((_thread)->context, 1); \
     ST_END_MACRO
 

--- a/trunk/3rdparty/st-srs/docs/timeout_heap.txt
+++ b/trunk/3rdparty/st-srs/docs/timeout_heap.txt
@@ -22,7 +22,7 @@ appropriate for ST than introducing a separate array.
 Thus, the new ST timeout heap works by organizing the existing
 _st_thread_t objects in a balanced binary tree, just as they were
 previously organized into a doubly-linked, sorted list.  The global
-_ST_SLEEPQ variable, formerly a linked list head, is now simply a
+_st_this_vp.sleep_q variable, formerly a linked list head, is now simply a
 pointer to the root of this tree, and the root node of the tree is the
 thread with the earliest timeout.  Each thread object has two child
 pointers, "left" and "right", pointing to threads with later timeouts.

--- a/trunk/3rdparty/st-srs/event.c
+++ b/trunk/3rdparty/st-srs/event.c
@@ -254,7 +254,7 @@ ST_HIDDEN void _st_select_find_bad_fd(void)
         }
 
         if (notify) {
-            ST_REMOVE_LINK(&pq->links);
+            st_clist_remove(&pq->links);
             pq->on_ioq = 0;
             /*
              * Decrement the count of descriptors for each descriptor/event
@@ -359,7 +359,7 @@ ST_HIDDEN void _st_select_dispatch(void)
                 }
             }
             if (notify) {
-                ST_REMOVE_LINK(&pq->links);
+                st_clist_remove(&pq->links);
                 pq->on_ioq = 0;
                 /*
                  * Decrement the count of descriptors for each descriptor/event
@@ -756,7 +756,7 @@ ST_HIDDEN void _st_kq_dispatch(void)
                 }
             }
             if (notify) {
-                ST_REMOVE_LINK(&pq->links);
+                st_clist_remove(&pq->links);
                 pq->on_ioq = 0;
                 for (pds = pq->pds; pds < epds; pds++) {
                     osfd = pds->fd;
@@ -1135,7 +1135,7 @@ ST_HIDDEN void _st_epoll_dispatch(void)
                 }
             }
             if (notify) {
-                ST_REMOVE_LINK(&pq->links);
+                st_clist_remove(&pq->links);
                 pq->on_ioq = 0;
                 /*
                  * Here we will only delete/modify descriptors that

--- a/trunk/3rdparty/st-srs/event.c
+++ b/trunk/3rdparty/st-srs/event.c
@@ -233,7 +233,7 @@ ST_HIDDEN void _st_select_find_bad_fd(void)
 
     _ST_SELECT_MAX_OSFD = -1;
 
-    for (q = _ST_IOQ.next; q != &_ST_IOQ; q = q->next) {
+    for (q = _st_this_vp.io_q.next; q != &_st_this_vp.io_q; q = q->next) {
         pq = _ST_POLLQUEUE_PTR(q);
         notify = 0;
         epds = pq->pds + pq->npds;
@@ -315,11 +315,11 @@ ST_HIDDEN void _st_select_dispatch(void)
     wp = &w;
     ep = &e;
 
-    if (_ST_SLEEPQ == NULL) {
+    if (_st_this_vp.sleep_q == NULL) {
         tvp = NULL;
     } else {
-        min_timeout = (_ST_SLEEPQ->due <= _ST_LAST_CLOCK) ? 0 :
-                      (_ST_SLEEPQ->due - _ST_LAST_CLOCK);
+        min_timeout = (_st_this_vp.sleep_q->due <= _st_this_vp.last_clock) ? 0 :
+                      (_st_this_vp.sleep_q->due - _st_this_vp.last_clock);
         timeout.tv_sec  = (int) (min_timeout / 1000000);
         timeout.tv_usec = (int) (min_timeout % 1000000);
         tvp = &timeout;
@@ -331,7 +331,7 @@ ST_HIDDEN void _st_select_dispatch(void)
     /* Notify threads that are associated with the selected descriptors */
     if (nfd > 0) {
         _ST_SELECT_MAX_OSFD = -1;
-        for (q = _ST_IOQ.next; q != &_ST_IOQ; q = q->next) {
+        for (q = _st_this_vp.io_q.next; q != &_st_this_vp.io_q; q = q->next) {
             pq = _ST_POLLQUEUE_PTR(q);
             notify = 0;
             epds = pq->pds + pq->npds;
@@ -697,10 +697,10 @@ ST_HIDDEN void _st_kq_dispatch(void)
     int nfd, i, osfd, notify, filter;
     short events, revents;
 
-    if (_ST_SLEEPQ == NULL) {
+    if (_st_this_vp.sleep_q == NULL) {
         tsp = NULL;
     } else {
-        min_timeout = (_ST_SLEEPQ->due <= _ST_LAST_CLOCK) ? 0 : (_ST_SLEEPQ->due - _ST_LAST_CLOCK);
+        min_timeout = (_st_this_vp.sleep_q->due <= _st_this_vp.last_clock) ? 0 : (_st_this_vp.sleep_q->due - _st_this_vp.last_clock);
         timeout.tv_sec  = (time_t) (min_timeout / 1000000);
         timeout.tv_nsec = (long) ((min_timeout % 1000000) * 1000);
         tsp = &timeout;
@@ -735,7 +735,7 @@ ST_HIDDEN void _st_kq_dispatch(void)
 
         _st_kq_data->dellist_cnt = 0;
 
-        for (q = _ST_IOQ.next; q != &_ST_IOQ; q = q->next) {
+        for (q = _st_this_vp.io_q.next; q != &_st_this_vp.io_q; q = q->next) {
             pq = _ST_POLLQUEUE_PTR(q);
             notify = 0;
             epds = pq->pds + pq->npds;
@@ -811,7 +811,7 @@ ST_HIDDEN void _st_kq_dispatch(void)
             _st_kq_data->pid = getpid();
             /* Re-register all descriptors on ioq with new kqueue */
             memset(_st_kq_data->fd_data, 0, _st_kq_data->fd_data_size * sizeof(_kq_fd_data_t));
-            for (q = _ST_IOQ.next; q != &_ST_IOQ; q = q->next) {
+            for (q = _st_this_vp.io_q.next; q != &_st_this_vp.io_q; q = q->next) {
                 pq = _ST_POLLQUEUE_PTR(q);
                 _st_kq_pollset_add(pq->pds, pq->npds);
             }
@@ -1064,10 +1064,10 @@ ST_HIDDEN void _st_epoll_dispatch(void)
     ++_st_stat_epoll;
     #endif
 
-    if (_ST_SLEEPQ == NULL) {
+    if (_st_this_vp.sleep_q == NULL) {
         timeout = -1;
     } else {
-        min_timeout = (_ST_SLEEPQ->due <= _ST_LAST_CLOCK) ? 0 : (_ST_SLEEPQ->due - _ST_LAST_CLOCK);
+        min_timeout = (_st_this_vp.sleep_q->due <= _st_this_vp.last_clock) ? 0 : (_st_this_vp.sleep_q->due - _st_this_vp.last_clock);
         timeout = (int) (min_timeout / 1000);
 
         // At least wait 1ms when <1ms, to avoid epoll_wait spin loop.
@@ -1105,7 +1105,7 @@ ST_HIDDEN void _st_epoll_dispatch(void)
             }
         }
 
-        for (q = _ST_IOQ.next; q != &_ST_IOQ; q = q->next) {
+        for (q = _st_this_vp.io_q.next; q != &_st_this_vp.io_q; q = q->next) {
             pq = _ST_POLLQUEUE_PTR(q);
             notify = 0;
             epds = pq->pds + pq->npds;

--- a/trunk/3rdparty/st-srs/event.c
+++ b/trunk/3rdparty/st-srs/event.c
@@ -281,9 +281,9 @@ ST_HIDDEN void _st_select_find_bad_fd(void)
             }
 
             if (pq->thread->flags & _ST_FL_ON_SLEEPQ)
-                _ST_DEL_SLEEPQ(pq->thread);
+                _st_del_sleep_q(pq->thread);
             pq->thread->state = _ST_ST_RUNNABLE;
-            _ST_ADD_RUNQ(pq->thread);
+            st_clist_insert_before(&pq->thread->links, &_st_this_vp.run_q);
         } else {
             if (_ST_SELECT_MAX_OSFD < pq_max_osfd)
                 _ST_SELECT_MAX_OSFD = pq_max_osfd;
@@ -386,9 +386,9 @@ ST_HIDDEN void _st_select_dispatch(void)
                 }
 
                 if (pq->thread->flags & _ST_FL_ON_SLEEPQ)
-                    _ST_DEL_SLEEPQ(pq->thread);
+                    _st_del_sleep_q(pq->thread);
                 pq->thread->state = _ST_ST_RUNNABLE;
-                _ST_ADD_RUNQ(pq->thread);
+                st_clist_insert_before(&pq->thread->links, &_st_this_vp.run_q);
             } else {
                 if (_ST_SELECT_MAX_OSFD < pq_max_osfd)
                     _ST_SELECT_MAX_OSFD = pq_max_osfd;
@@ -782,9 +782,9 @@ ST_HIDDEN void _st_kq_dispatch(void)
                 }
 
                 if (pq->thread->flags & _ST_FL_ON_SLEEPQ)
-                    _ST_DEL_SLEEPQ(pq->thread);
+                    _st_del_sleep_q(pq->thread);
                 pq->thread->state = _ST_ST_RUNNABLE;
-                _ST_ADD_RUNQ(pq->thread);
+                st_clist_insert_before(&pq->thread->links, &_st_this_vp.run_q);
             }
         }
 
@@ -1144,9 +1144,9 @@ ST_HIDDEN void _st_epoll_dispatch(void)
                 _st_epoll_pollset_del(pq->pds, pq->npds);
 
                 if (pq->thread->flags & _ST_FL_ON_SLEEPQ)
-                    _ST_DEL_SLEEPQ(pq->thread);
+                    _st_del_sleep_q(pq->thread);
                 pq->thread->state = _ST_ST_RUNNABLE;
-                _ST_ADD_RUNQ(pq->thread);
+                st_clist_insert_before(&pq->thread->links, &_st_this_vp.run_q);
             }
         }
 

--- a/trunk/3rdparty/st-srs/key.c
+++ b/trunk/3rdparty/st-srs/key.c
@@ -78,7 +78,7 @@ int st_key_getlimit(void)
 
 int st_thread_setspecific(int key, void *value)
 {
-    _st_thread_t *me = _ST_CURRENT_THREAD();
+    _st_thread_t *me = _st_this_thread;
     return st_thread_setspecific2(me, key, value);
 }
 
@@ -107,7 +107,7 @@ void *st_thread_getspecific(int key)
     if (key < 0 || key >= key_max)
         return NULL;
     
-    return ((_ST_CURRENT_THREAD())->private_data[key]);
+    return _st_this_thread->private_data[key];
 }
 
 

--- a/trunk/3rdparty/st-srs/md.h
+++ b/trunk/3rdparty/st-srs/md.h
@@ -102,13 +102,6 @@ extern void _st_md_cxt_restore(_st_jmp_buf_t env, int val);
     #else
         #error Unknown CPU architecture
     #endif
-    
-    #define MD_INIT_CONTEXT(_thread, _sp, _main) \
-        ST_BEGIN_MACRO                             \
-        if (MD_SETJMP((_thread)->context))         \
-            _main();                                 \
-        MD_GET_SP(_thread) = (long) (_sp);         \
-        ST_END_MACRO
 
     #define MD_GET_UTIME()            \
         struct timeval tv;              \
@@ -161,14 +154,7 @@ extern void _st_md_cxt_restore(_st_jmp_buf_t env, int val);
         #define MD_GET_SP(_t) *((long *)&((_t)->context[0].__jmpbuf[0]))
     #else
         #error "Unknown CPU architecture"
-    #endif /* Cases with common MD_INIT_CONTEXT and different SP locations */
-
-    #define MD_INIT_CONTEXT(_thread, _sp, _main) \
-        ST_BEGIN_MACRO                             \
-        if (MD_SETJMP((_thread)->context))         \
-            _main();                                 \
-        MD_GET_SP(_thread) = (long) (_sp);         \
-        ST_END_MACRO
+    #endif
 
 #elif defined (CYGWIN64)
 
@@ -184,13 +170,6 @@ extern void _st_md_cxt_restore(_st_jmp_buf_t env, int val);
     #else
         #error Unknown CPU architecture
     #endif
-
-    #define MD_INIT_CONTEXT(_thread, _sp, _main) \
-        ST_BEGIN_MACRO                             \
-        if (MD_SETJMP((_thread)->context))         \
-            _main();                                 \
-        MD_GET_SP(_thread) = (long) (_sp);         \
-        ST_END_MACRO
 
     #define MD_GET_UTIME()            \
         struct timeval tv;              \

--- a/trunk/3rdparty/st-srs/md.h
+++ b/trunk/3rdparty/st-srs/md.h
@@ -176,10 +176,6 @@ extern void _st_md_cxt_restore(_st_jmp_buf_t env, int val);
     #error Unknown OS
 #endif /* OS */
 
-#ifndef MD_STACK_PAD_SIZE
-    #define MD_STACK_PAD_SIZE 128
-#endif
-
 #if !defined(MD_HAVE_SOCKLEN_T) && !defined(socklen_t)
     #define socklen_t int
 #endif

--- a/trunk/3rdparty/st-srs/md.h
+++ b/trunk/3rdparty/st-srs/md.h
@@ -74,13 +74,11 @@ typedef struct _st_jmp_buf {
     long __jmpbuf[22];
 } _st_jmp_buf_t[1];
 
+/* Defined in *.S file and implemented by ASM. */
 extern int _st_md_cxt_save(_st_jmp_buf_t env);
 extern void _st_md_cxt_restore(_st_jmp_buf_t env, int val);
 
 /* Always use builtin setjmp/longjmp, use asm code. */
-#define MD_USE_BUILTIN_SETJMP
-#define MD_SETJMP(env) _st_md_cxt_save(env)
-#define MD_LONGJMP(env, val) _st_md_cxt_restore(env, val)
 #if defined(USE_LIBC_SETJMP)
 #error The libc setjmp is not supported now
 #endif
@@ -162,8 +160,6 @@ extern void _st_md_cxt_restore(_st_jmp_buf_t env, int val);
     #define MD_USE_BSD_ANON_MMAP
     #define MD_ACCEPT_NB_INHERITED
     #define MD_HAVE_SOCKLEN_T
-
-    #define MD_USE_BUILTIN_SETJMP
 
     #if defined(__amd64__) || defined(__x86_64__)
         #define MD_GET_SP(_t) *((long *)&((_t)->context[0].__jmpbuf[6]))

--- a/trunk/3rdparty/st-srs/sched.c
+++ b/trunk/3rdparty/st-srs/sched.c
@@ -50,7 +50,7 @@
 #include "common.h"
 
 /* merge from https://github.com/toffaletti/state-threads/commit/7f57fc9acc05e657bca1223f1e5b9b1a45ed929b */
-#ifndef NVALGRIND
+#ifdef MD_VALGRIND
 #include <valgrind/valgrind.h>
 #endif
 
@@ -310,7 +310,7 @@ void st_thread_exit(void *retval)
 #endif
     
     /* merge from https://github.com/toffaletti/state-threads/commit/7f57fc9acc05e657bca1223f1e5b9b1a45ed929b */
-#ifndef NVALGRIND
+#ifdef MD_VALGRIND
     if (!(thread->flags & _ST_FL_PRIMORDIAL)) {
         VALGRIND_STACK_DEREGISTER(thread->stack->valgrind_stack_id);
     }
@@ -686,7 +686,7 @@ _st_thread_t *st_thread_create(void *(*start)(void *arg), void *arg, int joinabl
 #endif
     
     /* merge from https://github.com/toffaletti/state-threads/commit/7f57fc9acc05e657bca1223f1e5b9b1a45ed929b */
-#ifndef NVALGRIND
+#ifdef MD_VALGRIND
     if (!(thread->flags & _ST_FL_PRIMORDIAL)) {
         thread->stack->valgrind_stack_id = VALGRIND_STACK_REGISTER(thread->stack->stk_top, thread->stack->stk_bottom);
     }

--- a/trunk/3rdparty/st-srs/sched.c
+++ b/trunk/3rdparty/st-srs/sched.c
@@ -182,16 +182,16 @@ int st_init(void)
         return -1;
 
     // Initialize the thread-local variables.
-    ST_INIT_CLIST(&_st_free_stacks);
+    st_clist_init(&_st_free_stacks);
 
     // Initialize ST.
     memset(&_st_this_vp, 0, sizeof(_st_vp_t));
     
-    ST_INIT_CLIST(&_ST_RUNQ);
-    ST_INIT_CLIST(&_ST_IOQ);
-    ST_INIT_CLIST(&_ST_ZOMBIEQ);
+    st_clist_init(&_ST_RUNQ);
+    st_clist_init(&_ST_IOQ);
+    st_clist_init(&_ST_ZOMBIEQ);
 #ifdef DEBUG
-    ST_INIT_CLIST(&_ST_THREADQ);
+    st_clist_init(&_ST_THREADQ);
 #endif
     
     if ((*_st_eventsys->init)() < 0)

--- a/trunk/3rdparty/st-srs/stk.c
+++ b/trunk/3rdparty/st-srs/stk.c
@@ -71,7 +71,7 @@ _st_stack_t *_st_stack_new(int stack_size)
         ts = _ST_THREAD_STACK_PTR(qp);
         if (ts->stk_size >= stack_size) {
             /* Found a stack that is big enough */
-            ST_REMOVE_LINK(&ts->links);
+            st_clist_remove(&ts->links);
             _st_num_free_stacks--;
             ts->links.next = NULL;
             ts->links.prev = NULL;
@@ -90,7 +90,7 @@ _st_stack_t *_st_stack_new(int stack_size)
         /* Before qp is freed, move to next one, because the qp will be freed when free the ts. */
         qp = qp->next;
 
-        ST_REMOVE_LINK(&ts->links);
+        st_clist_remove(&ts->links);
         _st_num_free_stacks--;
 
 #if defined(DEBUG) && !defined(MD_NO_PROTECT)
@@ -142,7 +142,7 @@ void _st_stack_free(_st_stack_t *ts)
         return;
 
     /* Put the stack on the free list */
-    ST_APPEND_LINK(&ts->links, _st_free_stacks.prev);
+    st_clist_insert_before(&ts->links, _st_free_stacks.prev);
     _st_num_free_stacks++;
 }
 

--- a/trunk/3rdparty/st-srs/stk.c
+++ b/trunk/3rdparty/st-srs/stk.c
@@ -50,7 +50,7 @@
 
 
 /* How much space to leave between the stacks, at each end */
-#define REDZONE	_ST_PAGE_SIZE
+#define REDZONE	_st_this_vp.pagesize
 
 __thread _st_clist_t _st_free_stacks;
 __thread int _st_num_free_stacks = 0;
@@ -80,7 +80,7 @@ _st_stack_t *_st_stack_new(int stack_size)
     }
 #endif
 
-    extra = _st_randomize_stacks ? _ST_PAGE_SIZE : 0;
+    extra = _st_randomize_stacks ? _st_this_vp.pagesize : 0;
     /* If not cache stack, we will free all stack in the list, which contains the stack to be freed.
      * Note that we should never directly free it at _st_stack_free, because it is still be used,
      * and will cause crash. */

--- a/trunk/3rdparty/st-srs/sync.c
+++ b/trunk/3rdparty/st-srs/sync.c
@@ -130,7 +130,7 @@ int st_usleep(st_utime_t usecs)
     } else
         me->state = _ST_ST_SUSPENDED;
     
-    _ST_SWITCH_CONTEXT(me);
+    _st_switch_context(me);
     
     if (me->flags & _ST_FL_INTERRUPT) {
         me->flags &= ~_ST_FL_INTERRUPT;
@@ -196,7 +196,7 @@ int st_cond_timedwait(_st_cond_t *cvar, st_utime_t timeout)
     if (timeout != ST_UTIME_NO_TIMEOUT)
         _st_add_sleep_q(me, timeout);
     
-    _ST_SWITCH_CONTEXT(me);
+    _st_switch_context(me);
     
     st_clist_remove(&me->wait_links);
     rv = 0;
@@ -313,7 +313,7 @@ int st_mutex_lock(_st_mutex_t *lock)
     me->state = _ST_ST_LOCK_WAIT;
     st_clist_insert_before(&me->wait_links, &lock->wait_q);
     
-    _ST_SWITCH_CONTEXT(me);
+    _st_switch_context(me);
     
     st_clist_remove(&me->wait_links);
     

--- a/trunk/3rdparty/st-srs/sync.c
+++ b/trunk/3rdparty/st-srs/sync.c
@@ -87,7 +87,7 @@ int st_set_utime_function(st_utime_t (*func)(void))
 
 st_utime_t st_utime_last_clock(void)
 {
-    return _ST_LAST_CLOCK;
+    return _st_this_vp.last_clock;
 }
 
 
@@ -116,7 +116,7 @@ time_t st_time(void)
 
 int st_usleep(st_utime_t usecs)
 {
-    _st_thread_t *me = _ST_CURRENT_THREAD();
+    _st_thread_t *me = _st_this_thread;
     
     if (me->flags & _ST_FL_INTERRUPT) {
         me->flags &= ~_ST_FL_INTERRUPT;
@@ -180,7 +180,7 @@ int st_cond_destroy(_st_cond_t *cvar)
 
 int st_cond_timedwait(_st_cond_t *cvar, st_utime_t timeout)
 {
-    _st_thread_t *me = _ST_CURRENT_THREAD();
+    _st_thread_t *me = _st_this_thread;
     int rv;
     
     if (me->flags & _ST_FL_INTERRUPT) {
@@ -290,7 +290,7 @@ int st_mutex_destroy(_st_mutex_t *lock)
 
 int st_mutex_lock(_st_mutex_t *lock)
 {
-    _st_thread_t *me = _ST_CURRENT_THREAD();
+    _st_thread_t *me = _st_this_thread;
     
     if (me->flags & _ST_FL_INTERRUPT) {
         me->flags &= ~_ST_FL_INTERRUPT;
@@ -332,7 +332,7 @@ int st_mutex_unlock(_st_mutex_t *lock)
     _st_thread_t *thread;
     _st_clist_t *q;
     
-    if (lock->owner != _ST_CURRENT_THREAD()) {
+    if (lock->owner != _st_this_thread) {
         errno = EPERM;
         return -1;
     }
@@ -363,7 +363,7 @@ int st_mutex_trylock(_st_mutex_t *lock)
     }
     
     /* Got the mutex */
-    lock->owner = _ST_CURRENT_THREAD();
+    lock->owner = _st_this_thread;
     
     return 0;
 }

--- a/trunk/configure
+++ b/trunk/configure
@@ -128,7 +128,7 @@ fi
 
 # Start to generate the Makefile.
 cat << END >> ${SRS_OBJS}/Makefile
-GCC = ${SRS_TOOL_CC}
+CC = ${SRS_TOOL_CC}
 CXX = ${SRS_TOOL_CXX}
 AR = ${SRS_TOOL_AR}
 LINK = ${SRS_TOOL_CXX}
@@ -514,7 +514,7 @@ cat << END > ${SRS_MAKEFILE}
 .PHONY: clean_srs clean_modules clean_openssl clean_srtp2 clean_opus clean_ffmpeg clean_st
 .PHONY: st ffmpeg
 
-GCC = ${SRS_TOOL_CC}
+CC = ${SRS_TOOL_CC}
 CXX = ${SRS_TOOL_CXX}
 AR = ${SRS_TOOL_AR}
 LINK = ${SRS_TOOL_LD}
@@ -606,7 +606,7 @@ clean_st:
 st:
 	@rm -f ${SRS_OBJS}/srs srs_utest
 	@\$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/st-srs clean
-	@env EXTRA_CFLAGS="${_ST_EXTRA_CFLAGS}" \$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/st-srs ${_ST_MAKE_ARGS} CC=\$(GCC) AR=\$(AR) LD=\$(LINK) RANDLIB=\$(RANDLIB)
+	@env EXTRA_CFLAGS="${_ST_EXTRA_CFLAGS}" \$(MAKE)\$(JOBS) -C ${SRS_OBJS}/${SRS_PLATFORM}/st-srs ${_ST_MAKE_ARGS} CC=\$(CC) CXX=\$(CXX) AR=\$(AR) LD=\$(LINK) RANDLIB=\$(RANDLIB)
 	@echo "Please rebuild srs by: make"
 
 ffmpeg:

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2024-08-21, Merge [#4149](https://github.com/ossrs/srs/pull/4149): ST: Replace macros with explicit code for better understanding. v7.0.7 (#4149)
 * v7.0, 2024-08-21, Merge [#4150](https://github.com/ossrs/srs/pull/4150): API: Support new HTTP API for VALGRIND. v7.0.6 (#4150)
 * v7.0, 2024-08-15, Merge [#4144](https://github.com/ossrs/srs/pull/4144): HTTP-FLV: Crash when multiple viewers. v7.0.5 (#4144)
 * v7.0, 2024-08-15, Merge [#4142](https://github.com/ossrs/srs/pull/4142): Config: Add more utest for env config. v7.0.4 (#4142)

--- a/trunk/research/st/.gitignore
+++ b/trunk/research/st/.gitignore
@@ -3,3 +3,10 @@ udp-client
 cost
 cost.log
 thread-join
+st-cond
+hello-st
+hello-world
+huge-threads
+exceptions
+hello
+pthreads

--- a/trunk/research/st/st-cond.cpp
+++ b/trunk/research/st/st-cond.cpp
@@ -1,0 +1,26 @@
+/*
+g++ st-cond.cpp ../../objs/st/libst.a -g -O0 -o st-cond && ./st-cond
+*/
+#include <stdio.h>
+#include "../../objs/st/st.h"
+
+st_cond_t lock;
+
+void* foo(void*) {
+    st_cond_wait(lock);
+    printf("Hello World, ST!\n");
+    return NULL;
+}
+
+int main() {
+    st_init();
+    lock = st_cond_new();
+
+    st_thread_create(foo, NULL, 0, 0);
+    st_sleep(1);
+    st_cond_signal(lock);
+    st_sleep(1);
+
+    st_cond_destroy(lock);
+    return 0;
+}

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       7
 #define VERSION_MINOR       0
-#define VERSION_REVISION    6
+#define VERSION_REVISION    7
 
 #endif


### PR DESCRIPTION
Improvements for ST(State Threads):

1. ST: Use g++ for CXX compiler.
2. ST: Remove macros for clist.
3. ST: Remove macros for global thread and vp.
4. ST: Remove macros for vp queue operations.
5. ST: Remove macros for context switch.
6. ST: Remove macros for setjmp/longjmp.
7. ST: Remove macro for stack pad.
8. ST: Refine macro for valgrind.

---------

Co-authored-by: Jacob Su <suzp1984@gmail.com>