### PR TITLE
AI: refine http api query param (#4358) (#4580) (#4542)

### DIFF
--- a/trunk/configure
+++ b/trunk/configure
@@ -385,10 +385,11 @@ if [[ $SRS_UTEST == YES ]]; then
     MODULE_FILES+=("srs_utest_workflow_rtc_playstream" "srs_utest_workflow_rtc_publishstream"
         "srs_utest_workflow_rtc_conn" "srs_utest_workflow_rtmp_conn" "srs_utest_workflow_srt_conn" "srs_utest_workflow_http_conn"
         "srs_utest_workflow_forward" "srs_utest_workflow_rtc2rtmp" "srs_utest_workflow_rtmp2rtc")
-    MODULE_FILES+=("srs_utest_ai01" "srs_utest_ai02" "srs_utest_ai03" "srs_utest_ai04" "srs_utest_ai05"
+    MODULE_FILES+=(
+        "srs_utest_ai01" "srs_utest_ai02" "srs_utest_ai03" "srs_utest_ai04" "srs_utest_ai05"
         "srs_utest_ai06" "srs_utest_ai07" "srs_utest_ai08" "srs_utest_ai09" "srs_utest_ai10" "srs_utest_ai11"
         "srs_utest_ai12" "srs_utest_ai13" "srs_utest_ai14" "srs_utest_ai15" "srs_utest_ai16" "srs_utest_ai17"
-        "srs_utest_ai18" "srs_utest_ai19" "srs_utest_ai20" "srs_utest_ai24")
+        "srs_utest_ai18" "srs_utest_ai19" "srs_utest_ai20" "srs_utest_ai24" "srs_utest_ai25")
     if [[ $SRS_GB28181 == YES ]]; then
         MODULE_FILES+=("srs_utest_manual_gb28181" "srs_utest_ai23")
     fi

--- a/trunk/src/app/srs_app_http_api.cpp
+++ b/trunk/src/app/srs_app_http_api.cpp
@@ -797,7 +797,24 @@ srs_error_t SrsGoApiStreams::serve_http(ISrsHttpResponseWriter *w, ISrsHttpMessa
             std::string rstart = r->query_get("start");
             std::string rcount = r->query_get("count");
             int start = srs_max(0, atoi(rstart.c_str()));
-            int count = srs_max(1, atoi(rcount.c_str()));
+
+            // Process the "count" query parameter
+            // 1. Default value is 10 if not provided or invalid
+            // 2. Valid values are positive integers
+            int count = 10; // Default value
+
+            if (!rcount.empty()) {
+                int value = atoi(rcount.c_str());
+
+                // Check if value is a positive integer
+                if (value > 0) {
+                    count = value;
+                } else {
+                    // Invalid count value (zero or negative), using default
+                    srs_trace("HTTP API: Invalid count parameter value: %s, using default value 10", rcount.c_str());
+                }
+            }
+            // If empty, we keep the default value of 10
             if ((err = stat_->dumps_streams(data, start, count)) != srs_success) {
                 int code = srs_error_code(err);
                 srs_freep(err);
@@ -869,7 +886,24 @@ srs_error_t SrsGoApiClients::serve_http(ISrsHttpResponseWriter *w, ISrsHttpMessa
             std::string rstart = r->query_get("start");
             std::string rcount = r->query_get("count");
             int start = srs_max(0, atoi(rstart.c_str()));
-            int count = srs_max(1, atoi(rcount.c_str()));
+
+            // Process the "count" query parameter
+            // 1. Default value is 10 if not provided or invalid
+            // 2. Valid values are positive integers
+            int count = 10; // Default value
+
+            if (!rcount.empty()) {
+                int value = atoi(rcount.c_str());
+
+                // Check if value is a positive integer
+                if (value > 0) {
+                    count = value;
+                } else {
+                    // Invalid count value (zero or negative), using default
+                    srs_trace("HTTP API: Invalid count parameter value: %s, using default value 10", rcount.c_str());
+                }
+            }
+            // If empty, we keep the default value of 10
             if ((err = stat_->dumps_clients(data, start, count)) != srs_success) {
                 int code = srs_error_code(err);
                 srs_freep(err);

--- a/trunk/src/utest/srs_utest_ai25.cpp
+++ b/trunk/src/utest/srs_utest_ai25.cpp
@@ -1,0 +1,306 @@
+//
+// Copyright (c) 2013-2025 The SRS Authors
+//
+// SPDX-License-Identifier: MIT
+//
+
+#include <srs_utest_ai25.hpp>
+
+MockHttpMessageForCountTest::MockHttpMessageForCountTest()
+{
+    mock_conn_ = new MockHttpConn();
+}
+
+MockHttpMessageForCountTest::~MockHttpMessageForCountTest()
+{
+    srs_freep(mock_conn_);
+    query_params_.clear();
+}
+
+void MockHttpMessageForCountTest::set_query_param(const std::string &key, const std::string &value)
+{
+    query_params_[key] = value;
+}
+
+void MockHttpMessageForCountTest::clear_query_params()
+{
+    query_params_.clear();
+}
+
+// ISrsHttpMessage interface implementation
+uint8_t MockHttpMessageForCountTest::message_type()
+{
+    return HTTP_REQUEST;
+}
+
+uint8_t MockHttpMessageForCountTest::method()
+{
+    return HTTP_GET;
+}
+
+uint16_t MockHttpMessageForCountTest::status_code()
+{
+    return HTTP_STATUS_OK;
+}
+
+std::string MockHttpMessageForCountTest::method_str()
+{
+    return "GET";
+}
+
+bool MockHttpMessageForCountTest::is_http_get()
+{
+    return true;
+}
+
+bool MockHttpMessageForCountTest::is_http_put()
+{
+    return false;
+}
+
+bool MockHttpMessageForCountTest::is_http_post()
+{
+    return false;
+}
+
+bool MockHttpMessageForCountTest::is_http_delete()
+{
+    return false;
+}
+
+bool MockHttpMessageForCountTest::is_http_options()
+{
+    return false;
+}
+
+std::string MockHttpMessageForCountTest::uri()
+{
+    return "/api/v1/streams";
+}
+
+std::string MockHttpMessageForCountTest::url()
+{
+    return "http://localhost/api/v1/streams";
+}
+
+std::string MockHttpMessageForCountTest::host()
+{
+    return "localhost";
+}
+
+std::string MockHttpMessageForCountTest::path()
+{
+    return "/api/v1/streams";
+}
+
+std::string MockHttpMessageForCountTest::query()
+{
+    return "";
+}
+
+std::string MockHttpMessageForCountTest::ext()
+{
+    return "";
+}
+
+srs_error_t MockHttpMessageForCountTest::body_read_all(std::string &body)
+{
+    body = "";
+    return srs_success;
+}
+
+ISrsHttpResponseReader *MockHttpMessageForCountTest::body_reader()
+{
+    return NULL;
+}
+
+int64_t MockHttpMessageForCountTest::content_length()
+{
+    return 0;
+}
+
+std::string MockHttpMessageForCountTest::query_get(std::string key)
+{
+    std::map<std::string, std::string>::iterator it = query_params_.find(key);
+    if (it != query_params_.end()) {
+        return it->second;
+    }
+    return "";
+}
+
+SrsHttpHeader *MockHttpMessageForCountTest::header()
+{
+    return NULL;
+}
+
+bool MockHttpMessageForCountTest::is_jsonp()
+{
+    return false;
+}
+
+bool MockHttpMessageForCountTest::is_keep_alive()
+{
+    return false;
+}
+
+std::string MockHttpMessageForCountTest::parse_rest_id(std::string pattern)
+{
+    return "";
+}
+
+// Test fixture implementation
+void HttpApiCountParameterTest::SetUp()
+{
+    mock_msg_ = new MockHttpMessageForCountTest();
+}
+
+void HttpApiCountParameterTest::TearDown()
+{
+    srs_freep(mock_msg_);
+}
+
+// Helper method to simulate the count parameter processing logic
+int HttpApiCountParameterTest::process_count_parameter(const std::string &count_value)
+{
+    // This method replicates the count parameter processing logic from srs_app_http_api.cpp
+    std::string rcount = count_value;
+    int count = 10; // Default value
+
+    if (!rcount.empty()) {
+        // Use atoi for simple conversion
+        int value = atoi(rcount.c_str());
+
+        // Check if value is a positive integer
+        if (value > 0) {
+            count = value;
+        }
+        // If not positive, we keep the default value
+    }
+
+    return count;
+}
+
+// Test cases implementation
+void HttpApiCountParameterTest::test_empty_count_parameter()
+{
+    // Test with empty count parameter
+    int count = process_count_parameter("");
+    EXPECT_EQ(10, count) << "Empty count parameter should use default value 10";
+}
+
+void HttpApiCountParameterTest::test_valid_positive_count()
+{
+    // Test with valid positive count values
+    EXPECT_EQ(1, process_count_parameter("1")) << "Count value 1 should be accepted";
+    EXPECT_EQ(5, process_count_parameter("5")) << "Count value 5 should be accepted";
+    EXPECT_EQ(20, process_count_parameter("20")) << "Count value 20 should be accepted";
+    EXPECT_EQ(100, process_count_parameter("100")) << "Count value 100 should be accepted";
+}
+
+void HttpApiCountParameterTest::test_zero_count_parameter()
+{
+    // Test with count=0, should use default value
+    int count = process_count_parameter("0");
+    EXPECT_EQ(10, count) << "Count value 0 should use default value 10";
+}
+
+void HttpApiCountParameterTest::test_negative_count_parameter()
+{
+    // Test with negative count values, should use default value
+    EXPECT_EQ(10, process_count_parameter("-1")) << "Negative count value -1 should use default value 10";
+    EXPECT_EQ(10, process_count_parameter("-5")) << "Negative count value -5 should use default value 10";
+    EXPECT_EQ(10, process_count_parameter("-100")) << "Negative count value -100 should use default value 10";
+}
+
+void HttpApiCountParameterTest::test_non_numeric_count_parameter()
+{
+    // Test with non-numeric count values, should use default value
+    // Since atoi returns 0 for non-numeric strings
+    EXPECT_EQ(10, process_count_parameter("abc")) << "Non-numeric count value 'abc' should use default value 10";
+    EXPECT_EQ(10, process_count_parameter("test")) << "Non-numeric count value 'test' should use default value 10";
+    EXPECT_EQ(10, process_count_parameter("!@#$%")) << "Non-numeric count value '!@#$%' should use default value 10";
+}
+
+void HttpApiCountParameterTest::test_mixed_numeric_text_count()
+{
+    // Test with mixed numeric and text values
+    // atoi stops at first non-digit character
+    EXPECT_EQ(123, process_count_parameter("123abc")) << "Mixed value '123abc' should be parsed as 123";
+    EXPECT_EQ(45, process_count_parameter("45test67")) << "Mixed value '45test67' should be parsed as 45";
+    EXPECT_EQ(10, process_count_parameter("abc123")) << "Mixed value starting with letters should be parsed as 0";
+}
+
+void HttpApiCountParameterTest::test_large_numeric_count()
+{
+    // Test with large numeric values
+    EXPECT_EQ(9999, process_count_parameter("9999")) << "Large count value 9999 should be accepted";
+
+    // Test with maximum int value (assuming 32-bit int)
+    EXPECT_EQ(2147483647, process_count_parameter("2147483647")) << "Maximum int value should be accepted";
+
+    // Test with value exceeding maximum int (will cause overflow)
+    // The behavior is implementation-defined, but we can still test it
+    // Note: We don't check the exact value due to undefined overflow behavior
+    int large_overflow = process_count_parameter("2147483648");
+    EXPECT_NE(2147483648, large_overflow) << "Value exceeding max int should cause overflow";
+}
+
+// Google Test test cases
+VOID TEST_F(HttpApiCountParameterTest, EmptyCountParameter)
+{
+    test_empty_count_parameter();
+}
+
+VOID TEST_F(HttpApiCountParameterTest, ValidPositiveCount)
+{
+    test_valid_positive_count();
+}
+
+VOID TEST_F(HttpApiCountParameterTest, ZeroCountParameter)
+{
+    test_zero_count_parameter();
+}
+
+VOID TEST_F(HttpApiCountParameterTest, NegativeCountParameter)
+{
+    test_negative_count_parameter();
+}
+
+VOID TEST_F(HttpApiCountParameterTest, NonNumericCountParameter)
+{
+    test_non_numeric_count_parameter();
+}
+
+VOID TEST_F(HttpApiCountParameterTest, MixedNumericTextCount)
+{
+    test_mixed_numeric_text_count();
+}
+
+VOID TEST_F(HttpApiCountParameterTest, LargeNumericCount)
+{
+    test_large_numeric_count();
+}
+
+// Additional test case: Integration with actual query_get method
+VOID TEST_F(HttpApiCountParameterTest, IntegrationWithQueryGet)
+{
+    // Clear any existing parameters
+    mock_msg_->clear_query_params();
+
+    // Test with no count parameter
+    std::string rcount = mock_msg_->query_get("count");
+    int count = process_count_parameter(rcount);
+    EXPECT_EQ(10, count) << "No count parameter should use default value 10";
+
+    // Test with valid count parameter
+    mock_msg_->set_query_param("count", "5");
+    rcount = mock_msg_->query_get("count");
+    count = process_count_parameter(rcount);
+    EXPECT_EQ(5, count) << "Valid count parameter 5 should be used";
+
+    // Test with invalid count parameter
+    mock_msg_->set_query_param("count", "invalid");
+    rcount = mock_msg_->query_get("count");
+    count = process_count_parameter(rcount);
+    EXPECT_EQ(10, count) << "Invalid count parameter should use default value 10";
+}

--- a/trunk/src/utest/srs_utest_ai25.hpp
+++ b/trunk/src/utest/srs_utest_ai25.hpp
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2013-2025 The SRS Authors
+//
+// SPDX-License-Identifier: MIT
+//
+
+#ifndef SRS_UTEST_AI25_HPP
+#define SRS_UTEST_AI25_HPP
+
+/*
+#include <srs_utest_ai25.hpp>
+*/
+#include <srs_utest.hpp>
+
+#include <srs_app_http_api.hpp>
+#include <srs_protocol_http_conn.hpp>
+#include <srs_protocol_http_stack.hpp>
+
+// Mock HTTP message for testing count parameter handling
+class MockHttpMessageForCountTest : public ISrsHttpMessage
+{
+public:
+    MockHttpConn *mock_conn_;
+    std::map<std::string, std::string> query_params_;
+
+public:
+    MockHttpMessageForCountTest();
+    virtual ~MockHttpMessageForCountTest();
+
+    // Set a query parameter value
+    void set_query_param(const std::string& key, const std::string& value);
+    
+    // Clear all query parameters
+    void clear_query_params();
+
+public:
+    // ISrsHttpMessage interface implementation
+    virtual uint8_t message_type();
+    virtual uint8_t method();
+    virtual uint16_t status_code();
+    virtual std::string method_str();
+    virtual bool is_http_get();
+    virtual bool is_http_put();
+    virtual bool is_http_post();
+    virtual bool is_http_delete();
+    virtual bool is_http_options();
+    virtual std::string uri();
+    virtual std::string url();
+    virtual std::string host();
+    virtual std::string path();
+    virtual std::string query();
+    virtual std::string ext();
+    virtual srs_error_t body_read_all(std::string &body);
+    virtual ISrsHttpResponseReader *body_reader();
+    virtual int64_t content_length();
+    virtual std::string query_get(std::string key);
+    virtual SrsHttpHeader *header();
+    virtual bool is_jsonp();
+    virtual bool is_keep_alive();
+    virtual std::string parse_rest_id(std::string pattern);
+};
+
+// Test fixture for HTTP API count parameter handling
+class HttpApiCountParameterTest : public ::testing::Test
+{
+protected:
+    void SetUp() override;
+    void TearDown() override;
+    
+    // Helper method to test count parameter processing
+    int process_count_parameter(const std::string& count_value);
+    
+    // Test different count parameter scenarios
+    void test_empty_count_parameter();
+    void test_valid_positive_count();
+    void test_zero_count_parameter();
+    void test_negative_count_parameter();
+    void test_non_numeric_count_parameter();
+    void test_mixed_numeric_text_count();
+    void test_large_numeric_count();
+
+protected:
+    MockHttpMessageForCountTest *mock_msg_;
+};
+
+#endif // SRS_UTEST_AI25_HPP


### PR DESCRIPTION
Try to fix/refine #4358 #4580 #4542

According to the doc: 
https://ossrs.io/lts/en-us/docs/v7/doc/http-api#streams and https://ossrs.io/lts/en-us/docs/v7/doc/http-api#clients

`?count=N` gives the number of result http api can return, the default is 10, which means when `count` is empty or invalid, use the default value 10, else use the give value.

But b7828e1 didn't fellow the doc, blame AI. 