### PR TITLE
ASAN: Disable memory leak detection by default. v7.0.8

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2024-08-22, Merge [#4154](https://github.com/ossrs/srs/pull/4154): ASAN: Disable memory leak detection by default. v7.0.8 (#4154)
 * v7.0, 2024-08-21, Merge [#4149](https://github.com/ossrs/srs/pull/4149): ST: Replace macros with explicit code for better understanding. v7.0.7 (#4149)
 * v7.0, 2024-08-21, Merge [#4150](https://github.com/ossrs/srs/pull/4150): API: Support new HTTP API for VALGRIND. v7.0.6 (#4150)
 * v7.0, 2024-08-15, Merge [#4144](https://github.com/ossrs/srs/pull/4144): HTTP-FLV: Crash when multiple viewers. v7.0.5 (#4144)

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       7
 #define VERSION_MINOR       0
-#define VERSION_REVISION    7
+#define VERSION_REVISION    8
 
 #endif

--- a/trunk/src/kernel/srs_kernel_error.cpp
+++ b/trunk/src/kernel/srs_kernel_error.cpp
@@ -169,6 +169,22 @@ void asan_report_callback(const char* str)
 }
 #endif
 
+#ifdef SRS_SANITIZER
+// This function return the default options for asan, before main() is called,
+// see https://github.com/google/sanitizers/wiki/AddressSanitizerFlags#run-time-flags
+//
+// Disable halt on errors by halt_on_error, only print messages, note that it still quit for fatal errors,
+// see https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
+//
+// Disable the memory leaking detect for daemon by detect_leaks,
+// see https://github.com/google/sanitizers/wiki/SanitizerCommonFlags
+//
+// Also disable alloc_dealloc_mismatch for gdb.
+extern "C" const char *__asan_default_options() {
+    return "halt_on_error=0:detect_leaks=0:alloc_dealloc_mismatch=0";
+}
+#endif
+
 bool srs_is_system_control_error(srs_error_t err)
 {
     int error_code = srs_error_code(err);

--- a/trunk/src/main/srs_main_server.cpp
+++ b/trunk/src/main/srs_main_server.cpp
@@ -81,9 +81,6 @@ const char* _srs_binary = NULL;
 // @global Other variables.
 bool _srs_in_docker = false;
 
-// Free global data, for address sanitizer.
-extern void srs_free_global_system_ips();
-
 #ifdef SRS_SANITIZER_LOG
 extern void asan_report_callback(const char* str);
 #endif
@@ -242,9 +239,7 @@ srs_error_t do_main(int argc, char** argv, char** envp)
     __asan_set_error_report_callback(asan_report_callback);
 #endif
 
-    err = run_directly_or_daemon();
-    srs_free_global_system_ips();
-    if (err != srs_success) {
+    if ((err = run_directly_or_daemon()) != srs_success) {
         return srs_error_wrap(err, "run");
     }
 
@@ -440,7 +435,6 @@ srs_error_t run_directly_or_daemon()
         int status = 0;
         waitpid(pid, &status, 0);
         srs_trace("grandpa process exit.");
-        srs_free_global_system_ips();
         exit(0);
     }
     
@@ -453,7 +447,6 @@ srs_error_t run_directly_or_daemon()
     
     if(pid > 0) {
         srs_trace("father process exit");
-        srs_free_global_system_ips();
         exit(0);
     }
     

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -673,17 +673,6 @@ bool srs_net_device_is_internet(const sockaddr* addr)
 }
 
 vector<SrsIPAddress*> _srs_system_ips;
-void srs_free_global_system_ips()
-{
-    vector<SrsIPAddress*>& ips = _srs_system_ips;
-
-    // Release previous IPs.
-    for (int i = 0; i < (int)ips.size(); i++) {
-        SrsIPAddress* ip = ips[i];
-        srs_freep(ip);
-    }
-    ips.clear();
-}
 
 void discover_network_iface(ifaddrs* cur, vector<SrsIPAddress*>& ips, stringstream& ss0, stringstream& ss1, bool ipv6, bool loopback)
 {
@@ -721,9 +710,6 @@ void discover_network_iface(ifaddrs* cur, vector<SrsIPAddress*>& ips, stringstre
 
 void retrieve_local_ips()
 {
-    // Release previous IPs.
-    srs_free_global_system_ips();
-
     vector<SrsIPAddress*>& ips = _srs_system_ips;
 
     // Get the addresses.

--- a/trunk/src/utest/srs_utest.cpp
+++ b/trunk/src/utest/srs_utest.cpp
@@ -96,9 +96,6 @@ srs_error_t prepare_main() {
     return err;
 }
 
-// Free global data, for address sanitizer.
-extern void srs_free_global_system_ips();
-
 // We could do something in the main of utest.
 // Copy from gtest-1.6.0/src/gtest_main.cc
 GTEST_API_ int main(int argc, char **argv) {
@@ -116,8 +113,6 @@ GTEST_API_ int main(int argc, char **argv) {
 
     testing::InitGoogleTest(&argc, argv);
     int r0 = RUN_ALL_TESTS();
-
-    srs_free_global_system_ips();
 
     return r0;
 }


### PR DESCRIPTION
By setting the env `ASAN_OPTIONS=halt_on_error=0`, we can ignore memory leaks, see https://github.com/google/sanitizers/wiki/AddressSanitizerFlags

By setting env `ASAN_OPTIONS=detect_leaks=0`, we can disable memory leaking detection in parent process when forking for daemon.