### PR TITLE
RTC: Fix missing CRLF for SSRC group in SDP

### DIFF
--- a/trunk/src/protocol/srs_protocol_sdp.cpp
+++ b/trunk/src/protocol/srs_protocol_sdp.cpp
@@ -297,7 +297,7 @@ srs_error_t SrsSSRCGroup::encode(std::ostringstream &os)
     for (int i = 0; i < (int)ssrcs_.size(); i++) {
         os << " " << ssrcs_[i];
     }
-
+    os << kCRLF;
     return err;
 }
 


### PR DESCRIPTION
Hello SRS team,

During my recent experimental development to support downlink RTX/FEC (which requires negotiating a=ssrc-group:FID/FEC to players), I found a formatting bug in the SDP generation logic.

In  trunk/src/protocol/srs_protocol_sdp.cpp, the SrsSSRCGroup::encode function lacks a trailing kCRLF.
If ssrc_groups_ is not empty during downlink SDP generation, it will generate concatenated SDP lines like:
a=ssrc-group:FID 111 222a=ssrc:111 cname:...
This causes WebRTC clients (e.g., Chrome) to fail to parse the remote answer SDP.