### PR TITLE
Build: Support static linked executable

### DIFF
--- a/trunk/configure
+++ b/trunk/configure
@@ -224,6 +224,10 @@ fi
 # so we need to link the c++ libraries staticly but not all.
 # @see https://stackoverflow.com/a/26107550
 if [[ $SRS_STATIC == YES ]]; then
+    SrsLinkOptions="${SrsLinkOptions} -static";
+fi
+
+if [[ $SRS_STATIC_STD_CPP == YES ]]; then
     SrsLinkOptions="${SrsLinkOptions} -static-libstdc++";
 fi
 


### PR DESCRIPTION
related to #4148 : support static linked srs executable.

Only verified Linux and MacOS platform, Cygwin wait for verify.

## How to use static linking option and verify the static linked executable?

> docker run -it --rm -v \`pwd\`:/srs -w /srs ossrs/srs:ubuntu20 bash -c "./configure --static=on && make"
> docker run -it --rm -v \`pwd\`:/srs -w /srs ossrs/srs:ubuntu20 bash -c "ldd ./objs/srs"

if you just want the static linking the c++ std library, use option `--static-stdcpp=on`: 

> docker run -it --rm -v \`pwd\`:/srs -w /srs ossrs/srs:ubuntu20 bash -c "./configure --static-stdcpp=on && make"


# MacOS platform

Mac OS X does not support statically linked executable binaries. The compiler exit with error for `-static`.
@see https://developer.apple.com/library/archive/qa/qa1118/_index.html

for `-static-libstdc++` compiler option: MacOS didn't implement it, the compiler just give a unused warning.

# Linux platform

`-static`, `-static-libstdc++` and `-static-libgcc` support them well.
But this PR not include the `-static-libgcc`.

# Cygwin

Not yet verified.