### PR TITLE
AI: SRT: Stop TS parsing in SrsSrtFormat after codec detection. v7.0.125 (#4569)

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2025-11-11, AI: SRT: Stop TS parsing after codec detection. v7.0.125 (#4569)
 * v7.0, 2025-11-09, AI: WebRTC: Support G.711 (PCMU/PCMA) audio codec for WebRTC. v7.0.124 (#4075)
 * v7.0, 2025-11-08, AI: WebRTC: Support VP9 codec for WebRTC-to-WebRTC streaming. v7.0.123 (#4548)
 * v7.0, 2025-11-08, AI: API: Add audio_frames and video_frames to HTTP API. v7.0.122 (#4559)

--- a/trunk/src/app/srs_app_srt_source.cpp
+++ b/trunk/src/app/srs_app_srt_source.cpp
@@ -969,6 +969,12 @@ srs_error_t SrsSrtFormat::on_srt_packet(SrsSrtPacket *pkt)
 {
     srs_error_t err = srs_success;
 
+    // Skip TS parsing if both video and audio codecs have been reported
+    // This avoids unnecessary TS decoding and log flooding from unrecognized stream types
+    if (video_codec_reported_ && audio_codec_reported_) {
+        return err;
+    }
+
     char *buf = pkt->data();
     int nb_buf = pkt->size();
 

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 124
+#define VERSION_REVISION 125
 
 #endif


### PR DESCRIPTION
Fix log flooding issue when processing SRT streams containing SCTE-35 PIDs or other unrecognized stream types.

The `SrsSrtFormat::on_srt_packet()` method continuously parses TS packets throughout the entire stream lifetime. The TS parser logs warnings for every unrecognized stream type (like SCTE-35) in the PMT, causing log flooding.

However, `SrsFormat` is only used to detect audio/video codec information. Once both codecs are detected, there's no need to continue parsing TS packets.

Note: This fix mitigates the problem - there will still be some warning logs during the initial codec detection phase (typically 5-10 seconds), but the continuous log flooding after codec detection is completely eliminated.