### PR TITLE
FLV: Refine source and http handler. v6.0.155 v7.0.14

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2024-09-01, Merge [#4165](https://github.com/ossrs/srs/pull/4165): FLV: Refine source and http handler. v7.0.14 (#4165)
 * v7.0, 2024-09-01, Merge [#4166](https://github.com/ossrs/srs/pull/4166): Edge: Fix flv edge crash when http unmount. v7.0.13 (#4166)
 * v7.0, 2024-08-31, Merge [#4162](https://github.com/ossrs/srs/pull/4162): Fix #3767: RTMP: Do not response empty data packet. v7.0.12 (#4162)
 * v7.0, 2024-08-31, Merge [#4164](https://github.com/ossrs/srs/pull/4164): HTTP-FLV: Notify connection to expire when unpublishing. v7.0.11 (#4164)
@@ -25,6 +26,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-09-01, Merge [#4165](https://github.com/ossrs/srs/pull/4165): FLV: Refine source and http handler. v6.0.155 (#4165)
 * v6.0, 2024-09-01, Merge [#4166](https://github.com/ossrs/srs/pull/4166): Edge: Fix flv edge crash when http unmount. v6.0.154 (#4166)
 * v6.0, 2024-08-31, Merge [#4162](https://github.com/ossrs/srs/pull/4162): Fix #3767: RTMP: Do not response empty data packet. v6.0.153 (#4162)
 * v6.0, 2024-08-31, Merge [#4164](https://github.com/ossrs/srs/pull/4164): HTTP-FLV: Notify connection to expire when unpublishing. v6.0.152 (#4164)

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -70,6 +70,11 @@ srs_error_t SrsBufferCache::update_auth(SrsRequest* r)
 srs_error_t SrsBufferCache::start()
 {
     srs_error_t err = srs_success;
+
+    // Not enabled.
+    if (fast_cache <= 0) {
+        return err;
+    }
     
     if ((err = trd->start()) != srs_success) {
         return srs_error_wrap(err, "corotine");
@@ -80,11 +85,21 @@ srs_error_t SrsBufferCache::start()
 
 void SrsBufferCache::stop()
 {
+    // Not enabled.
+    if (fast_cache <= 0) {
+        return;
+    }
+
     trd->stop();
 }
 
 bool SrsBufferCache::alive()
 {
+    // Not enabled.
+    if (fast_cache <= 0) {
+        return false;
+    }
+
     srs_error_t err = trd->pull();
     if (err == srs_success) {
         return true;
@@ -116,12 +131,6 @@ srs_error_t SrsBufferCache::dump_cache(SrsLiveConsumer* consumer, SrsRtmpJitterA
 srs_error_t SrsBufferCache::cycle()
 {
     srs_error_t err = srs_success;
-    
-    // TODO: FIXME: support reload.
-    if (fast_cache <= 0) {
-        srs_usleep(SRS_STREAM_CACHE_CYCLE);
-        return err;
-    }
 
     SrsSharedPtr<SrsLiveSource> live_source;
     if ((err = _srs_sources->fetch_or_create(req, server_, live_source)) != srs_success) {

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -1307,7 +1307,7 @@ srs_error_t SrsHttpStreamDestroy::call()
 
     // Free all HTTP resources.
     SrsUniquePtr<SrsLiveEntry> entry(it->second);
-    entry->disposing = true;
+    srs_assert(entry->disposing);
 
     SrsUniquePtr<SrsLiveStream> stream(entry->stream);
     SrsUniquePtr<SrsBufferCache> cache(entry->cache);

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -1081,7 +1081,7 @@ srs_error_t SrsHttpStreamServer::http_mount(SrsRequest* r)
 
         // Fail if system is disposing the entry.
         if (entry->disposing) {
-            return srs_error_new(ERROR_NO_SOURCE, "stream is disposing");
+            return srs_error_new(ERROR_STREAM_DISPOSING, "stream is disposing");
         }
 
         entry->stream->update_auth(r);

--- a/trunk/src/app/srs_app_http_stream.hpp
+++ b/trunk/src/app/srs_app_http_stream.hpp
@@ -10,6 +10,7 @@
 #include <srs_core.hpp>
 #include <srs_app_security.hpp>
 #include <srs_app_http_conn.hpp>
+#include <srs_app_async_call.hpp>
 
 #include <vector>
 
@@ -17,6 +18,7 @@ class SrsAacTransmuxer;
 class SrsMp3Transmuxer;
 class SrsFlvTransmuxer;
 class SrsTsTransmuxer;
+class SrsAsyncCallWorker;
 
 // A cache for HTTP Live Streaming encoder, to make android(weixin) happy.
 class SrsBufferCache : public ISrsCoroutineHandler
@@ -245,6 +247,7 @@ class SrsHttpStreamServer : public ISrsReloadHandler
 {
 private:
     SrsServer* server;
+    SrsAsyncCallWorker* async_;
 public:
     SrsHttpServeMux mux;
     // The http live streaming template, to create streams.
@@ -266,6 +269,20 @@ public:
 private:
     virtual srs_error_t initialize_flv_streaming();
     virtual srs_error_t initialize_flv_entry(std::string vhost);
+};
+
+class SrsHttpStreamDestroy : public ISrsAsyncCallTask
+{
+private:
+    std::string sid_;
+    std::map<std::string, SrsLiveEntry*>* streamHandlers_;
+    SrsHttpServeMux* mux_;
+public:
+    SrsHttpStreamDestroy(SrsHttpServeMux* mux, map<std::string, SrsLiveEntry*>* handlers, string sid);
+    virtual ~SrsHttpStreamDestroy();
+public:
+    virtual srs_error_t call();
+    virtual std::string to_string();
 };
 
 #endif

--- a/trunk/src/app/srs_app_http_stream.hpp
+++ b/trunk/src/app/srs_app_http_stream.hpp
@@ -278,7 +278,7 @@ private:
     std::map<std::string, SrsLiveEntry*>* streamHandlers_;
     SrsHttpServeMux* mux_;
 public:
-    SrsHttpStreamDestroy(SrsHttpServeMux* mux, map<std::string, SrsLiveEntry*>* handlers, string sid);
+    SrsHttpStreamDestroy(SrsHttpServeMux* mux, std::map<std::string, SrsLiveEntry*>* handlers, std::string sid);
     virtual ~SrsHttpStreamDestroy();
 public:
     virtual srs_error_t call();

--- a/trunk/src/app/srs_app_http_stream.hpp
+++ b/trunk/src/app/srs_app_http_stream.hpp
@@ -23,12 +23,13 @@ class SrsBufferCache : public ISrsCoroutineHandler
 {
 private:
     srs_utime_t fast_cache;
+    SrsServer* server_;
 private:
     SrsMessageQueue* queue;
     SrsRequest* req;
     SrsCoroutine* trd;
 public:
-    SrsBufferCache(SrsRequest* r);
+    SrsBufferCache(SrsServer* s, SrsRequest* r);
     virtual ~SrsBufferCache();
     virtual srs_error_t update_auth(SrsRequest* r);
 public:
@@ -184,12 +185,13 @@ private:
     SrsRequest* req;
     SrsBufferCache* cache;
     SrsSecurity* security_;
+    SrsServer* server_;
     // For multiple viewers, which means there will more than one alive viewers for a live stream, so we must
     // use an int value to represent if there is any viewer is alive. We should never do cleanup unless all
     // viewers closed the connection.
     std::vector<ISrsExpire*> viewers_;
 public:
-    SrsLiveStream(SrsRequest* r, SrsBufferCache* c);
+    SrsLiveStream(SrsServer* s, SrsRequest* r, SrsBufferCache* c);
     virtual ~SrsLiveStream();
     virtual srs_error_t update_auth(SrsRequest* r);
 public:
@@ -223,6 +225,9 @@ public:
     
     SrsLiveStream* stream;
     SrsBufferCache* cache;
+
+    // Whether is disposing the entry.
+    bool disposing;
     
     SrsLiveEntry(std::string m);
     virtual ~SrsLiveEntry();

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -1909,9 +1909,6 @@ SrsLiveSource::SrsLiveSource()
 
 SrsLiveSource::~SrsLiveSource()
 {
-    // Because source maybe created by http stream, so we must notify the handler to cleanup.
-    handler->on_unpublish(req);
-
     _srs_config->unsubscribe(this);
     
     // never free the consumers,

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -1909,6 +1909,9 @@ SrsLiveSource::SrsLiveSource()
 
 SrsLiveSource::~SrsLiveSource()
 {
+    // Because source maybe created by http stream, so we must notify the handler to cleanup.
+    handler->on_unpublish(req);
+
     _srs_config->unsubscribe(this);
     
     // never free the consumers,

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    154
+#define VERSION_REVISION    155
 
 #endif

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       7
 #define VERSION_MINOR       0
-#define VERSION_REVISION    13
+#define VERSION_REVISION    14
 
 #endif

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -107,7 +107,8 @@
     XX(ERROR_BACKTRACE_ADDR2LINE           , 1094, "BacktraceAddr2Line", "Backtrace addr2line failed") \
     XX(ERROR_SYSTEM_FILE_NOT_OPEN          , 1095, "FileNotOpen", "File is not opened") \
     XX(ERROR_SYSTEM_FILE_SETVBUF           , 1096, "FileSetVBuf", "Failed to set file vbuf") \
-    XX(ERROR_NO_SOURCE                     , 1097, "NoSource", "No source found")
+    XX(ERROR_NO_SOURCE                     , 1097, "NoSource", "No source found") \
+    XX(ERROR_STREAM_DISPOSING              , 1098, "StreamDisposing", "Stream is disposing")
 
 /**************************************************/
 /* RTMP protocol error. */


### PR DESCRIPTION
1. Do not create a source when mounting FLV because it may not unmount FLV when freeing the source. If you access the FLV stream without any publisher, then wait for source cleanup and review the FLV stream again, there is an annoying warning message. 

```bash
# View HTTP FLV stream by curl, wait for stream to be ready.
# curl http://localhost:8080/live/livestream.flv -v >/dev/null
HTTP #0 127.0.0.1:58026 GET http://localhost:8080/live/livestream.flv, content-length=-1
new live source, stream_url=/live/livestream
http: mount flv stream for sid=/live/livestream, mount=/live/livestream.flv

# Cancel the curl and trigger source cleanup without http unmount.
client disconnect peer. ret=1007
Live: cleanup die source, id=[], total=1

# View the stream again, it fails.
# curl http://localhost:8080/live/livestream.flv -v >/dev/null
HTTP #0 127.0.0.1:58040 GET http://localhost:8080/live/livestream.flv, content-length=-1
serve error code=1097(NoSource)(No source found) : process request=0 : cors serve : serve http : no source for /live/livestream
serve_http() [srs_app_http_stream.cpp:641]
```

> Note: There is an inconsistency. The first time, you can access the FLV stream and wait for the publisher, but the next time, you cannot.

2. Create a source when starting to serve the FLV client. We do not need to create the source when creating the HTTP handler. Instead, we should try to create the source in the cache or stream. Because the source cleanup does not unmount the HTTP handler, the handler remains after the source is destroyed. The next time you access the FLV stream, the source is not found.

```cpp
srs_error_t SrsHttpStreamServer::hijack(ISrsHttpMessage* request, ISrsHttpHandler** ph) {
    SrsSharedPtr<SrsLiveSource> live_source;
    if ((err = _srs_sources->fetch_or_create(r.get(), server, live_source)) != srs_success) { }
    if ((err = http_mount(r.get())) != srs_success) { }

srs_error_t SrsBufferCache::cycle() {
    SrsSharedPtr<SrsLiveSource> live_source = _srs_sources->fetch(req);
    if (!live_source.get()) {
        return srs_error_new(ERROR_NO_SOURCE, "no source for %s", req->get_stream_url().c_str());
    }

srs_error_t SrsLiveStream::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r) {
    SrsSharedPtr<SrsLiveSource> live_source = _srs_sources->fetch(req);
    if (!live_source.get()) {
        return srs_error_new(ERROR_NO_SOURCE, "no source for %s", req->get_stream_url().c_str());
    }
```

> Note: We should not create the source in hijack, instead, we create it in cache or stream:

```cpp
srs_error_t SrsHttpStreamServer::hijack(ISrsHttpMessage* request, ISrsHttpHandler** ph) {
    if ((err = http_mount(r.get())) != srs_success) { }

srs_error_t SrsBufferCache::cycle() {
    SrsSharedPtr<SrsLiveSource> live_source;
    if ((err = _srs_sources->fetch_or_create(req, server_, live_source)) != srs_success) { }

srs_error_t SrsLiveStream::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r) {
    SrsSharedPtr<SrsLiveSource> live_source;
    if ((err = _srs_sources->fetch_or_create(req, server_, live_source)) != srs_success) { }
```

> Note: This fixes the failure and annoying warning message, and maintains consistency by always waiting for the stream to be ready if there is no publisher.

3. Fail the http request if the HTTP handler is disposing, and also keep the handler entry when disposing the stream, because we should dispose the handler entry and stream at the same time.

```cpp
srs_error_t SrsHttpStreamServer::http_mount(SrsRequest* r) {
        entry = streamHandlers[sid];
        if (entry->disposing) {
            return srs_error_new(ERROR_STREAM_DISPOSING, "stream is disposing");
        }

void SrsHttpStreamServer::http_unmount(SrsRequest* r) {
    std::map<std::string, SrsLiveEntry*>::iterator it = streamHandlers.find(sid);
    SrsUniquePtr<SrsLiveEntry> entry(it->second);
    entry->disposing = true;
```

> Note: If the disposal process takes a long time, this will prevent unexpected behavior or access to the resource that is being disposed of.

4. In edge mode, the edge ingester will unpublish the source when the last consumer quits, which is actually triggered by the HTTP stream. While it also waits for the stream to quit when the HTTP unmounts, there is a self-destruction risk: the HTTP live stream object destroys itself.

```cpp
srs_error_t SrsLiveStream::serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r) {
    SrsUniquePtr<SrsLiveConsumer> consumer(consumer_raw); // Trigger destroy.

void SrsHttpStreamServer::http_unmount(SrsRequest* r) {
    for (;;) { if (!cache->alive() && !stream->alive()) { break; } // A circle reference.
    mux.unhandle(entry->mount, stream.get()); // Free the SrsLiveStream itself.
```

> Note: It also introduces a circular reference in the object relationships, the stream reference to itself when unmount:

```text
SrsLiveStream::serve_http 
    -> SrsLiveConsumer::~SrsLiveConsumer -> SrsEdgeIngester::stop 
    -> SrsLiveSource::on_unpublish -> SrsHttpStreamServer::http_unmount 
        -> SrsLiveStream::alive
```

> Note: We should use an asynchronous worker to perform the cleanup to avoid the stream destroying itself and to prevent self-referencing.

```cpp
void SrsHttpStreamServer::http_unmount(SrsRequest* r) {
    entry->disposing = true;
    if ((err = async_->execute(new SrsHttpStreamDestroy(&mux, &streamHandlers, sid))) != srs_success) { }
```

> Note: This also ensures there are no circular references and no self-destruction.

---------

Co-authored-by: Jacob Su <suzp1984@gmail.com>