### PR TITLE
fix param's repeat in http callback

### DIFF
--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -52,11 +52,6 @@ void srs_discovery_tc_url(string tcUrl, string& schema, string& host, string& vh
     //      rtmp://ip/app?vhost=VHOST/stream
     string fullUrl = srs_string_replace(tcUrl, "...vhost...", "?vhost=");
 
-    // Standard URL is:
-    //      rtmp://ip/app/app2/stream?k=v
-    // Where after last slash is stream.
-    fullUrl += stream.empty() ? "/" : (stream.at(0) == '/' ? stream : "/" + stream);
-
     // First, we covert the FMLE URL to standard URL:
     //      rtmp://ip/app/app2?k=v/stream , or:
     //      rtmp://ip/app/app2#k=v/stream

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -56,7 +56,6 @@ void srs_discovery_tc_url(string tcUrl, string& schema, string& host, string& vh
     //      rtmp://ip/app/app2/stream?k=v
     // Where after last slash is stream.
     fullUrl += stream.empty() ? "/" : (stream.at(0) == '/' ? stream : "/" + stream);
-    fullUrl += param.empty() ? "" : (param.at(0) == '?' ? param : "?" + param);
 
     // First, we covert the FMLE URL to standard URL:
     //      rtmp://ip/app/app2?k=v/stream , or:

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -55,11 +55,9 @@ void srs_discovery_tc_url(string tcUrl, string& schema, string& host, string& vh
     // Standard URL is:
     //     rtmp://ip/app/app2/stream?k=v
     // Where after last slash is stream.
+    fullUrl += stream.empty() ? "/" : (stream.at(0) == '/' ? stream : "/" + stream);
     if (fullUrl.find_first_of("?#") == string::npos)
-    {
         fullUrl += param.empty() ? "" : (param.at(0) == '?' ? param : "?" + param);
-        fullUrl += stream.empty() ? "/" : (stream.at(0) == '/' ? stream : "/" + stream);
-    }
 
     // First, we covert the FMLE URL to standard URL:
     //      rtmp://ip/app/app2?k=v/stream , or:

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -52,6 +52,15 @@ void srs_discovery_tc_url(string tcUrl, string& schema, string& host, string& vh
     //      rtmp://ip/app?vhost=VHOST/stream
     string fullUrl = srs_string_replace(tcUrl, "...vhost...", "?vhost=");
 
+    // Standard URL is:
+    //     rtmp://ip/app/app2/stream?k=v
+    // Where after last slash is stream.
+    if (fullUrl.find_first_of("?#") == string::npos)
+    {
+        fullUrl += param.empty() ? "" : (param.at(0) == '?' ? param : "?" + param);
+        fullUrl += stream.empty() ? "/" : (stream.at(0) == '/' ? stream : "/" + stream);
+    }
+
     // First, we covert the FMLE URL to standard URL:
     //      rtmp://ip/app/app2?k=v/stream , or:
     //      rtmp://ip/app/app2#k=v/stream


### PR DESCRIPTION
This PR try to fix #3930 .

Line 59 in trunk/src/protocol/srs_protocol_utility.cpp,  causes the repeat of the param
because in some case, tcUrl has already contained param, but argument param repeat it.
And after this line, it repeats
```
fullUrl += param.empty() ? "" : (param.at(0) == '?' ? param : "?" + param);
```

line 67 to 69 below are able to get the param, if append at line 59, it will repeat
```
fullUrl = fullUrl.substr(0, pos_query) // rtmp://ip/app/app2
                  + fullUrl.substr(pos_rslash) // /stream
                  + fullUrl.substr(pos_query, pos_rslash - pos_query); // ?k=v
```

![successed!](https://github.com/user-attachments/assets/4379140e-f498-465d-ac52-25cf51692e28)


---------

`TRANS_BY_GPT4`