### PR TITLE
issue#4364: try to fix memory leak for daemon run.

### DIFF
--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -1984,19 +1984,6 @@ srs_error_t SrsConfig::parse_options(int argc, char** argv)
         if (root->directives.empty()) root->get_or_create("vhost", "__defaultVhost__");
     }
 
-    // Ignore any error while detecting docker.
-    if ((err = srs_detect_docker()) != srs_success) {
-        srs_error_reset(err);
-    }
-
-    // Try to load the config if docker detect failed.
-    if (!_srs_in_docker) {
-        _srs_in_docker = _srs_config->get_in_docker();
-        if (_srs_in_docker) {
-            srs_trace("enable in_docker by config");
-        }
-    }
-
     ////////////////////////////////////////////////////////////////////////
     // check log name and level
     ////////////////////////////////////////////////////////////////////////
@@ -2941,6 +2928,22 @@ bool SrsConfig::get_in_docker()
     }
 
     return SRS_CONF_PREFER_FALSE(conf->arg0());
+}
+
+bool SrsConfig::detect_in_docker()
+{
+    srs_error_t err;
+    
+    // Ignore any error while detecting docker.
+    if ((err = srs_detect_docker()) != srs_success) {
+        srs_error_reset(err);
+    }
+
+    if (!_srs_in_docker) {
+        _srs_in_docker = get_in_docker();
+    }
+
+    return _srs_in_docker;
 }
 
 bool SrsConfig::is_full_config()

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -402,6 +402,7 @@ public:
     virtual bool get_daemon();
     // Whether srs in docker.
     virtual bool get_in_docker();
+    virtual bool detect_in_docker();
 private:
     // Whether user use full.conf
     virtual bool is_full_config();

--- a/trunk/src/app/srs_app_threads.cpp
+++ b/trunk/src/app/srs_app_threads.cpp
@@ -298,6 +298,13 @@ extern srs_error_t _srs_reload_err;
 extern SrsReloadState _srs_reload_state;
 extern std::string _srs_reload_id;
 
+extern void srs_pre_global_initialize()
+{
+    _srs_config = new SrsConfig();
+    
+    return;
+}
+
 srs_error_t srs_global_initialize()
 {
     srs_error_t err = srs_success;
@@ -305,8 +312,7 @@ srs_error_t srs_global_initialize()
     // Root global objects.
     _srs_log = new SrsFileLog();
     _srs_context = new SrsThreadContext();
-    _srs_config = new SrsConfig();
-
+    
     // The clock wall object.
     _srs_clock = new SrsWallClock();
 

--- a/trunk/src/app/srs_app_threads.hpp
+++ b/trunk/src/app/srs_app_threads.hpp
@@ -51,6 +51,7 @@ private:
 
 extern SrsCircuitBreaker* _srs_circuit_breaker;
 
+extern void srs_pre_global_initialize();
 // Initialize global shared variables cross all threads.
 extern srs_error_t srs_global_initialize();
 

--- a/trunk/src/main/srs_main_server.cpp
+++ b/trunk/src/main/srs_main_server.cpp
@@ -55,7 +55,6 @@ using namespace std;
 #endif
 
 // pre-declare
-srs_error_t run_directly_or_daemon();
 srs_error_t run_in_thread_pool();
 void show_macro_features();
 
@@ -239,10 +238,71 @@ srs_error_t do_main(int argc, char** argv, char** envp)
     __asan_set_error_report_callback(asan_report_callback);
 #endif
 
-    if ((err = run_directly_or_daemon()) != srs_success) {
+    if ((err = run_in_thread_pool()) != srs_success) {
         return srs_error_wrap(err, "run");
     }
+    
+    return err;
+}
 
+srs_error_t run_daemon(int argc, char** argv, char** envp)
+{
+    srs_error_t err = srs_success;
+
+    srs_pre_global_initialize();
+    _srs_in_docker = _srs_config->detect_in_docker();
+    
+    // Load daemon from config, disable it for docker.
+    // @see https://github.com/ossrs/srs/issues/1594
+    bool run_as_daemon = _srs_config->get_daemon();
+    if (run_as_daemon && _srs_in_docker && _srs_config->disable_daemon_for_docker()) {
+        fprintf(stdout, "disable daemon for docker");
+        run_as_daemon = false;
+    }
+
+    // If not daemon, directly run hybrid server.
+    if (!run_as_daemon) {
+        if ((err = do_main(argc, argv, envp)) != srs_success) {
+            return srs_error_wrap(err, "run thread pool");
+        }
+        return srs_success;
+    }
+    
+    fprintf(stdout, "start daemon mode...");
+    
+    int pid = fork();
+    
+    if(pid < 0) {
+        return srs_error_new(-1, "fork father process");
+    }
+    
+    // grandpa
+    if(pid > 0) {
+        int status = 0;
+        waitpid(pid, &status, 0);
+        fprintf(stderr, "grandpa process exit.");
+        exit(0);
+    }
+    
+    // father
+    pid = fork();
+    
+    if(pid < 0) {
+        return srs_error_new(-1, "fork child process");
+    }
+    
+    if(pid > 0) {
+        fprintf(stdout, "father process exit");
+        exit(0);
+    }
+    
+    // son
+    fprintf(stdout, "son(daemon) process running.");
+    
+    if ((err = do_main(argc, argv, envp)) != srs_success) {
+        return srs_error_wrap(err, "daemon run thread pool");
+    }
+    
     return err;
 }
 
@@ -255,7 +315,7 @@ int main(int argc, char** argv, char** envp)
     srs_set_primordial_stack(&p);
 #endif
 
-    srs_error_t err = do_main(argc, argv, envp);
+    srs_error_t err = run_daemon(argc, argv, envp);
 
     if (err != srs_success) {
         srs_error("Failed, %s", srs_error_desc(err).c_str());
@@ -400,64 +460,6 @@ void show_macro_features()
 #if defined(SRS_PERF_SO_SNDBUF_SIZE) && !defined(SRS_PERF_MW_SO_SNDBUF)
 #error "SRS_PERF_SO_SNDBUF_SIZE depends on SRS_PERF_MW_SO_SNDBUF"
 #endif
-}
-
-srs_error_t run_directly_or_daemon()
-{
-    srs_error_t err = srs_success;
-
-    // Load daemon from config, disable it for docker.
-    // @see https://github.com/ossrs/srs/issues/1594
-    bool run_as_daemon = _srs_config->get_daemon();
-    if (run_as_daemon && _srs_in_docker && _srs_config->disable_daemon_for_docker()) {
-        srs_warn("disable daemon for docker");
-        run_as_daemon = false;
-    }
-    
-    // If not daemon, directly run hybrid server.
-    if (!run_as_daemon) {
-        if ((err = run_in_thread_pool()) != srs_success) {
-            return srs_error_wrap(err, "run thread pool");
-        }
-        return srs_success;
-    }
-    
-    srs_trace("start daemon mode...");
-    
-    int pid = fork();
-    
-    if(pid < 0) {
-        return srs_error_new(-1, "fork father process");
-    }
-    
-    // grandpa
-    if(pid > 0) {
-        int status = 0;
-        waitpid(pid, &status, 0);
-        srs_trace("grandpa process exit.");
-        exit(0);
-    }
-    
-    // father
-    pid = fork();
-    
-    if(pid < 0) {
-        return srs_error_new(-1, "fork child process");
-    }
-    
-    if(pid > 0) {
-        srs_trace("father process exit");
-        exit(0);
-    }
-    
-    // son
-    srs_trace("son(daemon) process running.");
-    
-    if ((err = run_in_thread_pool()) != srs_success) {
-        return srs_error_wrap(err, "daemon run thread pool");
-    }
-    
-    return err;
 }
 
 srs_error_t run_hybrid_server(void* arg);

--- a/trunk/src/utest/srs_utest.cpp
+++ b/trunk/src/utest/srs_utest.cpp
@@ -58,6 +58,8 @@ static void srs_srt_utest_null_log_handler(void* opaque, int level, const char* 
 srs_error_t prepare_main() {
     srs_error_t err = srs_success;
 
+    srs_pre_global_initialize();
+    
     if ((err = srs_global_initialize()) != srs_success) {
         return srs_error_wrap(err, "init global");
     }


### PR DESCRIPTION
This PR is try to workaround #4364. 
The memory continues increase problem didn't appear in the PR, but the root cause is not yet founded, by moving global initialize code into srs_pre_global_initialize(), It seems those 2 instructions may trigger this memory issue.

```
    _srs_log = new SrsFileLog();
    _srs_context = new SrsThreadContext();
```
