### PR TITLE
Correct the issue where the source is consistently emptied prior to configuration.

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -215,6 +215,7 @@ private:
 public:
     // Update the authentication information in request.
     virtual void update_auth(SrsRequest* r);
+    virtual void update_stream_die_at();
 private:
     // The stream source changed.
     virtual srs_error_t on_source_changed();

--- a/trunk/src/app/srs_app_source.hpp
+++ b/trunk/src/app/srs_app_source.hpp
@@ -563,6 +563,7 @@ public:
     virtual bool inactive();
     // Update the authentication information in request.
     virtual void update_auth(SrsRequest* r);
+    virtual void update_stream_die_at();
 public:
     virtual bool can_publish(bool is_edge);
     virtual srs_error_t on_meta_data(SrsCommonMessage* msg, SrsOnMetaDataPacket* metadata);

--- a/trunk/src/app/srs_app_srt_source.hpp
+++ b/trunk/src/app/srs_app_srt_source.hpp
@@ -173,6 +173,7 @@ public:
     virtual SrsContextId pre_source_id();
     // Update the authentication information in request.
     virtual void update_auth(SrsRequest* r);
+    virtual void update_stream_die_at();
 public:
     void set_bridge(ISrsStreamBridge* bridge);
 public:


### PR DESCRIPTION
Status following the completion of the create_of_fatch() operation by the stream publishing process.

---------

`TRANS_BY_GPT4`