### PR TITLE
Heartbeat: Report ports for proxy server. v5.0.215 v6.0.156 v7.0.15

### DIFF
--- a/.run/private.run.xml
+++ b/.run/private.run.xml
@@ -1,7 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="private" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="-c console.conf" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$CMakeCurrentBuildDir$/../../../" PASS_PARENT_ENVS_2="true" PROJECT_NAME="srs" TARGET_NAME="srs" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="srs" RUN_TARGET_NAME="srs">
     <envs>
-      <env name="SRS_RTC_SERVER_ENABLED" value="on" />
       <env name="MallocNanoZone" value="0" />
     </envs>
     <method v="2">

--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -907,6 +907,14 @@ heartbeat {
     # Overwrite by env SRS_HEARTBEAT_SUMMARIES
     # default: off
     summaries off;
+    # Whether report with listen ports.
+    # if on, request with the ports of SRS:
+    #   {
+    #       "rtmp": ["1935"], "http": ["8080"], "api": ["1985"], "srt": ["10080"], "rtc": ["8000"]
+    #   }
+    # Overwrite by env SRS_HEARTBEAT_PORTS
+    # default: off
+    ports off;
 }
 
 # system statistics section.

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2024-09-09, Merge [#4171](https://github.com/ossrs/srs/pull/4171): Heartbeat: Report ports for proxy server. v7.0.15 (#4171)
 * v7.0, 2024-09-01, Merge [#4165](https://github.com/ossrs/srs/pull/4165): FLV: Refine source and http handler. v7.0.14 (#4165)
 * v7.0, 2024-09-01, Merge [#4166](https://github.com/ossrs/srs/pull/4166): Edge: Fix flv edge crash when http unmount. v7.0.13 (#4166)
 * v7.0, 2024-08-31, Merge [#4162](https://github.com/ossrs/srs/pull/4162): Fix #3767: RTMP: Do not response empty data packet. v7.0.12 (#4162)
@@ -26,6 +27,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2024-09-09, Merge [#4171](https://github.com/ossrs/srs/pull/4171): Heartbeat: Report ports for proxy server. v6.0.156 (#4171)
 * v6.0, 2024-09-01, Merge [#4165](https://github.com/ossrs/srs/pull/4165): FLV: Refine source and http handler. v6.0.155 (#4165)
 * v6.0, 2024-09-01, Merge [#4166](https://github.com/ossrs/srs/pull/4166): Edge: Fix flv edge crash when http unmount. v6.0.154 (#4166)
 * v6.0, 2024-08-31, Merge [#4162](https://github.com/ossrs/srs/pull/4162): Fix #3767: RTMP: Do not response empty data packet. v6.0.153 (#4162)
@@ -185,6 +187,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2024-09-09, Merge [#4171](https://github.com/ossrs/srs/pull/4171): Heartbeat: Report ports for proxy server. v5.0.215 (#4171)
 * v5.0, 2024-07-24, Merge [#4126](https://github.com/ossrs/srs/pull/4126): Edge: Improve stability for state and fd closing. v5.0.214 (#4126)
 * v5.0, 2024-06-03, Merge [#4057](https://github.com/ossrs/srs/pull/4057): RTC: Support dropping h.264 SEI from NALUs. v5.0.213 (#4057)
 * v5.0, 2024-04-23, Merge [#4038](https://github.com/ossrs/srs/pull/4038): RTMP: Do not response publish start message if hooks fail. v5.0.212 (#4038)

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2409,7 +2409,7 @@ srs_error_t SrsConfig::check_normal_config()
         for (int i = 0; conf && i < (int)conf->directives.size(); i++) {
             string n = conf->at(i)->name;
             if (n != "enabled" && n != "interval" && n != "url"
-                && n != "device_id" && n != "summaries") {
+                && n != "device_id" && n != "summaries" && n != "ports") {
                 return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal heartbeat.%s", n.c_str());
             }
         }
@@ -8794,17 +8794,36 @@ bool SrsConfig::get_heartbeat_summaries()
     SRS_OVERWRITE_BY_ENV_BOOL("srs.heartbeat.summaries"); // SRS_HEARTBEAT_SUMMARIES
 
     static bool DEFAULT = false;
-    
+
     SrsConfDirective* conf = get_heartbeart();
     if (!conf) {
         return DEFAULT;
     }
-    
+
     conf = conf->get("summaries");
     if (!conf || conf->arg0().empty()) {
         return DEFAULT;
     }
-    
+
+    return SRS_CONF_PREFER_FALSE(conf->arg0());
+}
+
+bool SrsConfig::get_heartbeat_ports()
+{
+    SRS_OVERWRITE_BY_ENV_BOOL("srs.heartbeat.ports"); // SRS_HEARTBEAT_PORTS
+
+    static bool DEFAULT = false;
+
+    SrsConfDirective* conf = get_heartbeart();
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("ports");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+
     return SRS_CONF_PREFER_FALSE(conf->arg0());
 }
 

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -1119,6 +1119,7 @@ public:
     virtual std::string get_heartbeat_device_id();
     // Whether report with summaries of http api: /api/v1/summaries.
     virtual bool get_heartbeat_summaries();
+    bool get_heartbeat_ports();
 // stats section
 private:
     // Get the stats directive.

--- a/trunk/src/app/srs_app_heartbeat.cpp
+++ b/trunk/src/app/srs_app_heartbeat.cpp
@@ -116,7 +116,7 @@ srs_error_t SrsHttpHeartbeat::do_heartbeat()
             obj->set("srt", o);
 
             uint16_t endpoint = _srs_config->get_srt_listen_port();
-            o->append(SrsJsonAny::str(srs_int2str(endpoint).c_str()));
+            o->append(SrsJsonAny::str(srs_fmt("udp://0.0.0.0:%d", endpoint).c_str()));
         }
 
         // For WebRTC listen endpoints.

--- a/trunk/src/app/srs_app_heartbeat.cpp
+++ b/trunk/src/app/srs_app_heartbeat.cpp
@@ -125,7 +125,12 @@ srs_error_t SrsHttpHeartbeat::do_heartbeat()
             obj->set("rtc", o);
 
             int endpoint = _srs_config->get_rtc_server_listen();
-            o->append(SrsJsonAny::str(srs_int2str(endpoint).c_str()));
+            o->append(SrsJsonAny::str(srs_fmt("udp://0.0.0.0:%d", endpoint).c_str()));
+
+            if (_srs_config->get_rtc_server_tcp_enabled()) {
+                endpoint = _srs_config->get_rtc_server_tcp_listen();
+                o->append(SrsJsonAny::str(srs_fmt("tcp://0.0.0.0:%d", endpoint).c_str()));
+            }
         }
     }
     

--- a/trunk/src/app/srs_app_heartbeat.cpp
+++ b/trunk/src/app/srs_app_heartbeat.cpp
@@ -18,6 +18,7 @@ using namespace std;
 #include <srs_core_autofree.hpp>
 #include <srs_app_http_conn.hpp>
 #include <srs_protocol_amf0.hpp>
+#include <srs_kernel_utility.hpp>
 
 SrsHttpHeartbeat::SrsHttpHeartbeat()
 {
@@ -66,6 +67,55 @@ srs_error_t SrsHttpHeartbeat::do_heartbeat()
         obj->set("summaries", summaries);
         
         srs_api_dump_summaries(summaries);
+    }
+
+    if (_srs_config->get_heartbeat_ports()) {
+        // For RTMP listen endpoints.
+        if (true) {
+            SrsJsonArray* o = SrsJsonAny::array();
+            obj->set("rtmp", o);
+
+            vector<string> endpoints = _srs_config->get_listens();
+            for (int i = 0; i < (int) endpoints.size(); i++) {
+                o->append(SrsJsonAny::str(endpoints.at(i).c_str()));
+            }
+        }
+
+        // For HTTP Stream listen endpoints.
+        if (_srs_config->get_http_stream_enabled()) {
+            SrsJsonArray* o = SrsJsonAny::array();
+            obj->set("http", o);
+
+            string endpoint = _srs_config->get_http_stream_listen();
+            o->append(SrsJsonAny::str(endpoint.c_str()));
+        }
+
+        // For HTTP API listen endpoints.
+        if (_srs_config->get_http_api_enabled()) {
+            SrsJsonArray* o = SrsJsonAny::array();
+            obj->set("api", o);
+
+            string endpoint = _srs_config->get_http_api_listen();
+            o->append(SrsJsonAny::str(endpoint.c_str()));
+        }
+
+        // For SRT listen endpoints.
+        if (_srs_config->get_srt_enabled()) {
+            SrsJsonArray* o = SrsJsonAny::array();
+            obj->set("srt", o);
+
+            uint16_t endpoint = _srs_config->get_srt_listen_port();
+            o->append(SrsJsonAny::str(srs_int2str(endpoint).c_str()));
+        }
+
+        // For WebRTC listen endpoints.
+        if (_srs_config->get_rtc_server_enabled()) {
+            SrsJsonArray* o = SrsJsonAny::array();
+            obj->set("rtc", o);
+
+            int endpoint = _srs_config->get_rtc_server_listen();
+            o->append(SrsJsonAny::str(srs_int2str(endpoint).c_str()));
+        }
     }
     
     SrsHttpClient http;

--- a/trunk/src/app/srs_app_heartbeat.cpp
+++ b/trunk/src/app/srs_app_heartbeat.cpp
@@ -19,6 +19,7 @@ using namespace std;
 #include <srs_app_http_conn.hpp>
 #include <srs_protocol_amf0.hpp>
 #include <srs_kernel_utility.hpp>
+#include <srs_app_statistic.hpp>
 
 SrsHttpHeartbeat::SrsHttpHeartbeat()
 {
@@ -61,6 +62,11 @@ srs_error_t SrsHttpHeartbeat::do_heartbeat()
 
     obj->set("device_id", SrsJsonAny::str(device_id.c_str()));
     obj->set("ip", SrsJsonAny::str(ip->ip.c_str()));
+
+    SrsStatistic* stat = SrsStatistic::instance();
+    obj->set("server", SrsJsonAny::str(stat->server_id().c_str()));
+    obj->set("service", SrsJsonAny::str(stat->service_id().c_str()));
+    obj->set("pid", SrsJsonAny::str(stat->service_pid().c_str()));
     
     if (_srs_config->get_heartbeat_summaries()) {
         SrsJsonObject* summaries = SrsJsonAny::object();

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    214
+#define VERSION_REVISION    215
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    155
+#define VERSION_REVISION    156
 
 #endif

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       7
 #define VERSION_MINOR       0
-#define VERSION_REVISION    14
+#define VERSION_REVISION    15
 
 #endif


### PR DESCRIPTION
The heartbeat of SRS is a timer that requests an HTTP URL. We can use this heartbeat to report the necessary information for registering the backend server with the proxy server.

```text
SRS(backend) --heartbeat---> Proxy server
```

A proxy server is a specialized load balancer for media servers. It operates at the application level rather than the TCP level. For more information about the proxy server, see issue #4158.

Note that we will merge this PR into SRS 5.0+, allowing the use of SRS 5.0+ as the backend server, not limited to SRS 7.0. However, the proxy server is introduced in SRS 7.0.

It's also possible to implement a registration service, allowing you to use other media servers as backend servers. For example, if you gather information about an nginx-rtmp server and register it with the proxy server, the proxy will forward RTMP streams to nginx-rtmp. The backend server is not limited to SRS.

---------

Co-authored-by: Jacob Su <suzp1984@gmail.com>