### PR TITLE
improve timestamp type: int -> uint.

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -1489,7 +1489,7 @@ srs_error_t SrsRtcFrameBuilder::transcode_audio(SrsRtpPacket *pkt)
     srs_error_t err = srs_success;
 
     // to common message.
-    uint32_t ts = pkt->get_avsync_time();
+    uint64_t ts = pkt->get_avsync_time();
     if (is_first_audio_) {
         int header_len = 0;
         uint8_t* header = NULL;
@@ -1543,7 +1543,7 @@ srs_error_t SrsRtcFrameBuilder::transcode_audio(SrsRtpPacket *pkt)
     return err;
 }
 
-void SrsRtcFrameBuilder::packet_aac(SrsCommonMessage* audio, char* data, int len, uint32_t pts, bool is_header)
+void SrsRtcFrameBuilder::packet_aac(SrsCommonMessage* audio, char* data, int len, uint64_t pts, bool is_header)
 {
     int rtmp_len = len + 2;
     audio->header.initialize_audio(rtmp_len, pts, 1);

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -352,7 +352,7 @@ public:
     virtual srs_error_t on_rtp(SrsRtpPacket *pkt);
 private:
     srs_error_t transcode_audio(SrsRtpPacket *pkt);
-    void packet_aac(SrsCommonMessage* audio, char* data, int len, uint32_t pts, bool is_header);
+    void packet_aac(SrsCommonMessage* audio, char* data, int len, uint64_t pts, bool is_header);
 private:
     srs_error_t packet_video(SrsRtpPacket* pkt);
     srs_error_t packet_video_key_frame(SrsRtpPacket* pkt);

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -1259,7 +1259,7 @@ class SrsFrame
 {
 public:
     // The DTS/PTS in milliseconds, which is TBN=1000.
-    int64_t dts;
+    uint64_t dts;
     // PTS = DTS + CTS.
     int32_t cts;
 public:

--- a/trunk/src/kernel/srs_kernel_flv.cpp
+++ b/trunk/src/kernel/srs_kernel_flv.cpp
@@ -109,31 +109,31 @@ void SrsMessageHeader::initialize_amf0_script(int size, int stream)
     message_type = RTMP_MSG_AMF0DataMessage;
     payload_length = (int32_t)size;
     timestamp_delta = (int32_t)0;
-    timestamp = (int64_t)0;
+    timestamp = 0;
     stream_id = (int32_t)stream;
     
     // amf0 script use connection2 chunk-id
     prefer_cid = RTMP_CID_OverConnection2;
 }
 
-void SrsMessageHeader::initialize_audio(int size, uint32_t time, int stream)
+void SrsMessageHeader::initialize_audio(int size, uint64_t time, int stream)
 {
     message_type = RTMP_MSG_AudioMessage;
     payload_length = (int32_t)size;
     timestamp_delta = (int32_t)time;
-    timestamp = (int64_t)time;
+    timestamp = time;
     stream_id = (int32_t)stream;
     
     // audio chunk-id
     prefer_cid = RTMP_CID_Audio;
 }
 
-void SrsMessageHeader::initialize_video(int size, uint32_t time, int stream)
+void SrsMessageHeader::initialize_video(int size, uint64_t time, int stream)
 {
     message_type = RTMP_MSG_VideoMessage;
     payload_length = (int32_t)size;
     timestamp_delta = (int32_t)time;
-    timestamp = (int64_t)time;
+    timestamp = time;
     stream_id = (int32_t)stream;
     
     // video chunk-id

--- a/trunk/src/kernel/srs_kernel_flv.hpp
+++ b/trunk/src/kernel/srs_kernel_flv.hpp
@@ -151,7 +151,7 @@ public:
     // The 4 bytes are packed in the big-endian order.
     // @remark, used as calc timestamp when decode and encode time.
     // @remark, we use 64bits for large time for jitter detect and hls.
-    int64_t timestamp;
+    uint64_t timestamp;
 public:
     // Get the prefered cid(chunk stream id) which sendout over.
     // set at decoding, and canbe used for directly send message,
@@ -177,9 +177,9 @@ public:
     // Create a amf0 script header, set the size and stream_id.
     void initialize_amf0_script(int size, int stream);
     // Create a audio header, set the size, timestamp and stream_id.
-    void initialize_audio(int size, uint32_t time, int stream);
+    void initialize_audio(int size, uint64_t time, int stream);
     // Create a video header, set the size, timestamp and stream_id.
-    void initialize_video(int size, uint32_t time, int stream);
+    void initialize_video(int size, uint64_t time, int stream);
 };
 
 // The message is raw data RTMP message, bytes oriented,

--- a/trunk/src/kernel/srs_kernel_rtc_rtp.hpp
+++ b/trunk/src/kernel/srs_kernel_rtc_rtp.hpp
@@ -299,7 +299,7 @@ private:
     // The helper handler for decoder, use RAW payload if NULL.
     ISrsRtspPacketDecodeHandler* decode_handler;
 private:
-    int64_t avsync_time_;
+    uint64_t avsync_time_;
 public:
     SrsRtpPacket();
     virtual ~SrsRtpPacket();
@@ -336,8 +336,8 @@ public:
 public:
     bool is_keyframe();
     // Get and set the packet sync time in milliseconds.
-    void set_avsync_time(int64_t avsync_time) { avsync_time_ = avsync_time; }
-    int64_t get_avsync_time() const { return avsync_time_; }
+    void set_avsync_time(uint64_t avsync_time) { avsync_time_ = avsync_time; }
+    uint64_t get_avsync_time() const { return avsync_time_; }
 };
 
 // Single payload data.


### PR DESCRIPTION
when I check the timestamp type from RTC -> RTMP.

RTC(uint32_t) -> RTMP (uint64_t).

Some timestamp type can be improved.

e.g. `int64_t` convert to `int32_t`.