### PR TITLE
Fill missing defs for H264/AVC video levels. v7.0.116

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2025-11-03, Merge [#4556](https://github.com/ossrs/srs/pull/4556): Fill missing defs for H264/AVC video levels. v7.0.116 (#4556)
 * v7.0, 2025-10-31, Merge [#4547](https://github.com/ossrs/srs/pull/4547): Add ignore configuration for cursor. v7.0.115 (#4547)
 * v7.0, 2025-10-30, WebRTC: Use realtime for TWCC timestamp accuracy. v7.0.114
 * v7.0, 2025-10-30, AI: HLS: Fix crash when segment is not open by adding NULL checks. v7.0.113 (#3431)

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 115
+#define VERSION_REVISION 116
 
 #endif

--- a/trunk/src/kernel/srs_kernel_codec.cpp
+++ b/trunk/src/kernel/srs_kernel_codec.cpp
@@ -657,10 +657,20 @@ string srs_avc_level2str(SrsAvcLevel level)
         return "4";
     case SrsAvcLevel_41:
         return "4.1";
+    case SrsAvcLevel_42:
+        return "4.2";
     case SrsAvcLevel_5:
         return "5";
     case SrsAvcLevel_51:
         return "5.1";
+    case SrsAvcLevel_52:
+        return "5.2";
+    case SrsAvcLevel_6:
+        return "6";
+    case SrsAvcLevel_61:
+        return "6.1";
+    case SrsAvcLevel_62:
+        return "6.2";
     default:
         return "Other";
     }

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -1071,7 +1071,7 @@ enum SrsAvcLevel {
     SrsAvcLevel_5 = 50,
     SrsAvcLevel_51 = 51,
     SrsAvcLevel_52 = 52,
-    SrsAvcLevel_6 = 6,
+    SrsAvcLevel_6 = 60,
     SrsAvcLevel_61 = 61,
     SrsAvcLevel_62 = 62,
 };

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -1067,8 +1067,13 @@ enum SrsAvcLevel {
     SrsAvcLevel_32 = 32,
     SrsAvcLevel_4 = 40,
     SrsAvcLevel_41 = 41,
+    SrsAvcLevel_42 = 42,
     SrsAvcLevel_5 = 50,
     SrsAvcLevel_51 = 51,
+    SrsAvcLevel_52 = 52,
+    SrsAvcLevel_6 = 6,
+    SrsAvcLevel_61 = 61,
+    SrsAvcLevel_62 = 62,
 };
 std::string srs_avc_level2str(SrsAvcLevel level);
 


### PR DESCRIPTION
Fill missing H264/AVC video levels (4.2, 5.2, 6, 6.1, 6.2). 
Partial Fix #4555