### PR TITLE
Refactor: Convert HTTP hooks from static methods to interface-based architecture. v7.0.58

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,6 +65,8 @@
         "streambuf": "cpp",
         "typeinfo": "cpp",
         "variant": "cpp",
-        "algorithm": "cpp"
+        "algorithm": "cpp",
+        "span": "cpp",
+        "unordered_set": "cpp"
     }
 }

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2025-08-19, Merge [#4444](https://github.com/ossrs/srs/pull/4444): AI: Refine hooks from static to instance functions. v7.0.58 (#4444)
 * v7.0, 2025-08-19, Merge [#3126](https://github.com/ossrs/srs/pull/3126): HLS: restore HLS information when republish stream.(#3088). v7.0.57 (#3126)
 * v7.0, 2025-08-18, Merge [#4443](https://github.com/ossrs/srs/pull/4443): Support RTMPS server. v7.0.56 (#4443)
 * v7.0, 2025-08-16, Merge [#4441](https://github.com/ossrs/srs/pull/4441): fix err memory leak in rtc to rtmp bridge. v7.0.55 (#4441)

--- a/trunk/src/app/srs_app_dvr.cpp
+++ b/trunk/src/app/srs_app_dvr.cpp
@@ -551,7 +551,7 @@ srs_error_t SrsDvrAsyncCallOnDvr::call()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_dvr(cid, url, req, path)) != srs_success) {
+        if ((err = _srs_hooks->on_dvr(cid, url, req, path)) != srs_success) {
             return srs_error_wrap(err, "callback on_dvr %s", url.c_str());
         }
     }

--- a/trunk/src/app/srs_app_hls.cpp
+++ b/trunk/src/app/srs_app_hls.cpp
@@ -296,7 +296,7 @@ srs_error_t SrsDvrAsyncCallOnHls::call()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_hls(cid, url, req, path, ts_url, m3u8, m3u8_url, seq_no, duration)) != srs_success) {
+        if ((err = _srs_hooks->on_hls(cid, url, req, path, ts_url, m3u8, m3u8_url, seq_no, duration)) != srs_success) {
             return srs_error_wrap(err, "callback on_hls %s", url.c_str());
         }
     }
@@ -347,7 +347,7 @@ srs_error_t SrsDvrAsyncCallOnHlsNotify::call()
     int nb_notify = _srs_config->get_vhost_hls_nb_notify(req->vhost);
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_hls_notify(cid, url, req, ts_url, nb_notify)) != srs_success) {
+        if ((err = _srs_hooks->on_hls_notify(cid, url, req, ts_url, nb_notify)) != srs_success) {
             return srs_error_wrap(err, "callback on_hls_notify %s", url.c_str());
         }
     }

--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -33,6 +33,9 @@ using namespace std;
 // the timeout for hls notify, in srs_utime_t.
 #define SRS_HLS_NOTIFY_TIMEOUT (10 * SRS_UTIME_SECONDS)
 
+// Global HTTP hooks instance
+SrsHttpHooks* _srs_hooks = NULL;
+
 SrsHttpHooks::SrsHttpHooks()
 {
 }

--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -34,7 +34,7 @@ using namespace std;
 #define SRS_HLS_NOTIFY_TIMEOUT (10 * SRS_UTIME_SECONDS)
 
 // Global HTTP hooks instance
-ISrsHttpHooks* _srs_hooks = NULL;
+ISrsHttpHooks *_srs_hooks = NULL;
 
 ISrsHttpHooks::ISrsHttpHooks()
 {

--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -34,7 +34,15 @@ using namespace std;
 #define SRS_HLS_NOTIFY_TIMEOUT (10 * SRS_UTIME_SECONDS)
 
 // Global HTTP hooks instance
-SrsHttpHooks* _srs_hooks = NULL;
+ISrsHttpHooks* _srs_hooks = NULL;
+
+ISrsHttpHooks::ISrsHttpHooks()
+{
+}
+
+ISrsHttpHooks::~ISrsHttpHooks()
+{
+}
 
 SrsHttpHooks::SrsHttpHooks()
 {

--- a/trunk/src/app/srs_app_http_hooks.hpp
+++ b/trunk/src/app/srs_app_http_hooks.hpp
@@ -18,46 +18,43 @@ class SrsRequest;
 class SrsHttpParser;
 class SrsHttpClient;
 
-// the http hooks, http callback api,
-// for some event, such as on_connect, call
-// a http api(hooks).
-class SrsHttpHooks
+class ISrsHttpHooks
 {
 public:
-    SrsHttpHooks();
-    virtual ~SrsHttpHooks();
+    ISrsHttpHooks();
+    virtual ~ISrsHttpHooks();
 
 public:
     // The on_connect hook, when client connect to srs.
     // @param url the api server url, to valid the client.
     //         ignore if empty.
-    srs_error_t on_connect(std::string url, SrsRequest *req);
+    virtual srs_error_t on_connect(std::string url, SrsRequest *req) = 0;
     // The on_close hook, when client disconnect to srs, where client is valid by on_connect.
     // @param url the api server url, to process the event.
     //         ignore if empty.
-    void on_close(std::string url, SrsRequest *req, int64_t send_bytes, int64_t recv_bytes);
+    virtual void on_close(std::string url, SrsRequest *req, int64_t send_bytes, int64_t recv_bytes) = 0;
     // The on_publish hook, when client(encoder) start to publish stream
     // @param url the api server url, to valid the client.
     //         ignore if empty.
-    srs_error_t on_publish(std::string url, SrsRequest *req);
+    virtual srs_error_t on_publish(std::string url, SrsRequest *req) = 0;
     // The on_unpublish hook, when client(encoder) stop publish stream.
     // @param url the api server url, to process the event.
     //         ignore if empty.
-    void on_unpublish(std::string url, SrsRequest *req);
+    virtual void on_unpublish(std::string url, SrsRequest *req) = 0;
     // The on_play hook, when client start to play stream.
     // @param url the api server url, to valid the client.
     //         ignore if empty.
-    srs_error_t on_play(std::string url, SrsRequest *req);
+    virtual srs_error_t on_play(std::string url, SrsRequest *req) = 0;
     // The on_stop hook, when client stop to play the stream.
     // @param url the api server url, to process the event.
     //         ignore if empty.
-    void on_stop(std::string url, SrsRequest *req);
+    virtual void on_stop(std::string url, SrsRequest *req) = 0;
     // The on_dvr hook, when reap a dvr file.
     // @param url the api server url, to process the event.
     //         ignore if empty.
     // @param file the file path, can be relative or absolute path.
     // @param cid the source connection cid, for the on_dvr is async call.
-    srs_error_t on_dvr(SrsContextId cid, std::string url, SrsRequest *req, std::string file);
+    virtual srs_error_t on_dvr(SrsContextId cid, std::string url, SrsRequest *req, std::string file) = 0;
     // When hls reap segment, callback.
     // @param url the api server url, to process the event.
     //         ignore if empty.
@@ -68,20 +65,41 @@ public:
     // @param sn the seq_no, the sequence number of ts in hls/m3u8.
     // @param duration the segment duration in srs_utime_t.
     // @param cid the source connection cid, for the on_dvr is async call.
-    srs_error_t on_hls(SrsContextId cid, std::string url, SrsRequest *req, std::string file, std::string ts_url,
-                       std::string m3u8, std::string m3u8_url, int sn, srs_utime_t duration);
+    virtual srs_error_t on_hls(SrsContextId cid, std::string url, SrsRequest *req, std::string file, std::string ts_url,
+                       std::string m3u8, std::string m3u8_url, int sn, srs_utime_t duration) = 0;
     // When hls reap segment, callback.
     // @param url the api server url, to process the event.
     //         ignore if empty.
     // @param ts_url the ts uri, used to replace the variable [ts_url] in url.
     // @param nb_notify the max bytes to read from notify server.
     // @param cid the source connection cid, for the on_dvr is async call.
-    srs_error_t on_hls_notify(SrsContextId cid, std::string url, SrsRequest *req, std::string ts_url, int nb_notify);
+    virtual srs_error_t on_hls_notify(SrsContextId cid, std::string url, SrsRequest *req, std::string ts_url, int nb_notify) = 0;
     // Discover co-workers for origin cluster.
-    srs_error_t discover_co_workers(std::string url, std::string &host, int &port);
+    virtual srs_error_t discover_co_workers(std::string url, std::string &host, int &port) = 0;
     // The on_forward_backend hook, when publish stream start to forward
     // @param url the api server url, to valid the client.
     //         ignore if empty.
+    virtual srs_error_t on_forward_backend(std::string url, SrsRequest *req, std::vector<std::string> &rtmp_urls) = 0;
+};
+
+class SrsHttpHooks : public ISrsHttpHooks
+{
+public:
+    SrsHttpHooks();
+    virtual ~SrsHttpHooks();
+
+public:
+    srs_error_t on_connect(std::string url, SrsRequest *req);
+    void on_close(std::string url, SrsRequest *req, int64_t send_bytes, int64_t recv_bytes);
+    srs_error_t on_publish(std::string url, SrsRequest *req);
+    void on_unpublish(std::string url, SrsRequest *req);
+    srs_error_t on_play(std::string url, SrsRequest *req);
+    void on_stop(std::string url, SrsRequest *req);
+    srs_error_t on_dvr(SrsContextId cid, std::string url, SrsRequest *req, std::string file);
+    srs_error_t on_hls(SrsContextId cid, std::string url, SrsRequest *req, std::string file, std::string ts_url,
+                       std::string m3u8, std::string m3u8_url, int sn, srs_utime_t duration);
+    srs_error_t on_hls_notify(SrsContextId cid, std::string url, SrsRequest *req, std::string ts_url, int nb_notify);
+    srs_error_t discover_co_workers(std::string url, std::string &host, int &port);
     srs_error_t on_forward_backend(std::string url, SrsRequest *req, std::vector<std::string> &rtmp_urls);
 
 private:
@@ -89,6 +107,6 @@ private:
 };
 
 // Global HTTP hooks instance
-extern SrsHttpHooks* _srs_hooks;
+extern ISrsHttpHooks* _srs_hooks;
 
 #endif

--- a/trunk/src/app/srs_app_http_hooks.hpp
+++ b/trunk/src/app/srs_app_http_hooks.hpp
@@ -18,6 +18,16 @@ class SrsRequest;
 class SrsHttpParser;
 class SrsHttpClient;
 
+// HTTP hooks interface for SRS server event callbacks.
+//
+// This interface defines the contract for handling various server events
+// through HTTP callback APIs. Implementations can send HTTP requests to
+// external services to notify them of events like client connections,
+// stream publishing/playing, DVR recording, HLS segment generation, etc.
+//
+// All hook methods that return srs_error_t are used for validation and
+// can reject the operation by returning an error. Methods that return void
+// are notification-only and cannot prevent the operation.
 class ISrsHttpHooks
 {
 public:
@@ -25,61 +35,116 @@ public:
     virtual ~ISrsHttpHooks();
 
 public:
-    // The on_connect hook, when client connect to srs.
-    // @param url the api server url, to valid the client.
-    //         ignore if empty.
-    virtual srs_error_t on_connect(std::string url, SrsRequest *req) = 0;
-    // The on_close hook, when client disconnect to srs, where client is valid by on_connect.
-    // @param url the api server url, to process the event.
-    //         ignore if empty.
-    virtual void on_close(std::string url, SrsRequest *req, int64_t send_bytes, int64_t recv_bytes) = 0;
-    // The on_publish hook, when client(encoder) start to publish stream
-    // @param url the api server url, to valid the client.
-    //         ignore if empty.
+    // Stream start publishing validation hook.
+    // Called when a client (encoder) attempts to start publishing a stream.
+    // This hook can be used to authorize stream publishing or apply publishing policies.
+    // @param url The HTTP callback URL for publish validation. If empty, hook is ignored.
+    // @param req The publish request information including stream details.
+    // @return srs_success if publishing is allowed, error otherwise to reject publishing.
     virtual srs_error_t on_publish(std::string url, SrsRequest *req) = 0;
-    // The on_unpublish hook, when client(encoder) stop publish stream.
-    // @param url the api server url, to process the event.
-    //         ignore if empty.
+
+    // Stream stop publishing notification hook.
+    // Called when a client (encoder) stops publishing a stream.
+    // This is a notification-only hook that cannot prevent the unpublishing.
+    // @param url The HTTP callback URL for unpublish notification. If empty, hook is ignored.
+    // @param req The unpublish request information.
     virtual void on_unpublish(std::string url, SrsRequest *req) = 0;
-    // The on_play hook, when client start to play stream.
-    // @param url the api server url, to valid the client.
-    //         ignore if empty.
+
+    // Stream start playing validation hook.
+    // Called when a client attempts to start playing/subscribing to a stream.
+    // This hook can be used to authorize stream access or apply viewing policies.
+    // @param url The HTTP callback URL for play validation. If empty, hook is ignored.
+    // @param req The play request information including stream details.
+    // @return srs_success if playing is allowed, error otherwise to reject playing.
     virtual srs_error_t on_play(std::string url, SrsRequest *req) = 0;
-    // The on_stop hook, when client stop to play the stream.
-    // @param url the api server url, to process the event.
-    //         ignore if empty.
+
+    // Stream stop playing notification hook.
+    // Called when a client stops playing/subscribing to a stream.
+    // This is a notification-only hook that cannot prevent the stop operation.
+    // @param url The HTTP callback URL for stop notification. If empty, hook is ignored.
+    // @param req The stop request information.
     virtual void on_stop(std::string url, SrsRequest *req) = 0;
-    // The on_dvr hook, when reap a dvr file.
-    // @param url the api server url, to process the event.
-    //         ignore if empty.
-    // @param file the file path, can be relative or absolute path.
-    // @param cid the source connection cid, for the on_dvr is async call.
+
+public:
+    // DVR file completion notification hook.
+    // Called when a DVR recording file is completed and ready for processing.
+    // This hook can be used to trigger post-processing, upload, or notification workflows.
+    // Note: This is an asynchronous callback, so the connection context may differ.
+    // @param cid The source connection context ID for tracking the original stream.
+    // @param url The HTTP callback URL for DVR notification. If empty, hook is ignored.
+    // @param req The original stream request information.
+    // @param file The completed DVR file path (can be relative or absolute).
+    // @return srs_success if processing succeeds, error otherwise (logged but doesn't affect DVR).
     virtual srs_error_t on_dvr(SrsContextId cid, std::string url, SrsRequest *req, std::string file) = 0;
-    // When hls reap segment, callback.
-    // @param url the api server url, to process the event.
-    //         ignore if empty.
-    // @param file the ts file path, can be relative or absolute path.
-    // @param ts_url the ts url, which used for m3u8.
-    // @param m3u8 the m3u8 file path, can be relative or absolute path.
-    // @param m3u8_url the m3u8 url, which is used for the http mount path.
-    // @param sn the seq_no, the sequence number of ts in hls/m3u8.
-    // @param duration the segment duration in srs_utime_t.
-    // @param cid the source connection cid, for the on_dvr is async call.
+
+public:
+    // HLS segment completion notification hook.
+    // Called when an HLS segment (.ts file) is generated and the playlist is updated.
+    // This hook can be used for CDN synchronization, analytics, or custom HLS workflows.
+    // Note: This is an asynchronous callback, so the connection context may differ.
+    // @param cid The source connection context ID for tracking the original stream.
+    // @param url The HTTP callback URL for HLS notification. If empty, hook is ignored.
+    // @param req The original stream request information.
+    // @param file The generated TS segment file path (can be relative or absolute).
+    // @param ts_url The TS segment URL as it appears in the M3U8 playlist.
+    // @param m3u8 The M3U8 playlist file path (can be relative or absolute).
+    // @param m3u8_url The M3U8 playlist URL for HTTP access.
+    // @param sn The sequence number of the TS segment in the HLS playlist.
+    // @param duration The segment duration in microseconds (srs_utime_t).
+    // @return srs_success if processing succeeds, error otherwise (logged but doesn't affect HLS).
     virtual srs_error_t on_hls(SrsContextId cid, std::string url, SrsRequest *req, std::string file, std::string ts_url,
-                       std::string m3u8, std::string m3u8_url, int sn, srs_utime_t duration) = 0;
-    // When hls reap segment, callback.
-    // @param url the api server url, to process the event.
-    //         ignore if empty.
-    // @param ts_url the ts uri, used to replace the variable [ts_url] in url.
-    // @param nb_notify the max bytes to read from notify server.
-    // @param cid the source connection cid, for the on_dvr is async call.
+                               std::string m3u8, std::string m3u8_url, int sn, srs_utime_t duration) = 0;
+
+    // HLS segment notification hook with custom URL template.
+    // Called when an HLS segment is generated, allowing custom URL template processing.
+    // The callback URL can contain variables like [ts_url] that will be replaced.
+    // Note: This is an asynchronous callback, so the connection context may differ.
+    // @param cid The source connection context ID for tracking the original stream.
+    // @param url The HTTP callback URL template for HLS notification. If empty, hook is ignored.
+    // @param req The original stream request information.
+    // @param ts_url The TS segment URL to replace [ts_url] variable in the callback URL.
+    // @param nb_notify Maximum bytes to read from the notification server response.
+    // @return srs_success if processing succeeds, error otherwise (logged but doesn't affect HLS).
     virtual srs_error_t on_hls_notify(SrsContextId cid, std::string url, SrsRequest *req, std::string ts_url, int nb_notify) = 0;
-    // Discover co-workers for origin cluster.
+
+public:
+    // Origin cluster co-worker discovery hook.
+    // Called to discover available co-worker servers in an origin cluster setup.
+    // This enables dynamic load balancing and failover in clustered deployments.
+    // @param url The HTTP callback URL for co-worker discovery. If empty, hook is ignored.
+    // @param host Output parameter to receive the discovered co-worker host/IP.
+    // @param port Output parameter to receive the discovered co-worker port.
+    // @return srs_success if co-worker is discovered, error otherwise.
     virtual srs_error_t discover_co_workers(std::string url, std::string &host, int &port) = 0;
-    // The on_forward_backend hook, when publish stream start to forward
-    // @param url the api server url, to valid the client.
-    //         ignore if empty.
+
+public:
+    // Stream forwarding backend discovery hook.
+    // Called when a published stream needs to be forwarded to backend servers.
+    // This hook can dynamically determine which RTMP URLs to forward the stream to.
+    // @param url The HTTP callback URL for backend discovery. If empty, hook is ignored.
+    // @param req The publish request information.
+    // @param rtmp_urls Output parameter to receive the list of RTMP URLs for forwarding.
+    // @return srs_success if backends are discovered, error otherwise.
     virtual srs_error_t on_forward_backend(std::string url, SrsRequest *req, std::vector<std::string> &rtmp_urls) = 0;
+
+    // Deprecated hooks.
+public:
+    // Client connection validation hook.
+    // Called when a client attempts to connect to the SRS server.
+    // This hook can be used to authenticate or authorize client connections.
+    // @param url The HTTP callback URL for client validation. If empty, hook is ignored.
+    // @param req The client request information including IP, vhost, app, stream, etc.
+    // @return srs_success if connection is allowed, error otherwise to reject connection.
+    virtual srs_error_t on_connect(std::string url, SrsRequest *req) = 0;
+
+    // Client disconnection notification hook.
+    // Called when a client disconnects from the SRS server.
+    // This is a notification-only hook that cannot prevent the disconnection.
+    // @param url The HTTP callback URL for disconnect notification. If empty, hook is ignored.
+    // @param req The client request information.
+    // @param send_bytes Total bytes sent to the client during the session.
+    // @param recv_bytes Total bytes received from the client during the session.
+    virtual void on_close(std::string url, SrsRequest *req, int64_t send_bytes, int64_t recv_bytes) = 0;
 };
 
 class SrsHttpHooks : public ISrsHttpHooks
@@ -107,6 +172,6 @@ private:
 };
 
 // Global HTTP hooks instance
-extern ISrsHttpHooks* _srs_hooks;
+extern ISrsHttpHooks *_srs_hooks;
 
 #endif

--- a/trunk/src/app/srs_app_http_hooks.hpp
+++ b/trunk/src/app/srs_app_http_hooks.hpp
@@ -21,46 +21,43 @@ class SrsHttpClient;
 // the http hooks, http callback api,
 // for some event, such as on_connect, call
 // a http api(hooks).
-// TODO: Refine to global variable.
 class SrsHttpHooks
 {
-private:
-    SrsHttpHooks();
-
 public:
+    SrsHttpHooks();
     virtual ~SrsHttpHooks();
 
 public:
     // The on_connect hook, when client connect to srs.
     // @param url the api server url, to valid the client.
     //         ignore if empty.
-    static srs_error_t on_connect(std::string url, SrsRequest *req);
+    srs_error_t on_connect(std::string url, SrsRequest *req);
     // The on_close hook, when client disconnect to srs, where client is valid by on_connect.
     // @param url the api server url, to process the event.
     //         ignore if empty.
-    static void on_close(std::string url, SrsRequest *req, int64_t send_bytes, int64_t recv_bytes);
+    void on_close(std::string url, SrsRequest *req, int64_t send_bytes, int64_t recv_bytes);
     // The on_publish hook, when client(encoder) start to publish stream
     // @param url the api server url, to valid the client.
     //         ignore if empty.
-    static srs_error_t on_publish(std::string url, SrsRequest *req);
+    srs_error_t on_publish(std::string url, SrsRequest *req);
     // The on_unpublish hook, when client(encoder) stop publish stream.
     // @param url the api server url, to process the event.
     //         ignore if empty.
-    static void on_unpublish(std::string url, SrsRequest *req);
+    void on_unpublish(std::string url, SrsRequest *req);
     // The on_play hook, when client start to play stream.
     // @param url the api server url, to valid the client.
     //         ignore if empty.
-    static srs_error_t on_play(std::string url, SrsRequest *req);
+    srs_error_t on_play(std::string url, SrsRequest *req);
     // The on_stop hook, when client stop to play the stream.
     // @param url the api server url, to process the event.
     //         ignore if empty.
-    static void on_stop(std::string url, SrsRequest *req);
+    void on_stop(std::string url, SrsRequest *req);
     // The on_dvr hook, when reap a dvr file.
     // @param url the api server url, to process the event.
     //         ignore if empty.
     // @param file the file path, can be relative or absolute path.
     // @param cid the source connection cid, for the on_dvr is async call.
-    static srs_error_t on_dvr(SrsContextId cid, std::string url, SrsRequest *req, std::string file);
+    srs_error_t on_dvr(SrsContextId cid, std::string url, SrsRequest *req, std::string file);
     // When hls reap segment, callback.
     // @param url the api server url, to process the event.
     //         ignore if empty.
@@ -71,24 +68,27 @@ public:
     // @param sn the seq_no, the sequence number of ts in hls/m3u8.
     // @param duration the segment duration in srs_utime_t.
     // @param cid the source connection cid, for the on_dvr is async call.
-    static srs_error_t on_hls(SrsContextId cid, std::string url, SrsRequest *req, std::string file, std::string ts_url,
-                              std::string m3u8, std::string m3u8_url, int sn, srs_utime_t duration);
+    srs_error_t on_hls(SrsContextId cid, std::string url, SrsRequest *req, std::string file, std::string ts_url,
+                       std::string m3u8, std::string m3u8_url, int sn, srs_utime_t duration);
     // When hls reap segment, callback.
     // @param url the api server url, to process the event.
     //         ignore if empty.
     // @param ts_url the ts uri, used to replace the variable [ts_url] in url.
     // @param nb_notify the max bytes to read from notify server.
     // @param cid the source connection cid, for the on_dvr is async call.
-    static srs_error_t on_hls_notify(SrsContextId cid, std::string url, SrsRequest *req, std::string ts_url, int nb_notify);
+    srs_error_t on_hls_notify(SrsContextId cid, std::string url, SrsRequest *req, std::string ts_url, int nb_notify);
     // Discover co-workers for origin cluster.
-    static srs_error_t discover_co_workers(std::string url, std::string &host, int &port);
+    srs_error_t discover_co_workers(std::string url, std::string &host, int &port);
     // The on_forward_backend hook, when publish stream start to forward
     // @param url the api server url, to valid the client.
     //         ignore if empty.
-    static srs_error_t on_forward_backend(std::string url, SrsRequest *req, std::vector<std::string> &rtmp_urls);
+    srs_error_t on_forward_backend(std::string url, SrsRequest *req, std::vector<std::string> &rtmp_urls);
 
 private:
-    static srs_error_t do_post(SrsHttpClient *hc, std::string url, std::string req, int &code, std::string &res);
+    srs_error_t do_post(SrsHttpClient *hc, std::string url, std::string req, int &code, std::string &res);
 };
+
+// Global HTTP hooks instance
+extern SrsHttpHooks* _srs_hooks;
 
 #endif

--- a/trunk/src/app/srs_app_http_static.cpp
+++ b/trunk/src/app/srs_app_http_static.cpp
@@ -333,7 +333,7 @@ srs_error_t SrsHlsStream::http_hooks_on_play(SrsRequest *req)
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_play(url, req)) != srs_success) {
+        if ((err = _srs_hooks->on_play(url, req)) != srs_success) {
             return srs_error_wrap(err, "http on_play %s", url.c_str());
         }
     }
@@ -365,7 +365,7 @@ void SrsHlsStream::http_hooks_on_stop(SrsRequest *req)
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_stop(url, req);
+        _srs_hooks->on_stop(url, req);
     }
 
     return;

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -906,7 +906,7 @@ srs_error_t SrsLiveStream::http_hooks_on_play(ISrsHttpMessage *r)
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_play(url, nreq.get())) != srs_success) {
+        if ((err = _srs_hooks->on_play(url, nreq.get())) != srs_success) {
             return srs_error_wrap(err, "http on_play %s", url.c_str());
         }
     }
@@ -942,7 +942,7 @@ void SrsLiveStream::http_hooks_on_stop(ISrsHttpMessage *r)
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_stop(url, nreq.get());
+        _srs_hooks->on_stop(url, nreq.get());
     }
 
     return;

--- a/trunk/src/app/srs_app_rtc_api.cpp
+++ b/trunk/src/app/srs_app_rtc_api.cpp
@@ -317,7 +317,7 @@ srs_error_t SrsGoApiRtcPlay::http_hooks_on_play(SrsRequest *req)
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_play(url, req)) != srs_success) {
+        if ((err = _srs_hooks->on_play(url, req)) != srs_success) {
             return srs_error_wrap(err, "on_play %s", url.c_str());
         }
     }
@@ -590,7 +590,7 @@ srs_error_t SrsGoApiRtcPublish::http_hooks_on_publish(SrsRequest *req)
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_publish(url, req)) != srs_success) {
+        if ((err = _srs_hooks->on_publish(url, req)) != srs_success) {
             return srs_error_wrap(err, "rtmp on_publish %s", url.c_str());
         }
     }

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -403,7 +403,7 @@ srs_error_t SrsRtcAsyncCallOnStop::call()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_stop(url, req);
+        _srs_hooks->on_stop(url, req);
     }
 
     return err;
@@ -1061,7 +1061,7 @@ srs_error_t SrsRtcAsyncCallOnUnpublish::call()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_unpublish(url, req);
+        _srs_hooks->on_unpublish(url, req);
     }
 
     return err;

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -807,7 +807,7 @@ srs_error_t SrsRtmpConn::playing(SrsSharedPtr<SrsLiveSource> source)
             string coworker = coworkers.at(i);
 
             string url = "http://" + coworker + "/api/v1/clusters?" + "vhost=" + req->vhost + "&ip=" + req->host + "&app=" + req->app + "&stream=" + req->stream + "&coworker=" + coworker;
-            if ((err = SrsHttpHooks::discover_co_workers(url, host, port)) != srs_success) {
+            if ((err = _srs_hooks->discover_co_workers(url, host, port)) != srs_success) {
                 // If failed to discovery stream in this coworker, we should request the next one util the last.
                 // @see https://github.com/ossrs/srs/issues/1223
                 if (i < (int)coworkers.size() - 1) {
@@ -1516,7 +1516,7 @@ srs_error_t SrsRtmpConn::http_hooks_on_connect()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_connect(url, req)) != srs_success) {
+        if ((err = _srs_hooks->on_connect(url, req)) != srs_success) {
             return srs_error_wrap(err, "rtmp on_connect %s", url.c_str());
         }
     }
@@ -1549,7 +1549,7 @@ void SrsRtmpConn::http_hooks_on_close()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_close(url, req, transport_->get_send_bytes(), transport_->get_recv_bytes());
+        _srs_hooks->on_close(url, req, transport_->get_send_bytes(), transport_->get_recv_bytes());
     }
 }
 
@@ -1580,7 +1580,7 @@ srs_error_t SrsRtmpConn::http_hooks_on_publish()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_publish(url, req)) != srs_success) {
+        if ((err = _srs_hooks->on_publish(url, req)) != srs_success) {
             return srs_error_wrap(err, "rtmp on_publish %s", url.c_str());
         }
     }
@@ -1613,7 +1613,7 @@ void SrsRtmpConn::http_hooks_on_unpublish()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_unpublish(url, req);
+        _srs_hooks->on_unpublish(url, req);
     }
 }
 
@@ -1644,7 +1644,7 @@ srs_error_t SrsRtmpConn::http_hooks_on_play()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_play(url, req)) != srs_success) {
+        if ((err = _srs_hooks->on_play(url, req)) != srs_success) {
             return srs_error_wrap(err, "rtmp on_play %s", url.c_str());
         }
     }
@@ -1677,7 +1677,7 @@ void SrsRtmpConn::http_hooks_on_stop()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_stop(url, req);
+        _srs_hooks->on_stop(url, req);
     }
 
     return;

--- a/trunk/src/app/srs_app_rtsp_conn.cpp
+++ b/trunk/src/app/srs_app_rtsp_conn.cpp
@@ -876,7 +876,7 @@ srs_error_t SrsRtspConnection::http_hooks_on_play(SrsRequest *req)
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_play(url, req)) != srs_success) {
+        if ((err = _srs_hooks->on_play(url, req)) != srs_success) {
             return srs_error_wrap(err, "on_play %s", url.c_str());
         }
     }

--- a/trunk/src/app/srs_app_source.cpp
+++ b/trunk/src/app/srs_app_source.cpp
@@ -1514,7 +1514,7 @@ srs_error_t SrsOriginHub::create_backend_forwarders(bool &applied)
 
     // get urls on forward backend
     std::vector<std::string> urls;
-    if ((err = SrsHttpHooks::on_forward_backend(backend_url, req_, urls)) != srs_success) {
+    if ((err = _srs_hooks->on_forward_backend(backend_url, req_, urls)) != srs_success) {
         return srs_error_wrap(err, "get forward backend failed, backend=%s", backend_url.c_str());
     }
 

--- a/trunk/src/app/srs_app_srt_conn.cpp
+++ b/trunk/src/app/srs_app_srt_conn.cpp
@@ -614,7 +614,7 @@ srs_error_t SrsMpegtsSrtConn::http_hooks_on_connect()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_connect(url, req_)) != srs_success) {
+        if ((err = _srs_hooks->on_connect(url, req_)) != srs_success) {
             return srs_error_wrap(err, "srt on_connect %s", url.c_str());
         }
     }
@@ -645,7 +645,7 @@ void SrsMpegtsSrtConn::http_hooks_on_close()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_close(url, req_, srt_conn_->get_send_bytes(), srt_conn_->get_recv_bytes());
+        _srs_hooks->on_close(url, req_, srt_conn_->get_send_bytes(), srt_conn_->get_recv_bytes());
     }
 }
 
@@ -674,7 +674,7 @@ srs_error_t SrsMpegtsSrtConn::http_hooks_on_publish()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_publish(url, req_)) != srs_success) {
+        if ((err = _srs_hooks->on_publish(url, req_)) != srs_success) {
             return srs_error_wrap(err, "srt on_publish %s", url.c_str());
         }
     }
@@ -705,7 +705,7 @@ void SrsMpegtsSrtConn::http_hooks_on_unpublish()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_unpublish(url, req_);
+        _srs_hooks->on_unpublish(url, req_);
     }
 }
 
@@ -734,7 +734,7 @@ srs_error_t SrsMpegtsSrtConn::http_hooks_on_play()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = SrsHttpHooks::on_play(url, req_)) != srs_success) {
+        if ((err = _srs_hooks->on_play(url, req_)) != srs_success) {
             return srs_error_wrap(err, "srt on_play %s", url.c_str());
         }
     }
@@ -765,7 +765,7 @@ void SrsMpegtsSrtConn::http_hooks_on_stop()
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        SrsHttpHooks::on_stop(url, req_);
+        _srs_hooks->on_stop(url, req_);
     }
 
     return;

--- a/trunk/src/app/srs_app_threads.cpp
+++ b/trunk/src/app/srs_app_threads.cpp
@@ -9,6 +9,7 @@
 #include <srs_app_async_call.hpp>
 #include <srs_app_config.hpp>
 #include <srs_app_conn.hpp>
+#include <srs_app_http_hooks.hpp>
 #include <srs_app_hybrid.hpp>
 #include <srs_app_log.hpp>
 #include <srs_app_pithy_print.hpp>
@@ -323,6 +324,7 @@ srs_error_t srs_global_initialize()
     _srs_sources = new SrsLiveSourceManager();
     _srs_stages = new SrsStageManager();
     _srs_circuit_breaker = new SrsCircuitBreaker();
+    _srs_hooks = new SrsHttpHooks();
 
 #ifdef SRS_SRT
     _srs_srt_sources = new SrsSrtSourceManager();

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 57
+#define VERSION_REVISION 58
 
 #endif


### PR DESCRIPTION
This PR refactors the HTTP hooks system from static methods to a proper interface-based architecture, improving code maintainability, testability, and extensibility.

1. **Testability**: Interface allows easy mocking for unit tests
1. **Extensibility**: Custom hook implementations can be injected
1. **Maintainability**: Clear separation of concerns and better code organization
1. **Documentation**: Comprehensive inline documentation for all hook methods
1. **Future-proofing**: Enables plugin architecture and custom hook handlers