### PR TITLE
WebRTC: Fix race condition in RTC nack timer callbacks. v7.0.79

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2025-09-05, Merge [#4474](https://github.com/ossrs/srs/pull/4474): WebRTC: Fix race condition in RTC nack timer callbacks. v7.0.79 (#4474)
 * v7.0, 2025-09-04, Merge [#4467](https://github.com/ossrs/srs/pull/4467): WebRTC: Fix NACK recovered packets not being added to receive queue. v7.0.78 (#4467)
 * v7.0, 2025-09-03, Merge [#4469](https://github.com/ossrs/srs/pull/4469): Upgrade HTTP parser from http-parser to llhttp. v7.0.77 (#4469)
 * v7.0, 2025-09-03, Merge [#4470](https://github.com/ossrs/srs/pull/4470): RTX: Fix race condition for timer. v7.0.76 (#4470)

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -454,6 +454,7 @@ class SrsRtcConnectionNackTimer : public ISrsFastTimer
 {
 private:
     SrsRtcConnection *p_;
+    srs_mutex_t lock_;
 
 public:
     SrsRtcConnectionNackTimer(SrsRtcConnection *p);

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 78
+#define VERSION_REVISION 79
 
 #endif


### PR DESCRIPTION
See [WebRTC: Fix race condition in RTC publish timer callbacks.](https://github.com/ossrs/srs/commit/421ab6c3fba268bf91a30c147171c79b2c4033b8) v7.0.76 (https://github.com/ossrs/srs/pull/4470)