### PR TITLE
Fix error about TestRtcPublish_HttpFlvPlay. v7.0.36

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,10 @@ jobs:
         run: |
           WORKDIR=$(cygpath -u $SRS_WORKSPACE) && export PATH=/usr/bin:/usr/local/bin && cd ${WORKDIR} &&
           pwd && rm -rf /usr/local/srs-cache && mkdir -p /usr/local/srs-cache/srs/trunk && ls -lh &&
-          tar xf objs.tar.bz2 -C /usr/local/srs-cache/srs/trunk/ && du -sh /usr/local/srs-cache/srs/trunk/* && 
-          cd ${WORKDIR}/trunk && ./configure --h265=on --gb28181=on --utest=on && ls -lh && du -sh * && du -sh objs/* &&
+          tar xf objs.tar.bz2 -C /usr/local/srs-cache/srs/trunk/ && 
+          du -sh /usr/local/srs-cache/srs/trunk/* && du -sh /usr/local/srs-cache/srs/trunk/objs/* && 
+          cd ${WORKDIR}/trunk && ./configure --h265=on --gb28181=on --utest=on && 
+          ls -lh && du -sh * && du -sh objs/* &&
           cd ${WORKDIR}/trunk && make utest && ./objs/srs_utest
     runs-on: windows-latest
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ To learn more about RTMP, HLS, HTTP-FLV, SRT, MPEG-DASH, WebRTC protocols, clust
 HTTP API, DVR, and transcoding, please check the documents in [English](https://ossrs.io) 
 or [Chinese](https://ossrs.net).
 
+If you want to use an IDE, VSCode is recommanded. VSCode supports macOS, Linux, and Windows 
+platforms. The settings are ready. All you need to do is open the folder with VSCode and 
+enjoy the efficiency brought by the IDE. See [VSCode README](.vscode/README.md) for details.
+
 ## Sponsor
 
 Would you like additional assistance from us? By becoming a sponsor or backer of SRS, we can provide you 

--- a/trunk/3rdparty/srs-bench/srs/rtc_test.go
+++ b/trunk/3rdparty/srs-bench/srs/rtc_test.go
@@ -2418,7 +2418,7 @@ func TestRtcPublish_HttpFlvPlay(t *testing.T) {
 				}
 				logger.Tf(ctx, "got %v tag, %v %vms %vB", nnVideo+nnAudio, tagType, timestamp, len(tag))
 
-				if audioPacketsOK, videoPacketsOK := !hasAudio || nnAudio >= 10, !hasVideo || nnVideo >= 10; audioPacketsOK && videoPacketsOK {
+				if audioPacketsOK, videoPacketsOK := hasAudio && nnAudio >= 10, hasVideo && nnVideo >= 10; audioPacketsOK && videoPacketsOK {
 					logger.Tf(ctx, "Flv recv %v/%v audio, %v/%v video", hasAudio, nnAudio, hasVideo, nnVideo)
 					cancel()
 				}

--- a/trunk/conf/regression-test.conf
+++ b/trunk/conf/regression-test.conf
@@ -50,8 +50,9 @@ vhost __defaultVhost__ {
         atc         on;
     }
     http_remux {
-        enabled     on;
-        mount       [vhost]/[app]/[stream].flv;
+        enabled         on;
+        guess_has_av    off;
+        mount           [vhost]/[app]/[stream].flv;
     }
     ingest livestream {
         enabled on;

--- a/trunk/conf/regression-test.conf
+++ b/trunk/conf/regression-test.conf
@@ -51,6 +51,7 @@ vhost __defaultVhost__ {
     }
     http_remux {
         enabled         on;
+        # Disabling 'guess_has_av' as it is not required for the current test setup.
         guess_has_av    off;
         mount           [vhost]/[app]/[stream].flv;
     }

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2025-05-29, Merge [#4363](https://github.com/ossrs/srs/pull/4363): Fix error about TestRtcPublish_HttpFlvPlay. v7.0.36 (#4363)
 * v7.0, 2025-05-29, Merge [#4362](https://github.com/ossrs/srs/pull/4362): Update VSCode launch configuration to support GDB on Linux and LLDB on macOS. v7.0.35 (#4362)
 * v7.0, 2025-05-26, Merge [#4359](https://github.com/ossrs/srs/pull/4359): update pion/webrtc to v4. v7.0.34 (#4359)
 * v7.0, 2025-05-13, Merge [#4289](https://github.com/ossrs/srs/pull/4289): rtmp2rtc: Support RTMP-to-WebRTC conversion with HEVC. v7.0.33 (#4289)

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       7
 #define VERSION_MINOR       0
-#define VERSION_REVISION    35
+#define VERSION_REVISION    36
 
 #endif


### PR DESCRIPTION
In the scenario of converting WebRTC to RTMP, this conversion will not proceed until an SenderReport is received; for reference, see: https://github.com/ossrs/srs/pull/2470.
Thus, if HTTP-FLV streaming is attempted before the SR is received, the FLV Header will contain only audio, devoid of video content.
This error can be resolved by disabling `guess_has_av` in the configuration file, since we can guarantee that both audio and video are present in the test cases.

However, in the original regression tests, the `TestRtcPublish_HttpFlvPlay` test case contains a bug:
https://github.com/ossrs/srs/blob/5a404c089baa93b906d2452ef47e2ba8a9e6211c/trunk/3rdparty/srs-bench/srs/rtc_test.go#L2421-L2424

The test would pass when `hasAudio` is true and `hasVideo` is false, which is actually incorrect. Therefore, it has been revised so that the test now only passes if both values are true.