### PR TITLE
ASAN: Support coroutine context switching and stack tracing

### DIFF
--- a/trunk/3rdparty/st-srs/Makefile
+++ b/trunk/3rdparty/st-srs/Makefile
@@ -195,6 +195,12 @@ endif
 # or cache the stack and reuse it:
 # make EXTRA_CFLAGS=-DMD_CACHE_STACK
 #
+# or enable support for valgrind:
+# make EXTRA_CFLAGS="-DMD_VALGRIND"
+#
+# or enable support for asan:
+# make EXTRA_CFLAGS="-DMD_ASAN -fsanitize=address -fno-omit-frame-pointer"
+#
 # or enable the coverage for utest:
 # make UTEST_FLAGS="-fprofile-arcs -ftest-coverage"
 #

--- a/trunk/3rdparty/st-srs/README.md
+++ b/trunk/3rdparty/st-srs/README.md
@@ -51,6 +51,12 @@ Linux with valgrind and epoll:
 make linux-debug EXTRA_CFLAGS="-DMD_HAVE_EPOLL -DMD_VALGRIND"
 ```
 
+Linux with ASAN(Google Address Sanitizer):
+
+```bash
+make linux-debug EXTRA_CFLAGS="-DMD_ASAN"
+```
+
 ## Mac: Usage
 
 Get code:

--- a/trunk/3rdparty/st-srs/common.c
+++ b/trunk/3rdparty/st-srs/common.c
@@ -3,3 +3,12 @@
 
 #include "common.h"
 
+void *_st_primordial_stack_bottom = NULL;
+size_t _st_primordial_stack_size = 0;
+
+void st_set_primordial_stack(void *top, void *bottom)
+{
+    _st_primordial_stack_bottom = bottom;
+    _st_primordial_stack_size = (char *)top - (char *)bottom;
+}
+

--- a/trunk/3rdparty/st-srs/common.h
+++ b/trunk/3rdparty/st-srs/common.h
@@ -314,7 +314,7 @@ extern __thread _st_eventsys_t *_st_eventsys;
  * Forward declarations
  */
 
-void _st_vp_schedule(void);
+void _st_vp_schedule(_st_thread_t *from);
 void _st_vp_check_clock(void);
 void *_st_idle_thread_start(void *arg);
 void _st_thread_main(void);
@@ -374,7 +374,7 @@ static inline void _st_switch_context(_st_thread_t *thread)
     ST_SWITCH_OUT_CB(thread);
 
     if (!_st_md_cxt_save(thread->context)) {
-        _st_vp_schedule();
+        _st_vp_schedule(thread);
     }
 
     ST_DEBUG_ITERATE_THREADS();
@@ -385,7 +385,7 @@ static inline void _st_switch_context(_st_thread_t *thread)
  * Restore a thread context that was saved by _st_switch_context or
  * initialized by _ST_INIT_CONTEXT
  */
-static inline void _st_restore_context(_st_thread_t *thread)
+static inline void _st_restore_context(_st_thread_t *from, _st_thread_t *thread)
 {
     _st_this_thread = thread;
     _st_md_cxt_restore(thread->context, 1);

--- a/trunk/3rdparty/st-srs/public.h
+++ b/trunk/3rdparty/st-srs/public.h
@@ -159,6 +159,8 @@ extern st_netfd_t st_open(const char *path, int oflags, mode_t mode);
 extern void st_destroy(void);
 extern int st_thread_setspecific2(st_thread_t thread, int key, void *value);
 
+extern void st_set_primordial_stack(void *top, void *bottom);
+
 #ifdef DEBUG
 extern void _st_show_thread_stack(st_thread_t thread, const char *messg);
 extern void _st_iterate_threads(void);

--- a/trunk/3rdparty/st-srs/sched.c
+++ b/trunk/3rdparty/st-srs/sched.c
@@ -135,7 +135,7 @@ int st_poll(struct pollfd *pds, int npds, st_utime_t timeout)
 }
 
 
-void _st_vp_schedule(void)
+void _st_vp_schedule(_st_thread_t *from)
 {
     _st_thread_t *thread;
     
@@ -159,7 +159,7 @@ void _st_vp_schedule(void)
     
     /* Resume the thread */
     thread->state = _ST_ST_RUNNING;
-    _st_restore_context(thread);
+    _st_restore_context(from, thread);
 }
 
 

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -205,7 +205,7 @@ fi
 #####################################################################################
 # Check for address sanitizer, see https://github.com/google/sanitizers
 #####################################################################################
-if [[ $SRS_SANITIZER == YES && $OS_IS_X86_64 == YES ]]; then
+if [[ $SRS_SANITIZER == YES ]]; then
     echo 'int main() { return 0; }' > ${SRS_OBJS}/test_sanitizer.c &&
     gcc -fsanitize=address -fno-omit-frame-pointer -g -O0 ${SRS_OBJS}/test_sanitizer.c \
         -o ${SRS_OBJS}/test_sanitizer 1>/dev/null 2>&1;
@@ -217,7 +217,7 @@ if [[ $SRS_SANITIZER == YES && $OS_IS_X86_64 == YES ]]; then
     fi
 fi
 
-if [[ $SRS_SANITIZER == YES && $OS_IS_X86_64 == YES && $SRS_SANITIZER_STATIC == NO ]]; then
+if [[ $SRS_SANITIZER == YES && $SRS_SANITIZER_STATIC == NO ]]; then
     echo 'int main() { return 0; }' > ${SRS_OBJS}/test_sanitizer.c &&
     gcc -fsanitize=address -fno-omit-frame-pointer -static-libasan -g -O0 ${SRS_OBJS}/test_sanitizer.c \
         -o ${SRS_OBJS}/test_sanitizer 1>/dev/null 2>&1;
@@ -228,7 +228,7 @@ if [[ $SRS_SANITIZER == YES && $OS_IS_X86_64 == YES && $SRS_SANITIZER_STATIC == 
     fi
 fi
 
-if [[ $SRS_SANITIZER == YES && $OS_IS_X86_64 == YES && $SRS_SANITIZER_LOG == NO ]]; then
+if [[ $SRS_SANITIZER == YES && $SRS_SANITIZER_LOG == NO ]]; then
     echo "#include <sanitizer/asan_interface.h>" > ${SRS_OBJS}/test_sanitizer.c &&
     echo "int main() { return 0; }" >> ${SRS_OBJS}/test_sanitizer.c &&
     gcc -fsanitize=address -fno-omit-frame-pointer -g -O0 ${SRS_OBJS}/test_sanitizer.c \

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -267,6 +267,10 @@ fi
 if [[ $SRS_DEBUG_STATS == YES ]]; then
     _ST_EXTRA_CFLAGS="$_ST_EXTRA_CFLAGS -DDEBUG_STATS"
 fi
+# Whether to enable asan.
+if [[ $SRS_SANITIZER == YES ]]; then
+    _ST_EXTRA_CFLAGS="$_ST_EXTRA_CFLAGS -DMD_ASAN -fsanitize=address -fno-omit-frame-pointer"
+fi
 # Pass the global extra flags.
 if [[ $SRS_EXTRA_FLAGS != '' ]]; then
     _ST_EXTRA_CFLAGS="$_ST_EXTRA_CFLAGS $SRS_EXTRA_FLAGS"

--- a/trunk/configure
+++ b/trunk/configure
@@ -122,7 +122,7 @@ fi
 
 # For Sanitizer
 # @doc: https://github.com/google/sanitizers/wiki/AddressSanitizer
-if [[ $SRS_SANITIZER == YES && $OS_IS_X86_64 == YES ]]; then
+if [[ $SRS_SANITIZER == YES ]]; then
     CXXFLAGS="${CXXFLAGS} -fsanitize=address -fno-omit-frame-pointer";
 fi
 
@@ -244,7 +244,7 @@ fi
 
 # For address sanitizer
 # @doc: https://github.com/google/sanitizers/wiki/AddressSanitizer
-if [[ $SRS_SANITIZER == YES && $OS_IS_X86_64 == YES ]]; then
+if [[ $SRS_SANITIZER == YES ]]; then
     SrsLinkOptions="${SrsLinkOptions} -fsanitize=address -fno-omit-frame-pointer";
     if [[ $SRS_SANITIZER_STATIC == YES ]]; then
         SrsLinkOptions="${SrsLinkOptions} -static-libasan";

--- a/trunk/research/st/.gitignore
+++ b/trunk/research/st/.gitignore
@@ -11,3 +11,4 @@ exceptions
 hello
 pthreads
 asan-switch
+hello-thread

--- a/trunk/research/st/.gitignore
+++ b/trunk/research/st/.gitignore
@@ -10,3 +10,4 @@ huge-threads
 exceptions
 hello
 pthreads
+asan-switch

--- a/trunk/research/st/asan-switch.cpp
+++ b/trunk/research/st/asan-switch.cpp
@@ -3,12 +3,17 @@ g++ asan-switch.cpp ../../objs/st/libst.a -fsanitize=address -fno-omit-frame-poi
 */
 #include <stdio.h>
 #include <string.h>
+#include <sys/resource.h>
 #include "../../objs/st/st.h"
+
+extern "C" {
+extern void st_set_primordial_stack(void* top, void* bottom);
+}
 
 void* foo(void *args) {
     for (int i = 0; ; i++) {
         st_sleep(1);
-        if (i && (i % 3) == 0) {
+        if (i && (i % 2) == 0) {
             char *p = new char[3];
             p[3] = 'H';
         }
@@ -18,9 +23,18 @@ void* foo(void *args) {
 }
 
 int main(int argc, char **argv) {
+    register void* stack_top asm ("sp");
+    struct rlimit limit;
+    if (getrlimit (RLIMIT_STACK, &limit) == 0) {
+        void* stack_bottom = (char*)stack_top - limit.rlim_cur;
+        st_set_primordial_stack(stack_top, stack_bottom);
+    }
+
     st_init();
     if (argc > 1) {
-        foo(NULL); // Directly call foo() to trigger ASAN.
+        // Directly call foo() to trigger ASAN, call the function in the primordial thread,
+        // note that asan can not capther the stack of primordial thread.
+        foo(NULL);
     } else {
         st_thread_create(foo, NULL, 0, 0);
         st_thread_exit(NULL);

--- a/trunk/research/st/asan-switch.cpp
+++ b/trunk/research/st/asan-switch.cpp
@@ -6,10 +6,6 @@ g++ asan-switch.cpp ../../objs/st/libst.a -fsanitize=address -fno-omit-frame-poi
 #include <sys/resource.h>
 #include "../../objs/st/st.h"
 
-extern "C" {
-extern void st_set_primordial_stack(void* top, void* bottom);
-}
-
 void* foo(void *args) {
     for (int i = 0; ; i++) {
         st_sleep(1);

--- a/trunk/research/st/asan-switch.cpp
+++ b/trunk/research/st/asan-switch.cpp
@@ -1,0 +1,30 @@
+/*
+g++ asan-switch.cpp ../../objs/st/libst.a -fsanitize=address -fno-omit-frame-pointer -g -O0 -o asan-switch && ./asan-switch
+*/
+#include <stdio.h>
+#include <string.h>
+#include "../../objs/st/st.h"
+
+void* foo(void *args) {
+    for (int i = 0; ; i++) {
+        st_sleep(1);
+        if (i && (i % 3) == 0) {
+            char *p = new char[3];
+            p[3] = 'H';
+        }
+        printf("#%d: main: working\n", i);
+    }
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    st_init();
+    if (argc > 1) {
+        foo(NULL); // Directly call foo() to trigger ASAN.
+    } else {
+        st_thread_create(foo, NULL, 0, 0);
+        st_thread_exit(NULL);
+    }
+    return 0;
+}
+

--- a/trunk/research/st/hello-thread.cpp
+++ b/trunk/research/st/hello-thread.cpp
@@ -1,0 +1,21 @@
+/*
+g++ hello-thread.cpp ../../objs/st/libst.a -g -O0 -o hello-thread && ./hello-thread
+*/
+#include <stdio.h>
+#include "../../objs/st/st.h"
+
+void* foo(void *args) {
+    for (int i = 0; ; i++) {
+        st_sleep(1);
+        printf("#%d: main: working\n", i);
+    }
+
+    return NULL;
+}
+
+int main() {
+    st_init();
+    st_thread_create(foo, NULL, 0, 0);
+    st_thread_exit(NULL);
+    return 0;
+}

--- a/trunk/research/st/hello.c
+++ b/trunk/research/st/hello.c
@@ -1,0 +1,9 @@
+#include <sys/resource.h>
+#include <stdio.h>
+int main (void)
+{
+  struct rlimit limit;
+
+  getrlimit (RLIMIT_STACK, &limit);
+  printf ("\nStack Limit = %ld and %ld max\n", limit.rlim_cur, limit.rlim_max);
+}

--- a/trunk/src/main/srs_main_server.cpp
+++ b/trunk/src/main/srs_main_server.cpp
@@ -253,6 +253,13 @@ srs_error_t do_main(int argc, char** argv, char** envp)
 
 int main(int argc, char** argv, char** envp)
 {
+#ifdef SRS_SANITIZER
+    // Setup the primordial stack for st. Use the current variable address as the stack top.
+    // This is not very accurate but sufficient.
+    void* p = NULL;
+    srs_set_primordial_stack(&p);
+#endif
+
     srs_error_t err = do_main(argc, argv, envp);
 
     if (err != srs_success) {

--- a/trunk/src/protocol/srs_protocol_st.cpp
+++ b/trunk/src/protocol/srs_protocol_st.cpp
@@ -9,6 +9,7 @@
 #include <st.h>
 #include <fcntl.h>
 #include <sys/socket.h>
+#include <sys/resource.h>
 #include <netdb.h>
 using namespace std;
 
@@ -35,6 +36,23 @@ bool srs_st_epoll_is_supported(void)
     epoll_ctl(-1, EPOLL_CTL_ADD, -1, &ev);
     
     return (errno != ENOSYS);
+}
+#endif
+
+#ifdef SRS_SANITIZER
+void srs_set_primordial_stack(void* stack_top)
+{
+    if (!stack_top) {
+        return;
+    }
+
+    struct rlimit limit;
+    if (getrlimit (RLIMIT_STACK, &limit) != 0) {
+        return;
+    }
+
+    void* stack_bottom = (char*)stack_top - (uint64_t)limit.rlim_cur;
+    st_set_primordial_stack(stack_top, stack_bottom);
 }
 #endif
 

--- a/trunk/src/protocol/srs_protocol_st.hpp
+++ b/trunk/src/protocol/srs_protocol_st.hpp
@@ -20,6 +20,12 @@ typedef void* srs_thread_t;
 typedef void* srs_cond_t;
 typedef void* srs_mutex_t;
 
+
+#ifdef SRS_SANITIZER
+// Setup the primordial stack for asan detecting.
+void srs_set_primordial_stack(void* stack_top);
+#endif
+
 // Initialize ST, requires epoll for linux.
 extern srs_error_t srs_st_init();
 // Destroy ST, free resources for asan detecting.


### PR DESCRIPTION
For coroutine, we should use `__sanitizer_start_switch_fiber` which similar to`VALGRIND_STACK_REGISTER`, see https://github.com/google/sanitizers/issues/189#issuecomment-1346243598 for details. If not fix this, asan will output warning:

```
==72269==WARNING: ASan is ignoring requested __asan_handle_no_return: stack type: default top: 0x00016f638000; bottom 0x000106bec000; size: 0x000068a4c000 (1755627520)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189
```

It will cause asan failed to get the stack, see `research/st/asan-switch.cpp` for example:

```
==71611==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x000103600733 at pc 0x0001009d3d7c bp 0x000100b4bd40 sp 0x000100b4bd38
WRITE of size 1 at 0x000103600733 thread T0
    #0 0x1009d3d78 in foo(void*) asan-switch.cpp:13
```

After fix this issue, it should provide the full stack when crashing:

```
==73437==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x000103300733 at pc 0x000100693d7c bp 0x00016f76f550 sp 0x00016f76f548
WRITE of size 1 at 0x000103300733 thread T0
    #0 0x100693d78 in foo(void*) asan-switch.cpp:13
    #1 0x100693df4 in main asan-switch.cpp:23
    #2 0x195aa20dc  (<unknown module>)
```

For primordial coroutine, if not set the stack by `st_set_primordial_stack`, then the stack is NULL and asan can't get the stack tracing. Note that it's optional and only make it fail to display the stack information, no other errors.