### PR TITLE
fix compile error in srs_protocol_rtmp_stack.cpp

### DIFF
--- a/trunk/src/protocol/srs_protocol_rtmp_stack.cpp
+++ b/trunk/src/protocol/srs_protocol_rtmp_stack.cpp
@@ -539,7 +539,7 @@ srs_error_t SrsProtocol::do_send_messages(SrsSharedPtrMessage** msgs, int nb_msg
             // consume sendout bytes.
             p += payload_size;
             
-            if ((er = skt->writev(iovs, 2, NULL)) != srs_success) {
+            if ((err = skt->writev(iovs, 2, NULL)) != srs_success) {
                 return srs_error_wrap(err, "writev");
             }
         }


### PR DESCRIPTION
Fix a compiling error.

## How to reproduce?

https://github.com/ossrs/srs/blob/7951bf3bd63a33ec5bfddfba39f9d6e2d476e381/trunk/src/core/srs_core_performance.hpp#L146

Delete this line to write `iovs` one by one (or 2 by 2).
Then `./configure && make`, the compiling error appears.