### PR TITLE
fix Issue 3701  : HTTP streaming support listening at both IPv4 and IPv6

### DIFF
--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -7741,6 +7741,10 @@ std::vector<std::string> SrsConfig::get_http_apis_listens()
         return ports;
     }
     conf = conf->get("listen");
+    if (!conf) {
+        ports.push_back(DEFAULT);
+        return ports;
+    }
     for (int i = 0; i < (int)conf->args.size(); i++) {
         ports.push_back(conf->args.at(i));
     }
@@ -7969,6 +7973,10 @@ std::vector<std::string> SrsConfig::get_https_apis_listens()
         return ports;
     }
     conf = conf->get("listen");
+    if (!conf) {
+        ports.push_back(DEFAULT);
+        return ports;
+    }
     for (int i = 0; i < (int)conf->args.size(); i++) {
         ports.push_back(conf->args.at(i));
     }
@@ -8405,6 +8413,10 @@ std::vector<std::string> SrsConfig::get_http_streams_listens()
         return ports;
     }
     conf = conf->get("listen");
+    if (!conf) {
+        ports.push_back(DEFAULT);
+        return ports;
+    }
     for (int i = 0; i < (int)conf->args.size(); i++) {
         ports.push_back(conf->args.at(i));
     }
@@ -8530,6 +8542,10 @@ std::vector<std::string> SrsConfig::get_https_streams_listens()
         return ports;
     }
     conf = conf->get("listen");
+    if (!conf) {
+        ports.push_back(DEFAULT);
+        return ports;
+    }
     for (int i = 0; i < (int)conf->args.size(); i++) {
         ports.push_back(conf->args.at(i));
     }

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2533,10 +2533,10 @@ srs_error_t SrsConfig::check_normal_config()
         );
 
         bool isNotSameHttp = intersection_result.size() == 0;
-        bool isFullyContainedHttp = intersection_result.size() != 0 && intersection_result.size() == api_vec.size();
+        bool isFullyContainedHttp = !isNotSameHttp && intersection_result.size() == api_vec.size();
         if (!isNotSameHttp && !isFullyContainedHttp)
         {
-            return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "http api and server have a intersection, but http server doesn't fully contain http api");
+            return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "http api and http server intersect in functionality, but an http server does not fully encapsulate an http api");
         }
         vector<string> apis_vec = get_https_apis_listens();
         vector<string> servers_vec = get_https_streams_listens();
@@ -2550,10 +2550,10 @@ srs_error_t SrsConfig::check_normal_config()
         );
 
         bool isNotSameHttps = intersections_result.size() == 0;
-        bool isFullyContainedHttps = intersections_result.size() != 0 && intersections_result.size() == apis_vec.size();
+        bool isFullyContainedHttps = !isNotSameHttps && intersections_result.size() == apis_vec.size();
         if (!isNotSameHttps && !isFullyContainedHttps)
         {
-            return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "https api and server have a intersection, but https server doesn't fully contain https api");
+            return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "https api and https server intersect in functionality, but an https server does not fully encapsulate an https api");
         }
         if (!isNotSameHttp && isNotSameHttps) {
             return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "for same http, https api != server");

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2514,15 +2514,57 @@ srs_error_t SrsConfig::check_normal_config()
     if (true) {
         string api = get_http_api_listen();
         string server = get_http_stream_listen();
-        if (api.empty()) {
+        vector<string> api_vec = get_http_apis_listens();
+        vector<string> server_vec = get_http_streams_listens();
+        if (api_vec.empty()) {
             return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "http_api.listen requires params");
         }
-        if (server.empty()) {
+        if (server_vec.empty()) {
             return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "http_server.listen requires params");
         }
 
+        std::sort(api_vec.begin(), api_vec.end());
+        std::sort(server_vec.begin(), server_vec.end());
+
+        // 교집합 결과를 저장할 벡터
+        std::vector<string> intersection_result;
+        std::vector<string> intersections_result;
+
+        // set_intersection 사용
+        std::set_intersection(
+            api_vec.begin(), api_vec.end(),
+            server_vec.begin(), server_vec.end(),
+            std::back_inserter(intersection_result)
+        );
+
+        if (intersection_result.size() != 0 && intersection_result != api_vec.size())
+        {
+            return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "http api and server have a intersection, but http server did not include http api");
+        }
+
+
         string apis = get_https_api_listen();
         string servers = get_https_stream_listen();
+        vector<string> apis_vec = get_https_apis_listens();
+        vector<string> servers_vec = get_https_streams_listens();
+
+        std::sort(apis_vec.begin(), apis_vec.end());
+        std::sort(servers_vec.begin(), servers_vec.end());
+
+        // 교집합 결과를 저장할 벡터
+
+        // set_intersection 사용
+        std::set_intersection(
+            apis_vec.begin(), apis_vec.end(),
+            servers_vec.begin(), servers_vec.end(),
+            std::back_inserter(intersections_result)
+        );
+
+       if (intersections_result.size() != 0 && intersections_result != api_vec.size())
+        {
+            return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "https api and server have a intersection, but https server did not include http api");
+        }
+        
         if (api == server && apis != servers) {
             return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "for same http, https api(%s) != server(%s)", apis.c_str(), servers.c_str());
         }
@@ -7696,6 +7738,26 @@ string SrsConfig::get_http_api_listen()
     return conf->arg0();
 }
 
+std::vector<std::string> SrsConfig::get_http_apis_listens()
+{
+    std::vector<string> ports;
+    if (!srs_getenv("srs.http_api.listen").empty()) { // SRS_LISTEN
+        return srs_string_split(srs_getenv("srs.http_api.listen"), " ");
+    }
+    string DEFAULT = "1985";
+    SrsConfDirective* conf = root->get("http_api");
+    if (!conf) {
+        ports.push_back(DEFAULT);
+        return ports;
+    }
+    
+    for (int i = 0; i < (int)conf->args.size(); i++) {
+        ports.push_back(conf->args.at(i));
+    }
+    
+    return ports;
+}
+
 bool SrsConfig::get_http_api_crossdomain()
 {
     SRS_OVERWRITE_BY_ENV_BOOL2("srs.http_api.crossdomain"); // SRS_HTTP_API_CROSSDOMAIN
@@ -7899,6 +7961,31 @@ string SrsConfig::get_https_api_listen()
 
     return conf->arg0();
 }
+
+std::vector<std::string> SrsConfig::get_https_apis_listens()
+{
+    std::vector<string> ports;
+    if (!srs_getenv("srs.http_api.https.listen").empty()) { // SRS_LISTEN
+        return srs_string_split(srs_getenv("srs.http_api.https.listen"), " ");
+    }
+    static string DEFAULT = "1990";
+        if (get_http_api_listen() == get_http_stream_listen()) {
+        DEFAULT = get_https_stream_listen();
+    }
+
+    SrsConfDirective* conf = get_https_api();
+    if (!conf) {
+        ports.push_back(DEFAULT);
+        return ports;
+    }
+    
+    for (int i = 0; i < (int)conf->args.size(); i++) {
+        ports.push_back(conf->args.at(i));
+    }
+    
+    return ports;
+}
+
 
 string SrsConfig::get_https_api_ssl_key()
 {
@@ -8315,6 +8402,25 @@ bool SrsConfig::get_http_stream_enabled(SrsConfDirective* conf)
     
     return SRS_CONF_PREFER_FALSE(conf->arg0());
 }
+std::vector<std::string> SrsConfig::get_http_streams_listens()
+{
+    std::vector<string> ports;
+    if (!srs_getenv("srs.http_server.listen").empty()) { // SRS_LISTEN
+        return srs_string_split(srs_getenv("srs.http_server.listen"), " ");
+    }
+    string DEFAULT = "8080";
+    SrsConfDirective* conf = root->get("http_server");
+    if (!conf) {
+        ports.push_back(DEFAULT);
+        return ports;
+    }
+    
+    for (int i = 0; i < (int)conf->args.size(); i++) {
+        ports.push_back(conf->args.at(i));
+    }
+    
+    return ports;
+}
 
 string SrsConfig::get_http_stream_listen()
 {
@@ -8419,6 +8525,26 @@ string SrsConfig::get_https_stream_listen()
     }
 
     return conf->arg0();
+}
+
+std::vector<std::string> SrsConfig::get_https_streams_listens()
+{
+    std::vector<string> ports;
+    if (!srs_getenv("srs.http_server.https.listen").empty()) { // SRS_LISTEN
+        return srs_string_split(srs_getenv("srs.http_server.https.listen"), " ");
+    }
+    static string DEFAULT = "8088";
+    SrsConfDirective* conf = get_https_stream();
+    if (!conf) {
+        ports.push_back(DEFAULT);
+        return ports;
+    }
+    
+    for (int i = 0; i < (int)conf->args.size(); i++) {
+        ports.push_back(conf->args.at(i));
+    }
+    
+    return ports;
 }
 
 string SrsConfig::get_https_stream_ssl_key()

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -1031,6 +1031,10 @@ public:
     virtual bool get_http_api_enabled();
     // Get the http api listen port.
     virtual std::string get_http_api_listen();
+    // Get the http api listen port.
+    // user can specifies multiple listen ports,
+    // each args of directive is a listen port.
+    virtual std::vector<std::string> get_http_apis_listens();
     // Whether enable crossdomain for http api.
     virtual bool get_http_api_crossdomain();
     // Whether enable the HTTP RAW API.
@@ -1053,6 +1057,7 @@ private:
 public:
     virtual bool get_https_api_enabled();
     virtual std::string get_https_api_listen();
+    virtual std::vector<std::string> get_https_apis_listens();
     virtual std::string get_https_api_ssl_key();
     virtual std::string get_https_api_ssl_cert();
 // http stream section
@@ -1065,6 +1070,10 @@ public:
     virtual bool get_http_stream_enabled();
     // Get the http stream listen port.
     virtual std::string get_http_stream_listen();
+    // Get the http stream listen port.
+    // user can specifies multiple listen ports,
+    // each args of directive is a listen port.
+    virtual std::vector<std::string> get_http_streams_listens();
     // Get the http stream root dir.
     virtual std::string get_http_stream_dir();
     // Whether enable crossdomain for http static and stream server.
@@ -1075,6 +1084,7 @@ private:
 public:
     virtual bool get_https_stream_enabled();
     virtual std::string get_https_stream_listen();
+    virtual std::vector<std::string> get_https_streams_listens();
     virtual std::string get_https_stream_ssl_key();
     virtual std::string get_https_stream_ssl_cert();
 public:

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -493,6 +493,13 @@ srs_error_t SrsServer::initialize()
     bool stream = _srs_config->get_http_stream_enabled();
     string http_listen = _srs_config->get_http_stream_listen();
     string https_listen = _srs_config->get_https_stream_listen();
+    vector<string> server_vec = get_http_streams_listens();
+    vector<string> servers_vec = get_https_streams_listens();
+    std::sort(server_vec.begin(), server_vec.end());
+    std::sort(servers_vec.begin(), servers_vec.end());
+
+
+
 
 #ifdef SRS_RTC
     bool rtc = _srs_config->get_rtc_server_enabled();
@@ -513,6 +520,36 @@ srs_error_t SrsServer::initialize()
     bool api = _srs_config->get_http_api_enabled();
     string api_listen = _srs_config->get_http_api_listen();
     string apis_listen = _srs_config->get_https_api_listen();
+    vector<string> api_vec = get_http_apis_listens();
+    vector<string> apis_vec = get_https_apis_listens();
+
+    std::sort(api_vec.begin(), api_vec.end());
+    std::sort(apis_vec.begin(), apis_vec.end());
+
+    std::vector<string> intersection_result;
+    std::vector<string> intersections_result;
+
+    std::set_intersection(
+        api_vec.begin(), api_vec.end(),
+        server_vec.begin(), server_vec.end(),
+        std::back_inserter(intersection_result)
+    );
+
+    if (intersection_result.size() == 0)
+    {
+        reuse_api_over_server_ = false;
+    }
+    else if (intersection_result.size() == api_vec.size())
+    {
+        reuse_api_over_server_ = true;
+    }
+    else
+    {
+        return srs_error_wrap(err, "http api initialize");
+    }
+
+    
+
     if (stream && api && api_listen == http_listen && apis_listen == https_listen) {
         srs_trace("API reuses http=%s and https=%s server", http_listen.c_str(), https_listen.c_str());
         reuse_api_over_server_ = true;

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -512,9 +512,9 @@ srs_error_t SrsServer::initialize()
             reuse_rtc_over_server_ = true;
         }
     }
-    for (int idx = 0; idx < server_vecs.size(); idx++)
+    for (int idx = 0; idx < servers_vec.size(); idx++)
     {
-        string https_listen = server_vec[idx];
+        string https_listen = servers_vec[idx];
         if (stream && rtc && rtc_tcp && https_listen == rtc_listen) {
             srs_trace("WebRTC tcp=%s reuses https=%s server", rtc_listen.c_str(), https_listen.c_str());
             reuse_rtc_over_server_ = true;

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -544,13 +544,13 @@ srs_error_t SrsServer::initialize()
         std::back_inserter(intersections_result)
     );
     bool isNotSameHttp = intersection_result.size() == 0;
-    bool isFullyContainedHttp = intersection_result.size() != 0 && intersection_result.size() == api_vec.size();
+    bool isFullyContainedHttp = !isNotSameHttp && intersection_result.size() == api_vec.size();
     bool isNotSameHttps = intersections_result.size() == 0;
-    bool isFullyContainedHttps = intersections_result.size() != 0 && intersections_result.size() == apis_vec.size();
+    bool isFullyContainedHttps = !isNotSameHttps && intersections_result.size() == apis_vec.size();
 
     if ((!isNotSameHttp && !isFullyContainedHttp) || (!isNotSameHttps && !isFullyContainedHttps))
     {
-        return srs_error_wrap(err, "http api and http server have a intersection. but http server doesn't fully contain http api");
+        return srs_error_wrap(err, "http api and http server intersect in functionality, but an http server does not fully encapsulate an http api");
     }
     
     if (stream && api && isFullyContainedHttp && isFullyContainedHttps)

--- a/trunk/src/app/srs_app_server.cpp
+++ b/trunk/src/app/srs_app_server.cpp
@@ -504,15 +504,17 @@ srs_error_t SrsServer::initialize()
     bool rtc_tcp = _srs_config->get_rtc_server_tcp_enabled();
     string rtc_listen = srs_int2str(_srs_config->get_rtc_server_tcp_listen());
     // If enabled and listen is the same value, resue port for WebRTC over TCP.
-    for (string http_listen : server_vec)
+    for (int idx = 0; idx < server_vec.size(); idx++)
     {
+        string http_listen = server_vec[idx];
         if (stream && rtc && rtc_tcp && http_listen == rtc_listen) {
             srs_trace("WebRTC tcp=%s reuses http=%s server", rtc_listen.c_str(), http_listen.c_str());
             reuse_rtc_over_server_ = true;
         }
     }
-    for (string https_listen : servers_vec)
+    for (int idx = 0; idx < server_vecs.size(); idx++)
     {
+        string https_listen = server_vec[idx];
         if (stream && rtc && rtc_tcp && https_listen == rtc_listen) {
             srs_trace("WebRTC tcp=%s reuses https=%s server", rtc_listen.c_str(), https_listen.c_str());
             reuse_rtc_over_server_ = true;
@@ -554,12 +556,14 @@ srs_error_t SrsServer::initialize()
     if (stream && api && isFullyContainedHttp && isFullyContainedHttps)
     {
         srs_trace("API reuses http and https server");
-        for (string http_listen : intersection_result)
+        for (int idx = 0; idx < intersection_result.size(); idx++)
         {
+            string http_listen = intersection_result[idx];
             srs_trace("API reuses http=%s server", http_listen.c_str());
         }
-        for (string https_listen : intersections_result)
+        for (int idx = 0; idx < intersections_result.size(); idx++)
         {
+            string https_listen = intersections_result[idx];
             srs_trace("API reuses https=%s server", https_listen.c_str());
         }
         reuse_api_over_server_ = true;

--- a/trunk/src/app/srs_app_server.hpp
+++ b/trunk/src/app/srs_app_server.hpp
@@ -119,15 +119,15 @@ private:
     // RTMP stream listeners, over TCP. 
     SrsMultipleTcpListeners* rtmp_listener_;
     // HTTP API listener, over TCP. Please note that it might reuse with stream listener.
-    SrsTcpListener* api_listener_;
+    SrsMultipleTcpListeners* api_listener_;
     // HTTPS API listener, over TCP. Please note that it might reuse with stream listener.
-    SrsTcpListener* apis_listener_;
+    SrsMultipleTcpListeners* apis_listener_;
     // HTTP server listener, over TCP. Please note that request of both HTTP static and stream are served by this
     // listener, and it might be reused by HTTP API and WebRTC TCP.
-    SrsTcpListener* http_listener_;
+    SrsMultipleTcpListeners* http_listener_;
     // HTTPS server listener, over TCP. Please note that request of both HTTP static and stream are served by this
     // listener, and it might be reused by HTTP API and WebRTC TCP.
-    SrsTcpListener* https_listener_;
+    SrsMultipleTcpListeners* https_listener_;
     // WebRTC over TCP listener. Please note that there is always a UDP listener by RTC server.
     SrsTcpListener* webrtc_listener_;
     // Stream Caster for push over HTTP-FLV.

--- a/trunk/src/app/srs_app_server.hpp
+++ b/trunk/src/app/srs_app_server.hpp
@@ -116,7 +116,7 @@ private:
     bool reuse_api_over_server_;
     // If reusing, WebRTC TCP use the same port of HTTP server.
     bool reuse_rtc_over_server_;
-    // RTMP stream listeners, over TCP.
+    // RTMP stream listeners, over TCP. 
     SrsMultipleTcpListeners* rtmp_listener_;
     // HTTP API listener, over TCP. Please note that it might reuse with stream listener.
     SrsTcpListener* api_listener_;


### PR DESCRIPTION
this pr is for #3701 

**Main Changes**

In srs_app_server.cpp, I have updated the following components:
api_listener_
apis_listener_
http_listener_
https_listener_
These components have been replaced with SrsMultipleTcpListeners to enable support for multiple port inputs. The new SrsMultipleTcpListeners operate similarly to the original SrsTcpListener but provide enhanced functionality for handling multiple ports.

**Considerations**

There is a functional relationship between api_listener_ and http_listener_ (as well as between apis_listener_ and https_listener_). Specifically, when the port of api_listener_ matches that of http_listener_, they share the same HTTP multiplexer (http_mux) for efficiency.
With the introduction of multiple port handling via SrsMultipleTcpListeners, careful consideration is required to ensure proper reuse of HTTP components without conflicts.
If the configuration option reuse_api_over_server_ is enabled, the following behavior occurs:
The APIs / and /api/v1/versions are no longer handled by SrsServer::http_handle. Instead, these requests are processed by the HTTP server components.
However, under the new design with SrsMultipleTcpListeners, if there is any overlap between the ports of api(s)_listener_ and http(s)_listener_, the following issues may arise:
Regardless of the value of reuse_api_over_server_:
An error will occur if the two listeners share any ports.
If reuse_api_over_server_ == true:
Some ports in the range of api(s)_listener_ will be unable to handle requests for / and /api/v1/versions, as these are already managed by the HTTP server components.
If reuse_api_over_server_ == false:
The overlapping ports between the two listeners will result in duplicate definitions for / and /api/v1/versions, causing conflicts.
To address these potential issues, I have implemented logic to enforce one of the following conditions:
There must be no overlap between the ports used by api(s)_listener_ and those used by http(s)_listener_.
Alternatively, the range of ports in http(s)_listener_ must fully encompass those in api(s)_listener_.
If neither condition is satisfied, an error will be raised to prevent misconfiguration and ensure consistent behavior.
