### PR TITLE
API: Support new HTTP API for VALGRIND. v6.0.149 v7.0.6

### DIFF
--- a/trunk/auto/auto_headers.sh
+++ b/trunk/auto/auto_headers.sh
@@ -171,6 +171,11 @@ if [ $SRS_SANITIZER_LOG == YES ]; then
 else
     srs_undefine_macro "SRS_SANITIZER_LOG" $SRS_AUTO_HEADERS_H
 fi
+if [ $SRS_VALGRIND == YES ]; then
+    srs_define_macro "SRS_VALGRIND" $SRS_AUTO_HEADERS_H
+else
+    srs_undefine_macro "SRS_VALGRIND" $SRS_AUTO_HEADERS_H
+fi
 
 #####################################################################################
 # for embeded.

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2024-08-21, Merge [#4150](https://github.com/ossrs/srs/pull/4150): API: Support new HTTP API for VALGRIND. v7.0.6 (#4150)
 * v7.0, 2024-08-15, Merge [#4144](https://github.com/ossrs/srs/pull/4144): HTTP-FLV: Crash when multiple viewers. v7.0.5 (#4144)
 * v7.0, 2024-08-15, Merge [#4142](https://github.com/ossrs/srs/pull/4142): Config: Add more utest for env config. v7.0.4 (#4142)
 * v7.0, 2024-08-14, Merge [#4141](https://github.com/ossrs/srs/pull/4141): Live: Crash for invalid live stream state when unmount HTTP. v7.0.3 (#4141)
@@ -17,6 +18,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-08-21, Merge [#4150](https://github.com/ossrs/srs/pull/4150): API: Support new HTTP API for VALGRIND. v6.0.149 (#4150)
 * v6.0, 2024-08-15, Merge [#4144](https://github.com/ossrs/srs/pull/4144): HTTP-FLV: Crash when multiple viewers. v6.0.148 (#4144)
 * v6.0, 2024-08-15, Merge [#4142](https://github.com/ossrs/srs/pull/4142): Config: Add more utest for env config. v6.0.147 (#4142)
 * v6.0, 2024-08-14, Merge [#4141](https://github.com/ossrs/srs/pull/4141): Live: Crash for invalid live stream state when unmount HTTP. v6.0.146 (#4141)

--- a/trunk/src/app/srs_app_gb28181.hpp
+++ b/trunk/src/app/srs_app_gb28181.hpp
@@ -188,7 +188,7 @@ public:
     void on_media_transport(SrsSharedResource<SrsGbMediaTcpConn> media);
     // Get the candidate for SDP generation, the public IP address for device to connect to.
     std::string pip();
-// Interface ISrsOneCycleThreadHandler
+// Interface ISrsCoroutineHandler
 public:
     virtual srs_error_t cycle();
 private:
@@ -305,7 +305,7 @@ private:
 public:
     virtual const SrsContextId& get_id();
     virtual std::string desc();
-// Interface ISrsOneCycleThreadHandler
+// Interface ISrsCoroutineHandler
 public:
     virtual srs_error_t cycle();
 private:
@@ -333,7 +333,7 @@ public:
 // Interface ISrsStartable
 public:
     virtual srs_error_t start();
-// Interface ISrsOneCycleThreadHandler
+// Interface ISrsCoroutineHandler
 public:
     virtual srs_error_t cycle();
 private:
@@ -362,7 +362,7 @@ public:
 // Interface ISrsStartable
 public:
     virtual srs_error_t start();
-// Interface ISrsOneCycleThreadHandler
+// Interface ISrsCoroutineHandler
 public:
     virtual srs_error_t cycle();
 private:
@@ -422,7 +422,7 @@ public:
 public:
     virtual const SrsContextId& get_id();
     virtual std::string desc();
-// Interface ISrsOneCycleThreadHandler
+// Interface ISrsCoroutineHandler
 public:
     virtual srs_error_t cycle();
 private:

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -1118,18 +1118,28 @@ srs_error_t SrsGoApiValgrind::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMess
     SrsUniquePtr<SrsJsonObject> obj(SrsJsonAny::object());
 
     obj->set("code", SrsJsonAny::integer(ERROR_SUCCESS));
-    obj->set("data", SrsJsonAny::null());
+
+    SrsJsonObject* res = SrsJsonAny::object();
+    res->set("check", SrsJsonAny::str(check.c_str()));
+    res->set("help", SrsJsonAny::str("?check=full|added|changed|new|quick"));
+    res->set("see", SrsJsonAny::str("https://valgrind.org/docs/manual/mc-manual.html"));
+    obj->set("data", res);
 
     // Does a full memory check right now.
     if (check == "full") {
+        res->set("call", SrsJsonAny::str("VALGRIND_DO_LEAK_CHECK"));
         VALGRIND_DO_LEAK_CHECK;
     } else if (check == "quick") {
+        res->set("call", SrsJsonAny::str("VALGRIND_DO_QUICK_LEAK_CHECK"));
         VALGRIND_DO_QUICK_LEAK_CHECK;
     } else if (check == "added") {
+        res->set("call", SrsJsonAny::str("VALGRIND_DO_ADDED_LEAK_CHECK"));
         VALGRIND_DO_ADDED_LEAK_CHECK;
     } else if (check == "changed") {
+        res->set("call", SrsJsonAny::str("VALGRIND_DO_CHANGED_LEAK_CHECK"));
         VALGRIND_DO_CHANGED_LEAK_CHECK;
     } else if (check == "new") {
+        res->set("call", SrsJsonAny::str("VALGRIND_DO_NEW_LEAK_CHECK"));
         VALGRIND_DO_NEW_LEAK_CHECK;
     }
 

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -31,6 +31,11 @@ using namespace std;
 #include <srs_protocol_utility.hpp>
 #include <srs_app_coworkers.hpp>
 
+#ifdef SRS_VALGRIND
+#include <valgrind/valgrind.h>
+#include <valgrind/memcheck.h>
+#endif
+
 #if defined(__linux__) || defined(SRS_OSX)
 #include <sys/utsname.h>
 #endif
@@ -1092,8 +1097,6 @@ srs_error_t SrsGoApiTcmalloc::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMess
 #endif
 
 #ifdef SRS_VALGRIND
-#include <valgrind/valgrind.h>
-#include <valgrind/memcheck.h>
 
 SrsGoApiValgrind::SrsGoApiValgrind()
 {

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -267,6 +267,7 @@ srs_error_t SrsGoApiV1::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r
     urls->set("clusters", SrsJsonAny::str("origin cluster server API"));
     urls->set("perf", SrsJsonAny::str("System performance stat"));
     urls->set("tcmalloc", SrsJsonAny::str("tcmalloc api with params ?page=summary|api"));
+    urls->set("valgrind", SrsJsonAny::str("valgrind api to call VALGRIND_DO_LEAK_CHECK"));
 
     SrsJsonObject* tests = SrsJsonAny::object();
     obj->set("tests", tests);
@@ -1090,6 +1091,34 @@ srs_error_t SrsGoApiTcmalloc::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMess
 }
 #endif
 
+#ifdef SRS_VALGRIND
+#include <valgrind/valgrind.h>
+#include <valgrind/memcheck.h>
+
+SrsGoApiValgrind::SrsGoApiValgrind()
+{
+}
+
+SrsGoApiValgrind::~SrsGoApiValgrind()
+{
+}
+
+srs_error_t SrsGoApiValgrind::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r)
+{
+    srs_error_t err = srs_success;
+
+    // By default, response the json style response.
+    SrsUniquePtr<SrsJsonObject> obj(SrsJsonAny::object());
+
+    obj->set("code", SrsJsonAny::integer(ERROR_SUCCESS));
+    obj->set("data", SrsJsonAny::null());
+
+    // Does a full memory check right now.
+    VALGRIND_DO_LEAK_CHECK;
+
+    return srs_api_response(w, r, obj->dumps());
+}
+#endif
 
 SrsGoApiMetrics::SrsGoApiMetrics()
 {

--- a/trunk/src/app/srs_app_http_api.hpp
+++ b/trunk/src/app/srs_app_http_api.hpp
@@ -216,6 +216,17 @@ public:
 };
 #endif
 
+#ifdef SRS_VALGRIND
+class SrsGoApiValgrind : public ISrsHttpHandler
+{
+public:
+    SrsGoApiValgrind();
+    virtual ~SrsGoApiValgrind();
+public:
+    virtual srs_error_t serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r);
+};
+#endif
+
 class SrsGoApiMetrics : public ISrsHttpHandler
 {
 private:

--- a/trunk/src/app/srs_app_http_api.hpp
+++ b/trunk/src/app/srs_app_http_api.hpp
@@ -217,13 +217,19 @@ public:
 #endif
 
 #ifdef SRS_VALGRIND
-class SrsGoApiValgrind : public ISrsHttpHandler
+class SrsGoApiValgrind : public ISrsHttpHandler, public ISrsCoroutineHandler
 {
+private:
+    SrsCoroutine* trd_;
+    std::string task_;
 public:
     SrsGoApiValgrind();
     virtual ~SrsGoApiValgrind();
 public:
     virtual srs_error_t serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r);
+// Interface ISrsCoroutineHandler
+public:
+    virtual srs_error_t cycle();
 };
 #endif
 

--- a/trunk/src/app/srs_app_http_conn.hpp
+++ b/trunk/src/app/srs_app_http_conn.hpp
@@ -94,7 +94,7 @@ public:
 // Interface ISrsStartable
 public:
     virtual srs_error_t start();
-// Interface ISrsOneCycleThreadHandler
+// Interface ISrsCoroutineHandler
 public:
     virtual srs_error_t cycle();
 private:

--- a/trunk/src/app/srs_app_recv_thread.hpp
+++ b/trunk/src/app/srs_app_recv_thread.hpp
@@ -204,7 +204,7 @@ public:
     virtual srs_error_t start();
 public:
     virtual srs_error_t pull();
-// Interface ISrsOneCycleThreadHandler
+// Interface ISrsCoroutineHandler
 public:
     virtual srs_error_t cycle();
 };

--- a/trunk/src/app/srs_app_rtmp_conn.hpp
+++ b/trunk/src/app/srs_app_rtmp_conn.hpp
@@ -181,7 +181,7 @@ public:
     // when client cycle thread stop, invoke the on_thread_stop(), which will use server
     // To remove the client by server->remove(this).
     virtual srs_error_t start();
-// Interface ISrsOneCycleThreadHandler
+// Interface ISrsCoroutineHandler
 public:
     // The thread cycle function,
     // when serve connection completed, terminate the loop which will terminate the thread,

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -773,9 +773,17 @@ srs_error_t SrsServer::http_handle()
     // The test api for get tcmalloc stats.
     // @see Memory Introspection in https://gperftools.github.io/gperftools/tcmalloc.html
     if ((err = http_api_mux->handle("/api/v1/tcmalloc", new SrsGoApiTcmalloc())) != srs_success) {
-        return srs_error_wrap(err, "handle tests errors");
+        return srs_error_wrap(err, "handle tcmalloc errors");
     }
 #endif
+
+#ifdef SRS_VALGRIND
+    // The test api for valgrind. See VALGRIND_DO_LEAK_CHECK in https://valgrind.org/docs/manual/mc-manual.html
+    if ((err = http_api_mux->handle("/api/v1/valgrind", new SrsGoApiValgrind())) != srs_success) {
+        return srs_error_wrap(err, "handle valgrind errors");
+    }
+#endif
+
     // metrics by prometheus
     if ((err = http_api_mux->handle("/metrics", new SrsGoApiMetrics())) != srs_success) {
         return srs_error_wrap(err, "handle tests errors");

--- a/trunk/src/app/srs_app_st.hpp
+++ b/trunk/src/app/srs_app_st.hpp
@@ -291,7 +291,7 @@ public:
 public:
     virtual const SrsContextId& cid();
     virtual void set_cid(const SrsContextId& cid);
-// Interface ISrsOneCycleThreadHandler
+// Interface ISrsCoroutineHandler
 public:
     virtual srs_error_t cycle();
 // Interface ISrsResource

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    148
+#define VERSION_REVISION    149
 
 #endif

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       7
 #define VERSION_MINOR       0
-#define VERSION_REVISION    5
+#define VERSION_REVISION    6
 
 #endif


### PR DESCRIPTION
New features for valgrind:

1. ST: Support /api/v1/valgrind for leaking check.
2. ST: Support /api/v1/valgrind?check=full|added|changed|new|quick

To use Valgrind to detect memory leaks in SRS, even though Valgrind hooks are supported in ST, there are still many false positives. A more reasonable approach is to have Valgrind report incremental memory leaks. This way, global and static variables can be avoided, and detection can be achieved without exiting the program. Follow these steps:

1. Compile SRS with Valgrind support: `./configure --valgrind=on && make`
2. Start SRS with memory leak detection enabled: `valgrind --leak-check=full ./objs/srs -c conf/console.conf`
3. Trigger memory detection by using curl to access the API and generate calibration data. There will still be many false positives, but these can be ignored: `curl http://127.0.0.1:1985/api/v1/valgrind?check=added`
4. Perform load testing or test the suspected leaking functionality, such as RTMP streaming: `ffmpeg -re -i doc/source.flv -c copy -f flv rtmp://127.0.0.1/live/livestream`
5. Stop streaming and wait for SRS to clean up the Source memory, approximately 30 seconds.
6. Perform incremental memory leak detection. The reported leaks will be very accurate at this point: `curl http://127.0.0.1:1985/api/v1/valgrind?check=added`

> Note: To avoid interference from the HTTP request itself on Valgrind, SRS uses a separate coroutine to perform periodic checks. Therefore, after accessing the API, you may need to wait a few seconds for the detection to be triggered.

---------

Co-authored-by: Jacob Su <suzp1984@gmail.com>