### PR TITLE
SRT: Support configurable default_streamid option. v6.0.180

### DIFF
--- a/trunk/conf/full.conf
+++ b/trunk/conf/full.conf
@@ -338,6 +338,12 @@ srt_server {
     # Overwrite by env SRS_SRT_SERVER_DEFAULT_APP
     # default: live
     default_app live;
+    # Default streamid when client doesn't provide one.
+    # This is used when SRT client connects without setting SRTO_STREAMID socket option.
+    # The streamid format follows SRT standard: #!::r=app/stream,m=publish|request
+    # Overwrite by env SRS_SRT_SERVER_DEFAULT_STREAMID
+    # default: #!::r=live/livestream,m=publish
+    default_streamid "#!::r=live/livestream,m=publish";
 	# The peerlatency is set by the sender side and will notify the receiver side.
     # Overwrite by env SRS_SRT_SERVER_PEERLATENCY
     # default: 0

--- a/trunk/conf/srt.vlc.conf
+++ b/trunk/conf/srt.vlc.conf
@@ -28,7 +28,7 @@ srt_server {
     tlpktdrop off;
     sendbuf 2000000;
     recvbuf 2000000;
-    default_streamid "#!::r=live/livestream,m=publish";
+    default_streamid "#!::r=live/livestream,m=request";
 }
 
 # @doc https://github.com/ossrs/srs/issues/1147#issuecomment-577607026

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v6-changes"></a>
 
 ## SRS 6.0 Changelog
+* v6.0, 2025-10-01, SRT: Support configurable default_streamid option. v6.0.180
 * v6.0, 2025-09-27, For Edge, only support RTMP or HTTP-FLV. v6.0.179 (#4512)
 * v6.0, 2025-09-20, Fix WHIP with transcoding bug. v6.0.178 (#4495)
 * v6.0, 2025-09-15, RTC2RTMP: Fix sequence number wraparound assertion crashes. v6.0.177 (#4491)

--- a/trunk/src/app/srs_app_config.cpp
+++ b/trunk/src/app/srs_app_config.cpp
@@ -2399,7 +2399,8 @@ srs_error_t SrsConfig::check_normal_config()
                 && n != "peerlatency" && n != "connect_timeout" && n != "peer_idle_timeout"
                 && n != "sendbuf" && n != "recvbuf" && n != "payloadsize"
                 && n != "default_app" && n != "sei_filter" && n != "mix_correct"
-                && n != "tlpktdrop" && n != "tsbpdmode" && n != "passphrase" && n != "pbkeylen") {
+                && n != "tlpktdrop" && n != "tsbpdmode" && n != "passphrase" && n != "pbkeylen"
+                && n != "default_streamid") {
                 return srs_error_new(ERROR_SYSTEM_CONFIG_INVALID, "illegal srt_server.%s", n.c_str());
             }
         }
@@ -8248,6 +8249,23 @@ string SrsConfig::get_default_app_name()
     }
 
     conf = conf->get("default_app");
+    if (!conf || conf->arg0().empty()) {
+        return DEFAULT;
+    }
+    return conf->arg0();
+}
+
+string SrsConfig::get_srt_default_streamid()
+{
+    SRS_OVERWRITE_BY_ENV_STRING("srs.srt_server.default_streamid"); // SRS_SRT_SERVER_DEFAULT_STREAMID
+
+    static string DEFAULT = "#!::r=live/livestream,m=publish";
+    SrsConfDirective* conf = root->get("srt_server");
+    if (!conf) {
+        return DEFAULT;
+    }
+
+    conf = conf->get("default_streamid");
     if (!conf || conf->arg0().empty()) {
         return DEFAULT;
     }

--- a/trunk/src/app/srs_app_config.hpp
+++ b/trunk/src/app/srs_app_config.hpp
@@ -708,6 +708,8 @@ public:
     virtual int get_srto_pbkeylen();
     // Get the default app.
     virtual std::string get_default_app_name();
+    // Get the default streamid when client doesn't provide one.
+    virtual std::string get_srt_default_streamid();
 private:
     SrsConfDirective* get_srt(std::string vhost);
 public:

--- a/trunk/src/app/srs_app_srt_conn.cpp
+++ b/trunk/src/app/srs_app_srt_conn.cpp
@@ -261,7 +261,7 @@ srs_error_t SrsMpegtsSrtConn::do_cycle()
 
     // If streamid empty, using default streamid instead.
     if (streamid.empty()) {
-        streamid = "#!::r=live/livestream,m=publish";
+        streamid = _srs_config->get_srt_default_streamid();
         srs_warn("srt get empty streamid, using default streamid %s instead", streamid.c_str());
     }
 

--- a/trunk/src/core/srs_core_version6.hpp
+++ b/trunk/src/core/srs_core_version6.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 6
 #define VERSION_MINOR 0
-#define VERSION_REVISION 179
+#define VERSION_REVISION 180
 
 #endif


### PR DESCRIPTION
Add a new default_streamid configuration option for the SRT server to allow customization of the default streamid used when SRT clients connect without setting the SRTO_STREAMID socket option.

When SRT clients (like VLC) connect without properly setting the SRTO_STREAMID socket option, SRS previously used a hardcoded default value of "#!::r=live/livestream,m=publish". This caused conflicts when:

1. A publisher connects without setting streamid (uses default publish mode)
2. A player tries to connect without setting streamid (also uses default publish mode)
3. The player gets a "Stream already exists or busy" error because both are trying to publish

Start SRS with default stream id as viewer:

```bash
./objs/srs -c conf/srt.vlc.conf
```

Publish SRT stream by FFmpeg:

```bash
ffmpeg -re -i ./doc/source.flv -c copy -pes_payload_size 0 -f mpegts \
  'srt://127.0.0.1:10080?streamid=#!::r=live/livestream,m=publish'
```

Play SRT stream by ffplay:

```bash
ffplay 'srt://127.0.0.1:10080?streamid=#!::r=live/livestream,m=request'
```

Play SRT stream by VLC:

```
✅ Correct - Use simple URL without streamid parameter:
srt://127.0.0.1:10080

❌ Wrong - VLC doesn't support streamid parameter:
srt://127.0.0.1:10080?streamid=#!::r=live/livestream,m=request
```
