### PR TITLE
WHIP: Return detailed HTTP error responses with proper status codes. v7.0.121 (#4502)

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
-* v7.0, 2025-11-07, AI: Kernel: Add srs_error_transform to wrap errors with new error codes. v7.0.121 (#4502)
+* v7.0, 2025-11-07, AI: WHIP: Return detailed HTTP error responses with proper status codes. v7.0.121 (#4502)
 * v7.0, 2025-11-07, AI: HLS: Support query string in hls_key_url for JWT tokens. v7.0.120 (#4426)
 * v7.0, 2025-11-07, AI: RTC: Support keep_original_ssrc to preserve SSRC and timestamps. v7.0.119 (#3850)
 * v7.0, 2025-11-05, AI: WebRTC: Report video/audio codec info and frame stats in HTTP API. v7.0.118 (#4554)

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2025-11-07, AI: Kernel: Add srs_error_transform to wrap errors with new error codes. v7.0.121 (#4502)
 * v7.0, 2025-11-07, AI: HLS: Support query string in hls_key_url for JWT tokens. v7.0.120 (#4426)
 * v7.0, 2025-11-07, AI: RTC: Support keep_original_ssrc to preserve SSRC and timestamps. v7.0.119 (#3850)
 * v7.0, 2025-11-05, AI: WebRTC: Report video/audio codec info and frame stats in HTTP API. v7.0.118 (#4554)

--- a/trunk/src/app/srs_app_rtc_api.hpp
+++ b/trunk/src/app/srs_app_rtc_api.hpp
@@ -119,7 +119,8 @@ public:
 
 // clang-format off
 SRS_DECLARE_PRIVATE: // clang-format on
-    virtual srs_error_t do_serve_http(ISrsHttpResponseWriter *w, ISrsHttpMessage *r, SrsRtcUserConfig *ruc);
+    virtual srs_error_t serve_http_with(ISrsHttpResponseWriter *w, ISrsHttpMessage *r);
+    virtual srs_error_t do_serve_http_with(ISrsHttpResponseWriter *w, ISrsHttpMessage *r, SrsRtcUserConfig *ruc);
 };
 
 class SrsGoApiRtcNACK : public ISrsHttpHandler

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 120
+#define VERSION_REVISION 121
 
 #endif

--- a/trunk/src/utest/srs_utest_ai17.cpp
+++ b/trunk/src/utest/srs_utest_ai17.cpp
@@ -2437,7 +2437,7 @@ VOID TEST(SrsGoApiRtcWhipTest, DoServeHttpPublishSuccess)
     SrsUniquePtr<SrsRtcUserConfig> ruc(new SrsRtcUserConfig());
 
     // Call do_serve_http - major use scenario
-    HELPER_EXPECT_SUCCESS(whip->do_serve_http(mock_writer.get(), mock_request.get(), ruc.get()));
+    HELPER_EXPECT_SUCCESS(whip->do_serve_http_with(mock_writer.get(), mock_request.get(), ruc.get()));
 
     // Verify request fields were populated correctly
     EXPECT_STREQ("192.168.1.100", ruc->req_->ip_.c_str());

--- a/trunk/src/utest/srs_utest_ai17.cpp
+++ b/trunk/src/utest/srs_utest_ai17.cpp
@@ -2254,7 +2254,7 @@ VOID TEST(SrsGoApiRtcWhipTest, ServeHttpDeleteSuccess)
 // Test SrsGoApiRtcWhip::serve_http() to verify the major use scenario for WHIP POST request.
 // This test covers the WHIP session creation flow (non-DELETE path):
 // 1. Client sends POST request with SDP offer in body
-// 2. Server processes the request via do_serve_http() which populates ruc.local_sdp_str_
+// 2. Server processes the request via do_serve_http_with() which populates ruc.local_sdp_str_
 // 3. Server returns 201 Created with SDP answer in body
 // 4. Server includes Location header for subsequent DELETE request
 // 5. Server sets Content-Type to application/sdp
@@ -2265,14 +2265,14 @@ VOID TEST(SrsGoApiRtcWhipTest, ServeHttpPostSuccess)
     // Create mock RTC API server
     SrsUniquePtr<MockRtcApiServer> mock_server(new MockRtcApiServer());
 
-    // Create testable WHIP handler that overrides do_serve_http
+    // Create testable WHIP handler that overrides do_serve_http_with
     class TestableWhip : public SrsGoApiRtcWhip
     {
     public:
         TestableWhip(ISrsRtcApiServer *server) : SrsGoApiRtcWhip(server) {}
-        virtual srs_error_t do_serve_http(ISrsHttpResponseWriter *w, ISrsHttpMessage *r, SrsRtcUserConfig *ruc)
+        virtual srs_error_t do_serve_http_with(ISrsHttpResponseWriter *w, ISrsHttpMessage *r, SrsRtcUserConfig *ruc)
         {
-            // Mock the do_serve_http behavior by populating the required fields
+            // Mock the do_serve_http_with behavior by populating the required fields
             ruc->local_sdp_str_ = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=SRS\r\nt=0 0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 H264/90000\r\n";
             ruc->session_id_ = "test-session-12345";
             ruc->token_ = "test-token-67890";
@@ -2304,7 +2304,7 @@ VOID TEST(SrsGoApiRtcWhipTest, ServeHttpPostSuccess)
     // Call serve_http for POST request
     // Expected behavior:
     // 1. Check if method is DELETE (no, it's POST)
-    // 2. Call do_serve_http() which populates ruc.local_sdp_str_
+    // 2. Call do_serve_http_with() which populates ruc.local_sdp_str_
     // 3. Set Content-Type to application/sdp
     // 4. Set Location header with session and token
     // 5. Return 201 Created with SDP answer in body
@@ -2330,8 +2330,8 @@ VOID TEST(SrsGoApiRtcWhipTest, ServeHttpPostSuccess)
     EXPECT_TRUE(response.find("m=video 9 UDP/TLS/RTP/SAVPF 96") != std::string::npos);
 }
 
-// Test SrsGoApiRtcWhip::do_serve_http() - major use scenario for WHIP request parsing
-// This test covers the core parsing and validation logic of do_serve_http method:
+// Test SrsGoApiRtcWhip::do_serve_http_with() - major use scenario for WHIP request parsing
+// This test covers the core parsing and validation logic of do_serve_http_with method:
 // 1. Read SDP offer from request body
 // 2. Extract client IP from connection (with proxy IP override support)
 // 3. Parse query parameters (eip, codec, app, stream, action, ice-ufrag, ice-pwd, encrypt, dtls)
@@ -2464,6 +2464,186 @@ VOID TEST(SrsGoApiRtcWhipTest, DoServeHttpPublishSuccess)
 
     // Clean up
     whip->config_ = NULL;
+}
+
+// Test SrsGoApiRtcWhip::serve_http() error handling for invalid SDP.
+// This test verifies that WHIP returns HTTP 400 Bad Request when SDP parsing fails.
+VOID TEST(SrsGoApiRtcWhipTest, ServeHttpErrorInvalidSdp)
+{
+    srs_error_t err = srs_success;
+
+    // Create mock RTC API server
+    SrsUniquePtr<MockRtcApiServer> mock_server(new MockRtcApiServer());
+
+    // Create testable WHIP handler that simulates SDP parsing error
+    class TestableWhip : public SrsGoApiRtcWhip
+    {
+    public:
+        TestableWhip(ISrsRtcApiServer *server) : SrsGoApiRtcWhip(server) {}
+        virtual srs_error_t serve_http_with(ISrsHttpResponseWriter *w, ISrsHttpMessage *r)
+        {
+            return srs_error_new(ERROR_RTC_SDP_DECODE, "invalid sdp format");
+        }
+    };
+
+    // Create testable WHIP instance
+    SrsUniquePtr<TestableWhip> whip(new TestableWhip(mock_server.get()));
+
+    // Create mock response writer
+    SrsUniquePtr<MockResponseWriter> mock_writer(new MockResponseWriter());
+
+    // Create mock HTTP message for WHIP POST request
+    SrsUniquePtr<MockHttpMessageForRtcApi> mock_request(new MockHttpMessageForRtcApi());
+    mock_request->set_method(SRS_CONSTS_HTTP_POST);
+
+    // Call serve_http - should return HTTP 400 Bad Request
+    HELPER_EXPECT_SUCCESS(whip->serve_http(mock_writer.get(), mock_request.get()));
+
+    // Verify response status is 400 Bad Request
+    EXPECT_EQ(SRS_CONSTS_HTTP_BadRequest, mock_writer->w->status_);
+
+    // Get the HTTP response
+    string response = string(mock_writer->io.out_buffer.bytes(), mock_writer->io.out_buffer.length());
+    EXPECT_FALSE(response.empty());
+
+    // Verify the response contains error code and description
+    EXPECT_TRUE(response.find("5012") != std::string::npos); // ERROR_RTC_SDP_DECODE
+    EXPECT_TRUE(response.find("RtcSdpDecode") != std::string::npos);
+}
+
+// Test SrsGoApiRtcWhip::serve_http() error handling for stream busy.
+// This test verifies that WHIP returns HTTP 409 Conflict when stream is already publishing.
+VOID TEST(SrsGoApiRtcWhipTest, ServeHttpErrorStreamBusy)
+{
+    srs_error_t err = srs_success;
+
+    // Create mock RTC API server
+    SrsUniquePtr<MockRtcApiServer> mock_server(new MockRtcApiServer());
+
+    // Create testable WHIP handler that simulates stream busy error
+    class TestableWhip : public SrsGoApiRtcWhip
+    {
+    public:
+        TestableWhip(ISrsRtcApiServer *server) : SrsGoApiRtcWhip(server) {}
+        virtual srs_error_t serve_http_with(ISrsHttpResponseWriter *w, ISrsHttpMessage *r)
+        {
+            return srs_error_new(ERROR_SYSTEM_STREAM_BUSY, "stream already publishing");
+        }
+    };
+
+    // Create testable WHIP instance
+    SrsUniquePtr<TestableWhip> whip(new TestableWhip(mock_server.get()));
+
+    // Create mock response writer
+    SrsUniquePtr<MockResponseWriter> mock_writer(new MockResponseWriter());
+
+    // Create mock HTTP message for WHIP POST request
+    SrsUniquePtr<MockHttpMessageForRtcApi> mock_request(new MockHttpMessageForRtcApi());
+    mock_request->set_method(SRS_CONSTS_HTTP_POST);
+
+    // Call serve_http - should return HTTP 409 Conflict
+    HELPER_EXPECT_SUCCESS(whip->serve_http(mock_writer.get(), mock_request.get()));
+
+    // Verify response status is 409 Conflict
+    EXPECT_EQ(SRS_CONSTS_HTTP_Conflict, mock_writer->w->status_);
+
+    // Get the HTTP response
+    string response = string(mock_writer->io.out_buffer.bytes(), mock_writer->io.out_buffer.length());
+    EXPECT_FALSE(response.empty());
+
+    // Verify the response contains error code and description
+    EXPECT_TRUE(response.find("1028") != std::string::npos); // ERROR_SYSTEM_STREAM_BUSY
+    EXPECT_TRUE(response.find("StreamBusy") != std::string::npos);
+}
+
+// Test SrsGoApiRtcWhip::serve_http() error handling for authentication failure.
+// This test verifies that WHIP returns HTTP 401 Unauthorized when auth check fails.
+VOID TEST(SrsGoApiRtcWhipTest, ServeHttpErrorAuth)
+{
+    srs_error_t err = srs_success;
+
+    // Create mock RTC API server
+    SrsUniquePtr<MockRtcApiServer> mock_server(new MockRtcApiServer());
+
+    // Create testable WHIP handler that simulates auth error
+    class TestableWhip : public SrsGoApiRtcWhip
+    {
+    public:
+        TestableWhip(ISrsRtcApiServer *server) : SrsGoApiRtcWhip(server) {}
+        virtual srs_error_t serve_http_with(ISrsHttpResponseWriter *w, ISrsHttpMessage *r)
+        {
+            return srs_error_new(ERROR_SYSTEM_AUTH, "authentication failed");
+        }
+    };
+
+    // Create testable WHIP instance
+    SrsUniquePtr<TestableWhip> whip(new TestableWhip(mock_server.get()));
+
+    // Create mock response writer
+    SrsUniquePtr<MockResponseWriter> mock_writer(new MockResponseWriter());
+
+    // Create mock HTTP message for WHIP POST request
+    SrsUniquePtr<MockHttpMessageForRtcApi> mock_request(new MockHttpMessageForRtcApi());
+    mock_request->set_method(SRS_CONSTS_HTTP_POST);
+
+    // Call serve_http - should return HTTP 401 Unauthorized
+    HELPER_EXPECT_SUCCESS(whip->serve_http(mock_writer.get(), mock_request.get()));
+
+    // Verify response status is 401 Unauthorized
+    EXPECT_EQ(SRS_CONSTS_HTTP_Unauthorized, mock_writer->w->status_);
+
+    // Get the HTTP response
+    string response = string(mock_writer->io.out_buffer.bytes(), mock_writer->io.out_buffer.length());
+    EXPECT_FALSE(response.empty());
+
+    // Verify the response contains error code and description
+    EXPECT_TRUE(response.find("1102") != std::string::npos); // ERROR_SYSTEM_AUTH
+    EXPECT_TRUE(response.find("SystemAuth") != std::string::npos);
+}
+
+// Test SrsGoApiRtcWhip::serve_http() error handling for internal server error.
+// This test verifies that WHIP returns HTTP 500 for unexpected errors.
+VOID TEST(SrsGoApiRtcWhipTest, ServeHttpErrorInternal)
+{
+    srs_error_t err = srs_success;
+
+    // Create mock RTC API server
+    SrsUniquePtr<MockRtcApiServer> mock_server(new MockRtcApiServer());
+
+    // Create testable WHIP handler that simulates internal error
+    class TestableWhip : public SrsGoApiRtcWhip
+    {
+    public:
+        TestableWhip(ISrsRtcApiServer *server) : SrsGoApiRtcWhip(server) {}
+        virtual srs_error_t serve_http_with(ISrsHttpResponseWriter *w, ISrsHttpMessage *r)
+        {
+            return srs_error_new(ERROR_SOCKET_TIMEOUT, "socket timeout");
+        }
+    };
+
+    // Create testable WHIP instance
+    SrsUniquePtr<TestableWhip> whip(new TestableWhip(mock_server.get()));
+
+    // Create mock response writer
+    SrsUniquePtr<MockResponseWriter> mock_writer(new MockResponseWriter());
+
+    // Create mock HTTP message for WHIP POST request
+    SrsUniquePtr<MockHttpMessageForRtcApi> mock_request(new MockHttpMessageForRtcApi());
+    mock_request->set_method(SRS_CONSTS_HTTP_POST);
+
+    // Call serve_http - should return HTTP 500 Internal Server Error
+    HELPER_EXPECT_SUCCESS(whip->serve_http(mock_writer.get(), mock_request.get()));
+
+    // Verify response status is 500 Internal Server Error
+    EXPECT_EQ(SRS_CONSTS_HTTP_InternalServerError, mock_writer->w->status_);
+
+    // Get the HTTP response
+    string response = string(mock_writer->io.out_buffer.bytes(), mock_writer->io.out_buffer.length());
+    EXPECT_FALSE(response.empty());
+
+    // Verify the response contains error code and description
+    EXPECT_TRUE(response.find("1011") != std::string::npos); // ERROR_SOCKET_TIMEOUT
+    EXPECT_TRUE(response.find("SocketTimeout") != std::string::npos);
 }
 
 VOID TEST(RtcApiNackTest, ServeHttpSuccess)


### PR DESCRIPTION
This commit addresses issue #4502 by implementing proper HTTP error handling
for WHIP endpoints, allowing clients to receive detailed error information
instead of empty responses.

Before this change:
- WHIP clients received "Empty reply from server" when publish failed
- No way to distinguish between different failure reasons

After this change:
- WHIP clients receive proper HTTP status codes (400/401/409/500)
- Error responses include error code and description
- Clients can distinguish between SDP errors, stream busy, auth failures, etc.

If success:

```
< HTTP/1.1 201 Created
< Content-Type: application/sdp
< Location: /rtc/v1/whip/?action=delete&token=77h5570j1&app=live&stream=livestream&session=x209e499:TKxW
< Content-Length: 1376
< Server: SRS/7.0.120(Kai)
< 
v=0
......
```

If request without SDP:

```
curl 'http://localhost:1985/rtc/v1/whip/?app=live&stream=livestream' -v
< HTTP/1.1 400 Bad Request
< Content-Type: text/plain; charset=utf-8
< Content-Length: 13
< Server: SRS/7.0.120(Kai)
< 
5043: RtcInvalidSdp
```

If request with corrupt SDP:

```
curl 'http://localhost:1985/rtc/v1/whip/?app=live&stream=livestream' --data-raw $'invalidsdp' -v
< HTTP/1.1 400 Bad Request
< Content-Type: text/plain; charset=utf-8
< Content-Length: 18
< Server: SRS/7.0.120(Kai)
< 
5012: RtcSdpDecode
```

If request with insufficient SDP:

```
curl 'http://localhost:1985/rtc/v1/whip/?app=live&stream=livestream' --data-raw $'v=0' -v
< HTTP/1.1 400 Bad Request
< Content-Type: text/plain; charset=utf-8
< Content-Length: 21
< Server: SRS/7.0.120(Kai)
< 
5018: RtcSdpNegotiate
```

If publish to a exists stream:

```
< HTTP/1.1 409 Conflict
< Content-Type: text/plain; charset=utf-8
< Content-Length: 16
< Server: SRS/7.0.120(Kai)
< 
1028: StreamBusy
```

If HTTP hooks or security verify failed:

```
< HTTP/1.1 401 Unauthorized
< Content-Type: text/plain; charset=utf-8
< Content-Length: 16
< Server: SRS/7.0.120(Kai)
< 
1102: SystemAuth
```

Other errors, for exmaple, RTC disabled:

```
< HTTP/1.1 500 Internal Server Error
< Content-Type: text/plain; charset=utf-8
< Content-Length: 17
< Server: SRS/7.0.120(Kai)
< 
5021: RtcDisabled
```