### PR TITLE
optimize: inefficient srs_avc_startswith_annexb

### DIFF
--- a/trunk/src/kernel/srs_kernel_utility.cpp
+++ b/trunk/src/kernel/srs_kernel_utility.cpp
@@ -725,26 +725,32 @@ bool srs_avc_startswith_annexb(SrsBuffer* stream, int* pnb_start_code)
     
     char* bytes = stream->data() + stream->pos();
     char* p = bytes;
+
+    // h264 annexb start codes are either 00 00 01 or 00 00 00 01
+    if (!stream->require(3)) {
+        return false;
+    }
     
-    for (;;) {
-        if (!stream->require((int)(p - bytes + 3))) {
-            return false;
+    // first check if starts with 00 00
+    if (p[0] != (char)0x00 || p[1] != (char)0x00) {
+        return false;
+    }
+    
+    // check for 00 00 01
+    if (p[2] == (char)0x01) {
+        if (pnb_start_code) {
+            *pnb_start_code = 3;
         }
-        
-        // not match
-        if (p[0] != (char)0x00 || p[1] != (char)0x00) {
-            return false;
+        return true;
+    }
+    
+    // check for 00 00 00 01
+    // only check when we have enough bytes
+    if (stream->require(4) && p[2] == (char)0x00 && p[3] == (char)0x01) {
+        if (pnb_start_code) {
+            *pnb_start_code = 4;
         }
-        
-        // match N[00] 00 00 01, where N>=0
-        if (p[2] == (char)0x01) {
-            if (pnb_start_code) {
-                *pnb_start_code = (int)(p - bytes) + 3;
-            }
-            return true;
-        }
-        
-        p++;
+        return true;
     }
     
     return false;


### PR DESCRIPTION
Partially fixes #4522 .

I profiled SRS server during hang and found that `srs_avc_startswith_annexb` took up most of the CPU time:

<img width="2490" height="904" alt="image" src="https://github.com/user-attachments/assets/275333e6-d230-4645-ba61-89cf352d7b41" />

After examining the code, I found that the current implementation of `srs_avc_startswith_annexb` seems inefficient. Annex B specifies that bitstream begins with 00 00 00 01 or 00 00 01. There is no need to check for N x 00 + 01, which would require the buffer much more time. 

One thing yet to be explored is that this solved problem with hardware encoding of HEVC with OBS, but not QSV H264 with OBS (although it wont cause the server to hang anymore ).  When playing with ffplay (`ffplay -mode listener -i srt://:12345`), video will eventually start to play when there is SPS in stream; however, with SRS, SPS will never come in. I don't think OBS will change its behavior with different behaviors but maybe there's some special logic in ffmpeg that handles this. 

I developed on R6 branch. In develop branch, this function was moved to another file. Should I update this pr, please let me know. 