### PR TITLE
fix mp4 stts box bug.

### DIFF
--- a/trunk/src/app/srs_app_dvr.cpp
+++ b/trunk/src/app/srs_app_dvr.cpp
@@ -657,6 +657,16 @@ srs_error_t SrsDvrPlan::on_video(SrsSharedPtrMessage* shared_video, SrsFormat* f
                 return err;
             }
         }
+    } else if (format->vcodec->id == SrsVideoCodecIdHEVC) {
+#ifdef SRS_H265
+        for (int i = 0; i < format->video->nb_samples; ++i) {
+            SrsSample* sample = &format->video->samples[i];
+            SrsHevcNaluType hevc_nalu_type = SrsHevcNaluTypeParse(sample->bytes[0]);
+            if (hevc_nalu_type == SrsHevcNaluType_SEI || hevc_nalu_type == SrsHevcNaluType_SEI_SUFFIX) {
+                return err;
+            }
+        }
+#endif
     }
 
     // quicktime player compatible: skip the packet without any nalu.

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -1308,6 +1308,7 @@ public:
     bool has_sps_pps;
     // The first nalu type.
     SrsAvcNaluType first_nalu_type;
+
 public:
     SrsVideoFrame();
     virtual ~SrsVideoFrame();

--- a/trunk/src/kernel/srs_kernel_mp4.cpp
+++ b/trunk/src/kernel/srs_kernel_mp4.cpp
@@ -5696,7 +5696,7 @@ srs_error_t SrsMp4Encoder::initialize(ISrsWriteSeeker* ws)
 
         ftyp->major_brand = SrsMp4BoxBrandISOM;
         ftyp->minor_version = 512;
-        ftyp->set_compatible_brands(SrsMp4BoxBrandISOM, SrsMp4BoxBrandISO2, SrsMp4BoxBrandMP41);
+        ftyp->set_compatible_brands(SrsMp4BoxBrandISOM, SrsMp4BoxBrandISO2, SrsMp4BoxBrandAVC1, SrsMp4BoxBrandMP41);
         
         int nb_data = ftyp->nb_bytes();
         std::vector<char> data(nb_data);

--- a/trunk/src/kernel/srs_kernel_mp4.cpp
+++ b/trunk/src/kernel/srs_kernel_mp4.cpp
@@ -5024,9 +5024,9 @@ srs_error_t SrsMp4SampleManager::write_track(SrsFrameType track,
         }
 
         if (stts && previous) {
-            if (sample->dts >= previous->dts && previous->nb_samples > 0) {
-                uint32_t delta = (uint32_t)(sample->dts - previous->dts) / previous->nb_samples;
-                stts_entry.sample_count = previous->nb_samples;
+            if (sample->dts >= previous->dts && previous->nb_subsamples > 0) {
+                uint32_t delta = (uint32_t)(sample->dts - previous->dts) / previous->nb_subsamples;
+                stts_entry.sample_count = previous->nb_subsamples;
                 // calcaulate delta in the time-scale of the media.
                 // moov->mvhd->timescale which is hardcoded to 1000, sample->tbn also being hardcoded to 1000.
                 stts_entry.sample_delta = delta * previous->tbn / 1000;
@@ -5051,8 +5051,8 @@ srs_error_t SrsMp4SampleManager::write_track(SrsFrameType track,
         previous = sample;
     }
     
-    if (stts && previous && previous->nb_samples > 0) {
-        stts_entry.sample_count = previous->nb_samples;
+    if (stts && previous && previous->nb_subsamples > 0) {
+        stts_entry.sample_count = previous->nb_subsamples;
         // Can't calculate last sample duration, so set sample_delta to 1.
         stts_entry.sample_delta = 1;
         stts_entries.push_back(stts_entry);
@@ -5205,7 +5205,7 @@ srs_error_t SrsMp4SampleManager::load_trak(map<uint64_t, SrsMp4Sample*>& tses, S
                 uint32_t stts_index = sample->index - 1;
                 if (stts_index >= 0 && stts_index < stts->entries.size()) {
                     SrsMp4SttsEntry* stts_entry = &stts->entries[stts_index];
-                    sample->pts = sample->dts = previous->dts + stts_entry->sample_count * stts_entry->sample_delta;
+                    sample->pts = sample->dts = previous->dts + (uint64_t) stts_entry->sample_count * (uint64_t) stts_entry->sample_delta;
                 } else {
                     sample->pts = sample->dts = previous->dts;
                 }
@@ -5781,12 +5781,12 @@ srs_error_t SrsMp4Encoder::write_sample(
         ps->type = SrsFrameTypeVideo;
         ps->frame_type = (SrsVideoAvcFrameType)ft;
         ps->index = nb_videos++;
-        ps->nb_samples = format->video->nb_samples;
+        ps->nb_subsamples = format->video->nb_samples;
         vduration = dts;
     } else if (ht == SrsMp4HandlerTypeSOUN) {
         ps->type = SrsFrameTypeAudio;
         ps->index = nb_audios++;
-        ps->nb_samples = format->audio->nb_samples;
+        ps->nb_subsamples = format->audio->nb_samples;
         aduration = dts;
     } else {
         srs_freep(ps);

--- a/trunk/src/kernel/srs_kernel_mp4.hpp
+++ b/trunk/src/kernel/srs_kernel_mp4.hpp
@@ -1581,18 +1581,10 @@ class SrsMp4DecodingTime2SampleBox : public SrsMp4FullBox
 public:
     // An integer that gives the number of entries in the following table.
     std::vector<SrsMp4SttsEntry> entries;
-private:
-    // The index for counter to calc the dts for samples.
-    uint32_t index;
-    uint32_t count;
+
 public:
     SrsMp4DecodingTime2SampleBox();
     virtual ~SrsMp4DecodingTime2SampleBox();
-public:
-    // Initialize the counter.
-    virtual srs_error_t initialize_counter();
-    // When got an sample, index starts from 0.
-    virtual srs_error_t on_sample(uint32_t sample_index, SrsMp4SttsEntry** ppentry);
 protected:
     virtual int nb_header();
     virtual srs_error_t encode_header(SrsBuffer* buf);

--- a/trunk/src/kernel/srs_kernel_mp4.hpp
+++ b/trunk/src/kernel/srs_kernel_mp4.hpp
@@ -1886,7 +1886,7 @@ public:
     uint32_t nb_data;
     uint8_t* data;
     // number of nalu|audio-frames in this sample.
-    uint32_t nb_samples;
+    uint32_t nb_subsamples;
 
 public:
     SrsMp4Sample();

--- a/trunk/src/kernel/srs_kernel_mp4.hpp
+++ b/trunk/src/kernel/srs_kernel_mp4.hpp
@@ -1885,8 +1885,6 @@ public:
     // The sample data.
     uint32_t nb_data;
     uint8_t* data;
-    // number of nalu|audio-frames in this sample.
-    uint32_t nb_subsamples;
 
 public:
     SrsMp4Sample();

--- a/trunk/src/kernel/srs_kernel_mp4.hpp
+++ b/trunk/src/kernel/srs_kernel_mp4.hpp
@@ -1554,7 +1554,7 @@ public:
 };
 
 // 8.6.1.2 Decoding Time to Sample Box (stts), for Audio/Video.
-// ISO_IEC_14496-12-base-format-2012.pdf, page 48
+// ISO_IEC_14496-12-base-format-2012.pdf, page 36
 class SrsMp4SttsEntry
 {
 public:
@@ -1893,6 +1893,9 @@ public:
     // The sample data.
     uint32_t nb_data;
     uint8_t* data;
+    // number of nalu|audio-frames in this sample.
+    uint32_t nb_samples;
+
 public:
     SrsMp4Sample();
     virtual ~SrsMp4Sample();


### PR DESCRIPTION
## How to reproduce?

1. `./objs/srs -c conf/dvr.mp4.conf`
2. `ffmpeg -re -i output.flv -c copy -f flv rtmp://localhost/live/livestream`
     the `output.flv` is recorded from a DJI drone, download from this google drive link: https://drive.google.com/file/d/1IVoDXI-WYoIlKiyzs65fCsDRRt0z-EuU/view?usp=sharing
3. after finished publish this video, play the `livestream.*.mp4` located in `trunk/objs/nginx/html/live`.
4. the video playback is 2x slower than the original file.

## Cause
The Mp4 frame rate is determined by mp4 box: `mdhd` and `stts`. But the `stts` encoding in srs has bugs. The above `output.flv` video file has a lot of `SEI` type of nalu, which is not video samples, SRS can't calculate the `stts` correctly.

## How to calculate `stts`?
check doc ISO/IEC 14496-12:2012(E) 8.6.1.2 Decoding Time to Sample Box.

https://ossrs.net/lts/zh-cn/assets/files/ISO_IEC_14496-12-base-format-2012-b70dd5f101daecd072700609842c9649.pdf

## video source generated by OBS with ultrafast + zerolatency

https://drive.google.com/file/d/1rXipV93EWmtZ-rPShwE66f5aO85ugiIc/view?usp=sharing
Use this source, with video frames split to multi slices, to verify the dvr recorded mp4.
