### PR TITLE
AI: API: Add audio_frames and video_frames to HTTP API. v7.0.122 (#4559)

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2025-11-08, AI: API: Add audio_frames and video_frames to HTTP API. v7.0.122 (#4559)
 * v7.0, 2025-11-07, AI: WHIP: Return detailed HTTP error responses with proper status codes. v7.0.121 (#4502)
 * v7.0, 2025-11-07, AI: HLS: Support query string in hls_key_url for JWT tokens. v7.0.120 (#4426)
 * v7.0, 2025-11-07, AI: RTC: Support keep_original_ssrc to preserve SSRC and timestamps. v7.0.119 (#3850)

--- a/trunk/src/app/srs_app_recv_thread.cpp
+++ b/trunk/src/app/srs_app_recv_thread.cpp
@@ -299,6 +299,7 @@ SrsPublishRecvThread::SrsPublishRecvThread(ISrsRtmpServer *rtmp_sdk, ISrsRequest
     recv_error_ = srs_success;
     nb_msgs_ = 0;
     video_frames_ = 0;
+    audio_frames_ = 0;
     error_ = srs_cond_new();
 
     req_ = _req;
@@ -349,6 +350,11 @@ uint64_t SrsPublishRecvThread::nb_video_frames()
     return video_frames_;
 }
 
+uint64_t SrsPublishRecvThread::nb_audio_frames()
+{
+    return audio_frames_;
+}
+
 srs_error_t SrsPublishRecvThread::error_code()
 {
     return srs_error_copy(recv_error_);
@@ -396,6 +402,8 @@ srs_error_t SrsPublishRecvThread::consume(SrsRtmpCommonMessage *msg)
 
     if (msg->header_.is_video()) {
         video_frames_++;
+    } else if (msg->header_.is_audio()) {
+        audio_frames_++;
     }
 
     // log to show the time of recv thread.

--- a/trunk/src/app/srs_app_recv_thread.hpp
+++ b/trunk/src/app/srs_app_recv_thread.hpp
@@ -190,6 +190,8 @@ SRS_DECLARE_PRIVATE: // clang-format on
     int64_t nb_msgs_;
     // The video frames we got.
     uint64_t video_frames_;
+    // The audio frames we got.
+    uint64_t audio_frames_;
     // For mr(merged read),
     bool mr_;
     int mr_fd_;
@@ -219,6 +221,7 @@ public:
     virtual srs_error_t wait(srs_utime_t tm);
     virtual int64_t nb_msgs();
     virtual uint64_t nb_video_frames();
+    virtual uint64_t nb_audio_frames();
     virtual srs_error_t error_code();
     virtual void set_cid(SrsContextId v);
     virtual SrsContextId get_cid();

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -542,8 +542,8 @@ SRS_DECLARE_PRIVATE: // clang-format on
 // clang-format off
 SRS_DECLARE_PRIVATE: // clang-format on
     SrsContextId cid_;
-    uint64_t nn_audio_frames_;
-    int nn_rtp_pkts_;
+    int nn_audio_frames_;
+    int nn_video_frames_;
     ISrsRtcFormat *format_;
     ISrsRtcPliWorker *pli_worker_;
     SrsErrorPithyPrint *twcc_epp_;

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -988,6 +988,7 @@ srs_error_t SrsRtmpConn::do_publishing(SrsSharedPtr<SrsLiveSource> source, SrsPu
 
     int64_t nb_msgs = 0;
     uint64_t nb_frames = 0;
+    uint64_t nb_audio_frames = 0;
     while (true) {
         if ((err = trd_->pull()) != srs_success) {
             return srs_error_wrap(err, "rtmp: thread quit");
@@ -1028,6 +1029,12 @@ srs_error_t SrsRtmpConn::do_publishing(SrsSharedPtr<SrsLiveSource> source, SrsPu
             return srs_error_wrap(err, "rtmp: stat video frames");
         }
         nb_frames = rtrd->nb_video_frames();
+
+        // Update the stat for audio frames.
+        if ((err = stat_->on_audio_frames(req, (int)(rtrd->nb_audio_frames() - nb_audio_frames))) != srs_success) {
+            return srs_error_wrap(err, "rtmp: stat audio frames");
+        }
+        nb_audio_frames = rtrd->nb_audio_frames();
 
         // reportable
         if (pprint->can_print()) {

--- a/trunk/src/app/srs_app_srt_conn.cpp
+++ b/trunk/src/app/srs_app_srt_conn.cpp
@@ -554,7 +554,6 @@ srs_error_t SrsMpegtsSrtConn::do_publishing()
     SrsUniquePtr<SrsPithyPrint> pprint(SrsPithyPrint::create_srt_publish());
 
     int nb_packets = 0;
-    int nb_frames = 0;
 
     // Max udp packet size equal to 1500.
     char buf[1500];
@@ -586,15 +585,6 @@ srs_error_t SrsMpegtsSrtConn::do_publishing()
         }
 
         ++nb_packets;
-        ++nb_frames;
-
-        // Update the stat for frames every 100 packets, counting SRT packets as frames.
-        if (nb_frames > 288) {
-            if ((err = stat_->on_video_frames(req_, nb_frames)) != srs_success) {
-                return srs_error_wrap(err, "srt: stat frames");
-            }
-            nb_frames = 0;
-        }
 
         if ((err = on_srt_packet(buf, nb)) != srs_success) {
             return srs_error_wrap(err, "srt: process packet");

--- a/trunk/src/app/srs_app_srt_source.hpp
+++ b/trunk/src/app/srs_app_srt_source.hpp
@@ -179,6 +179,7 @@ public:
 
 // clang-format off
 SRS_DECLARE_PRIVATE: // clang-format on
+    void update_ts_message_stats(bool is_audio);
     srs_error_t parse_video_codec(SrsTsMessage *msg);
     srs_error_t parse_audio_codec(SrsTsMessage *msg);
 
@@ -191,6 +192,9 @@ SRS_DECLARE_PRIVATE: // clang-format on
     // Track whether we've already reported codec info to avoid duplicate updates
     bool video_codec_reported_;
     bool audio_codec_reported_;
+    // Frame counters for statistics reporting
+    int nn_video_frames_;
+    int nn_audio_frames_;
 };
 
 // Collect and build SRT TS packet to AV frames.

--- a/trunk/src/app/srs_app_statistic.hpp
+++ b/trunk/src/app/srs_app_statistic.hpp
@@ -63,8 +63,10 @@ public:
 public:
     // The stream total kbps.
     SrsKbps *kbps_;
-    // The fps of stream.
-    SrsPps *frames_;
+    // The fps of stream (video frames/packets).
+    SrsPps *video_frames_;
+    // The fps of audio (audio frames/packets).
+    SrsPps *audio_frames_;
 
 public:
     bool has_video_;
@@ -148,6 +150,7 @@ public:
     virtual void kbps_add_delta(std::string id, ISrsKbpsDelta *delta) = 0;
     virtual void kbps_sample() = 0;
     virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames) = 0;
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames) = 0;
 
 public:
     // Get the server id, used to identify the server.
@@ -240,6 +243,9 @@ public:
     // When got videos, update the frames.
     // We only stat the total number of video frames.
     virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames);
+    // When got audios, update the audio frames.
+    // We only stat the total number of audio frames.
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames);
     // When publish stream.
     // @param req the request object of publish connection.
     // @param publisher_id The id of publish connection.

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 121
+#define VERSION_REVISION 122
 
 #endif

--- a/trunk/src/utest/srs_utest_ai14.cpp
+++ b/trunk/src/utest/srs_utest_ai14.cpp
@@ -1963,6 +1963,11 @@ srs_error_t MockStatisticForOriginHub::on_video_frames(ISrsRequest *req, int nb_
     return srs_success;
 }
 
+srs_error_t MockStatisticForOriginHub::on_audio_frames(ISrsRequest *req, int nb_frames)
+{
+    return srs_success;
+}
+
 std::string MockStatisticForOriginHub::server_id()
 {
     return "mock_server_id";

--- a/trunk/src/utest/srs_utest_ai14.hpp
+++ b/trunk/src/utest/srs_utest_ai14.hpp
@@ -211,6 +211,7 @@ public:
     virtual void kbps_add_delta(std::string id, ISrsKbpsDelta *delta);
     virtual void kbps_sample();
     virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames);
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames);
     virtual std::string server_id();
     virtual std::string service_id();
     virtual std::string service_pid();

--- a/trunk/src/utest/srs_utest_ai15.cpp
+++ b/trunk/src/utest/srs_utest_ai15.cpp
@@ -809,6 +809,11 @@ srs_error_t MockStatisticForResampleKbps::on_video_frames(ISrsRequest *req, int 
     return srs_success;
 }
 
+srs_error_t MockStatisticForResampleKbps::on_audio_frames(ISrsRequest *req, int nb_frames)
+{
+    return srs_success;
+}
+
 std::string MockStatisticForResampleKbps::server_id()
 {
     return "mock_server_id";

--- a/trunk/src/utest/srs_utest_ai15.hpp
+++ b/trunk/src/utest/srs_utest_ai15.hpp
@@ -260,6 +260,7 @@ public:
     virtual void kbps_add_delta(std::string id, ISrsKbpsDelta *delta);
     virtual void kbps_sample();
     virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames);
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames);
     virtual std::string server_id();
     virtual std::string service_id();
     virtual std::string service_pid();

--- a/trunk/src/utest/srs_utest_ai16.cpp
+++ b/trunk/src/utest/srs_utest_ai16.cpp
@@ -827,6 +827,11 @@ srs_error_t MockStatisticForLiveStream::on_video_frames(ISrsRequest *req, int nb
     return srs_success;
 }
 
+srs_error_t MockStatisticForLiveStream::on_audio_frames(ISrsRequest *req, int nb_frames)
+{
+    return srs_success;
+}
+
 std::string MockStatisticForLiveStream::server_id()
 {
     return "mock_server_id";

--- a/trunk/src/utest/srs_utest_ai16.hpp
+++ b/trunk/src/utest/srs_utest_ai16.hpp
@@ -168,6 +168,7 @@ public:
     virtual void kbps_add_delta(std::string id, ISrsKbpsDelta *delta);
     virtual void kbps_sample();
     virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames);
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames);
     virtual std::string server_id();
     virtual std::string service_id();
     virtual std::string service_pid();

--- a/trunk/src/utest/srs_utest_ai17.cpp
+++ b/trunk/src/utest/srs_utest_ai17.cpp
@@ -1707,6 +1707,11 @@ srs_error_t MockStatisticForRtcApi::on_video_frames(ISrsRequest *req, int nb_fra
     return srs_success;
 }
 
+srs_error_t MockStatisticForRtcApi::on_audio_frames(ISrsRequest *req, int nb_frames)
+{
+    return srs_success;
+}
+
 std::string MockStatisticForRtcApi::server_id()
 {
     return server_id_;
@@ -3189,7 +3194,7 @@ VOID TEST(StatisticTest, StreamMediaInfo)
     // Verify frame count was accumulated correctly
     stream = stat->find_stream_by_url(req->get_stream_url());
     EXPECT_TRUE(stream != NULL);
-    EXPECT_EQ(55, stream->frames_->sugar_);
+    EXPECT_EQ(55, stream->video_frames_->sugar_);
 }
 
 // Test SrsStatistic audio sample rate handling for AAC 48000 Hz
@@ -3802,6 +3807,11 @@ void MockStatisticForHooks::kbps_sample()
 }
 
 srs_error_t MockStatisticForHooks::on_video_frames(ISrsRequest *req, int nb_frames)
+{
+    return srs_success;
+}
+
+srs_error_t MockStatisticForHooks::on_audio_frames(ISrsRequest *req, int nb_frames)
 {
     return srs_success;
 }

--- a/trunk/src/utest/srs_utest_ai17.hpp
+++ b/trunk/src/utest/srs_utest_ai17.hpp
@@ -317,6 +317,7 @@ public:
     virtual void kbps_add_delta(std::string id, ISrsKbpsDelta *delta);
     virtual void kbps_sample();
     virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames);
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames);
     virtual std::string server_id();
     virtual std::string service_id();
     virtual std::string service_pid();
@@ -566,6 +567,7 @@ public:
     virtual void kbps_add_delta(std::string id, ISrsKbpsDelta *delta);
     virtual void kbps_sample();
     virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames);
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames);
     virtual std::string server_id();
     virtual std::string service_id();
     virtual std::string service_pid();

--- a/trunk/src/utest/srs_utest_ai19.cpp
+++ b/trunk/src/utest/srs_utest_ai19.cpp
@@ -2234,6 +2234,16 @@ void MockStatisticForHttpxConn::kbps_sample()
 {
 }
 
+srs_error_t MockStatisticForHttpxConn::on_video_frames(ISrsRequest *req, int nb_frames)
+{
+    return srs_success;
+}
+
+srs_error_t MockStatisticForHttpxConn::on_audio_frames(ISrsRequest *req, int nb_frames)
+{
+    return srs_success;
+}
+
 srs_error_t MockStatisticForHttpxConn::dumps_vhosts(SrsJsonArray *arr)
 {
     return srs_success;
@@ -2252,6 +2262,41 @@ srs_error_t MockStatisticForHttpxConn::dumps_clients(SrsJsonArray *arr, int star
 srs_error_t MockStatisticForHttpxConn::dumps_metrics(int64_t &send_bytes, int64_t &recv_bytes, int64_t &nstreams, int64_t &nclients, int64_t &total_nclients, int64_t &nerrs)
 {
     return srs_success;
+}
+
+std::string MockStatisticForHttpxConn::server_id()
+{
+    return "mock_server_id";
+}
+
+std::string MockStatisticForHttpxConn::service_id()
+{
+    return "mock_service_id";
+}
+
+std::string MockStatisticForHttpxConn::service_pid()
+{
+    return "mock_pid";
+}
+
+SrsStatisticVhost *MockStatisticForHttpxConn::find_vhost_by_id(std::string vid)
+{
+    return NULL;
+}
+
+SrsStatisticStream *MockStatisticForHttpxConn::find_stream(std::string sid)
+{
+    return NULL;
+}
+
+SrsStatisticStream *MockStatisticForHttpxConn::find_stream_by_url(std::string url)
+{
+    return NULL;
+}
+
+SrsStatisticClient *MockStatisticForHttpxConn::find_client(std::string client_id)
+{
+    return NULL;
 }
 
 void MockStatisticForHttpxConn::reset()

--- a/trunk/src/utest/srs_utest_ai19.hpp
+++ b/trunk/src/utest/srs_utest_ai19.hpp
@@ -502,10 +502,19 @@ public:
     virtual void on_stream_close(ISrsRequest *req);
     virtual void kbps_add_delta(std::string id, ISrsKbpsDelta *delta);
     virtual void kbps_sample();
+    virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames);
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames);
     virtual srs_error_t dumps_vhosts(SrsJsonArray *arr);
     virtual srs_error_t dumps_streams(SrsJsonArray *arr, int start, int count);
     virtual srs_error_t dumps_clients(SrsJsonArray *arr, int start, int count);
     virtual srs_error_t dumps_metrics(int64_t &send_bytes, int64_t &recv_bytes, int64_t &nstreams, int64_t &nclients, int64_t &total_nclients, int64_t &nerrs);
+    virtual std::string server_id();
+    virtual std::string service_id();
+    virtual std::string service_pid();
+    virtual SrsStatisticVhost *find_vhost_by_id(std::string vid);
+    virtual SrsStatisticStream *find_stream(std::string sid);
+    virtual SrsStatisticStream *find_stream_by_url(std::string url);
+    virtual SrsStatisticClient *find_client(std::string client_id);
     void reset();
 };
 

--- a/trunk/src/utest/srs_utest_ai21.cpp
+++ b/trunk/src/utest/srs_utest_ai21.cpp
@@ -1257,6 +1257,11 @@ srs_error_t MockSrtStatistic::on_video_frames(ISrsRequest *req, int nb_frames)
     return srs_success;
 }
 
+srs_error_t MockSrtStatistic::on_audio_frames(ISrsRequest *req, int nb_frames)
+{
+    return srs_success;
+}
+
 std::string MockSrtStatistic::server_id()
 {
     return "mock_server_id";

--- a/trunk/src/utest/srs_utest_ai21.hpp
+++ b/trunk/src/utest/srs_utest_ai21.hpp
@@ -57,6 +57,7 @@ public:
     virtual void kbps_add_delta(std::string id, ISrsKbpsDelta *delta);
     virtual void kbps_sample();
     virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames);
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames);
     virtual std::string server_id();
     virtual std::string service_id();
     virtual std::string service_pid();

--- a/trunk/src/utest/srs_utest_ai22.cpp
+++ b/trunk/src/utest/srs_utest_ai22.cpp
@@ -1482,6 +1482,11 @@ srs_error_t MockStatisticForRtspPlayStream::on_video_frames(ISrsRequest *req, in
     return srs_success;
 }
 
+srs_error_t MockStatisticForRtspPlayStream::on_audio_frames(ISrsRequest *req, int nb_frames)
+{
+    return srs_success;
+}
+
 std::string MockStatisticForRtspPlayStream::server_id()
 {
     return "mock_server_id";

--- a/trunk/src/utest/srs_utest_ai22.hpp
+++ b/trunk/src/utest/srs_utest_ai22.hpp
@@ -340,6 +340,7 @@ public:
     virtual void kbps_add_delta(std::string id, ISrsKbpsDelta *delta);
     virtual void kbps_sample();
     virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames);
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames);
     virtual std::string server_id();
     virtual std::string service_id();
     virtual std::string service_pid();

--- a/trunk/src/utest/srs_utest_manual_mock.cpp
+++ b/trunk/src/utest/srs_utest_manual_mock.cpp
@@ -438,6 +438,11 @@ srs_error_t MockAppStatistic::on_video_frames(ISrsRequest *req, int nb_frames)
     return srs_success;
 }
 
+srs_error_t MockAppStatistic::on_audio_frames(ISrsRequest *req, int nb_frames)
+{
+    return srs_success;
+}
+
 std::string MockAppStatistic::server_id()
 {
     return "";

--- a/trunk/src/utest/srs_utest_manual_mock.hpp
+++ b/trunk/src/utest/srs_utest_manual_mock.hpp
@@ -215,6 +215,7 @@ public:
     virtual void kbps_add_delta(std::string id, ISrsKbpsDelta *delta);
     virtual void kbps_sample();
     virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames);
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames);
     virtual std::string server_id();
     virtual std::string service_id();
     virtual std::string service_pid();


### PR DESCRIPTION
This PR adds separate audio and video frame counting to the HTTP API (`/api/v1/streams/`) for better stream observability. The API now reports three frame fields:
- `frames` - Total frames (video + audio)
- `video_frames` - Video frames/packets only
- `audio_frames` - Audio frames/packets only

This enhancement provides better visibility into stream composition and helps detect issues with CBR/VBR streams, audio/video sync problems, and codec-specific behavior.

**Before:**
```json
{
  "streams": [
    {
      "frames": 0, // video frames.
    }
  ]
}
```

**After:**
```json
{
  "streams": [
    {
      "frames": 6912, // video frames.
      "audio_frames": 5678, // audio frames.
      "video_frames": 1234, // video frames.
    }
  ]
}
```

Frame Counting Strategy
- All protocols report frames every N frames to balance accuracy and performance
- Frames are counted at the protocol-specific message/packet level:
  - RTMP: Counts RTMP messages (video/audio)
  - WebRTC: Counts RTP packets (video/audio)
  - SRT: Counts MPEG-TS messages (H.264/HEVC/AAC)
