### PR TITLE
update geekyeggo/delete-artifact to 5.0.0. v5.0.221 v6.0.163 v7.0.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: srs-cache
-      - uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # v2.0.0
+      # https://github.com/marketplace/actions/delete-artifact?version=v5.0.0#-compatibility
+      - uses: geekyeggo/delete-artifact@v5.0.0
         with:
           name: srs-cache
       ##################################################################################################################

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2025-03-18, Merge [#4302](https://github.com/ossrs/srs/pull/4302): update geekyeggo/delete-artifact to 5.0.0. v7.0.25 (#4302)
 * v7.0, 2025-03-06, Merge [#4296](https://github.com/ossrs/srs/pull/4296): Dvr: support h265 flv fragments. v7.0.24 (#4296)
 * v7.0, 2025-02-20, Merge [#4253](https://github.com/ossrs/srs/pull/4253): fix typo about heartbeat. v7.0.23 (#4253)
 * v7.0, 2025-02-19, Merge [#4291](https://github.com/ossrs/srs/pull/4291): fix ci error. v7.0.22 (#4291)
@@ -36,6 +37,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2025-03-18, Merge [#4302](https://github.com/ossrs/srs/pull/4302): update geekyeggo/delete-artifact to 5.0.0. v6.0.163 (#4302)
 * v6.0, 2025-03-06, Merge [#4296](https://github.com/ossrs/srs/pull/4296): Dvr: support h265 flv fragments. v6.0.162 (#4296)
 * v6.0, 2025-02-20, Merge [#4253](https://github.com/ossrs/srs/pull/4253): fix typo about heartbeat. v6.0.161 (#4253)
 * v6.0, 2025-02-19, Merge [#4291](https://github.com/ossrs/srs/pull/4291): fix ci error. v6.0.160 (#4291)
@@ -202,6 +204,7 @@ The changelog for SRS.
 <a name="v5-changes"></a>
 
 ## SRS 5.0 Changelog
+* v5.0, 2025-03-18, Merge [#4302](https://github.com/ossrs/srs/pull/4302): update geekyeggo/delete-artifact to 5.0.0. v5.0.221 (#4302)
 * v5.0, 2025-02-20, Merge [#4253](https://github.com/ossrs/srs/pull/4253): fix typo about heartbeat. v5.0.220 (#4253)
 * v5.0, 2025-02-19, Merge [#4291](https://github.com/ossrs/srs/pull/4291): fix ci error. v5.0.219 (#4291)
 * v5.0, 2025-01-14, Merge [#4271](https://github.com/ossrs/srs/pull/4271): update copyright to 2025. v5.0.218 (#4271)

--- a/trunk/src/core/srs_core_version5.hpp
+++ b/trunk/src/core/srs_core_version5.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       5
 #define VERSION_MINOR       0
-#define VERSION_REVISION    220
+#define VERSION_REVISION    221
 
 #endif

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       6
 #define VERSION_MINOR       0
-#define VERSION_REVISION    162
+#define VERSION_REVISION    163
 
 #endif

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       7
 #define VERSION_MINOR       0
-#define VERSION_REVISION    24
+#define VERSION_REVISION    25
 
 #endif


### PR DESCRIPTION
> https://github.com/marketplace/actions/delete-artifact?version=v5.0.0#-compatibility

The current version of `actions/upload-artifact` is `v4`, and the corresponding version for `delete-artifact` should be `v5`.



---------

`TRANS_BY_GPT4`

---------

Co-authored-by: chundonglinlin <chundonglinlin@163.com>
Co-authored-by: winlin <winlinvip@gmail.com>