### PR TITLE
WebRTC: Fix missing msid in play answer

### DIFF
--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -3274,17 +3274,17 @@ srs_error_t SrsRtcConnection::generate_play_local_sdp(SrsRequest* req, SrsSdp& l
     std::string cname = srs_random_str(16);
 
     if (audio_before_video) {
-        if ((err = generate_play_local_sdp_for_audio(local_sdp, stream_desc, cname)) != srs_success) {
+        if ((err = generate_play_local_sdp_for_audio(local_sdp, stream_desc, cname, stream_id)) != srs_success) {
             return srs_error_wrap(err, "audio");
         }
-        if ((err = generate_play_local_sdp_for_video(local_sdp, stream_desc, unified_plan, cname)) != srs_success) {
+        if ((err = generate_play_local_sdp_for_video(local_sdp, stream_desc, unified_plan, cname, stream_id)) != srs_success) {
             return srs_error_wrap(err, "video");
         }
     } else {
-        if ((err = generate_play_local_sdp_for_video(local_sdp, stream_desc, unified_plan, cname)) != srs_success) {
+        if ((err = generate_play_local_sdp_for_video(local_sdp, stream_desc, unified_plan, cname, stream_id)) != srs_success) {
             return srs_error_wrap(err, "video");
         }
-        if ((err = generate_play_local_sdp_for_audio(local_sdp, stream_desc, cname)) != srs_success) {
+        if ((err = generate_play_local_sdp_for_audio(local_sdp, stream_desc, cname, stream_id)) != srs_success) {
             return srs_error_wrap(err, "audio");
         }
     }
@@ -3292,13 +3292,14 @@ srs_error_t SrsRtcConnection::generate_play_local_sdp(SrsRequest* req, SrsSdp& l
     return err;
 }
 
-srs_error_t SrsRtcConnection::generate_play_local_sdp_for_audio(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, std::string cname)
+srs_error_t SrsRtcConnection::generate_play_local_sdp_for_audio(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, std::string cname, std::string stream_id)
 {
     srs_error_t err = srs_success;
 
     // generate audio media desc
     if (stream_desc->audio_track_desc_) {
         SrsRtcTrackDescription* audio_track = stream_desc->audio_track_desc_;
+        audio_track->msid_ = stream_id;
 
         local_sdp.media_descs_.push_back(SrsMediaDesc("audio"));
         SrsMediaDesc& local_media_desc = local_sdp.media_descs_.back();
@@ -3358,12 +3359,13 @@ srs_error_t SrsRtcConnection::generate_play_local_sdp_for_audio(SrsSdp& local_sd
     return err;
 }
 
-srs_error_t SrsRtcConnection::generate_play_local_sdp_for_video(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, bool unified_plan, std::string cname)
+srs_error_t SrsRtcConnection::generate_play_local_sdp_for_video(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, bool unified_plan, std::string cname, std::string stream_id)
 {
     srs_error_t err = srs_success;
 
     for (int i = 0;  i < (int)stream_desc->video_track_descs_.size(); ++i) {
         SrsRtcTrackDescription* track = stream_desc->video_track_descs_[i];
+        track->msid_ = stream_id;
 
         if (!unified_plan) {
             // for plan b, we only add one m= for video track.

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -554,8 +554,8 @@ private:
     //TODO: Use StreamDescription to negotiate and remove first negotiate_play_capability function
     srs_error_t negotiate_play_capability(SrsRtcUserConfig* ruc, std::map<uint32_t, SrsRtcTrackDescription*>& sub_relations);
     srs_error_t generate_play_local_sdp(SrsRequest* req, SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, bool unified_plan, bool audio_before_video);
-    srs_error_t generate_play_local_sdp_for_audio(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, std::string cname);
-    srs_error_t generate_play_local_sdp_for_video(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, bool unified_plan, std::string cname);
+    srs_error_t generate_play_local_sdp_for_audio(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, std::string cname, std::string stream_id);
+    srs_error_t generate_play_local_sdp_for_video(SrsSdp& local_sdp, SrsRtcSourceDescription* stream_desc, bool unified_plan, std::string cname, std::string stream_id);
     srs_error_t create_player(SrsRequest* request, std::map<uint32_t, SrsRtcTrackDescription*> sub_relations);
     srs_error_t create_publisher(SrsRequest* request, SrsRtcSourceDescription* stream_desc);
 };


### PR DESCRIPTION
`a=ssrc:<ssrc> msid:<stream-id> <track-id>` is missing in play answer due to not setting the msid for track, so audio and video tracks are not explicitly associated to the same stream, which may cause player avsync and compatibility issues