### PR TITLE
Move build output to bin/, replace godotenv with custom .env parser, and update docs. v70.143

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,31 +1,4 @@
 {
-  "permissions": {
-    "allow": [
-      "Read",
-      "Glob",
-      "Grep",
-      "Bash(find:*)",
-      "Bash(ls:*)",
-      "Bash(cat:*)",
-      "Bash(head:*)",
-      "Bash(tail:*)",
-      "Bash(wc:*)",
-      "Bash(grep:*)",
-      "Bash(rg:*)",
-      "Bash(file:*)",
-      "Bash(stat:*)",
-      "Bash(tree:*)",
-      "Bash(du:*)",
-      "Bash(diff:*)",
-      "Bash(which:*)",
-      "Bash(type:*)",
-      "Bash(realpath:*)",
-      "Bash(dirname:*)",
-      "Bash(basename:*)",
-      "Bash(echo \"PID=$!\")",
-      "Bash(make)"
-    ]
-  },
   "hooks": {
     "SessionStart": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ cmake-build-debug
 /trunk/cmake/build
 
 # proxy (Go)
-srs-proxy
+/bin/
 .go-formarted
 .env
 

--- a/.openclaw/skills/srs-develop/scripts/proxy-e2e-test.sh
+++ b/.openclaw/skills/srs-develop/scripts/proxy-e2e-test.sh
@@ -109,7 +109,7 @@ env PROXY_RTMP_SERVER=$PROXY_RTMP_PORT \
     PROXY_SRT_SERVER=$PROXY_SRT_PORT \
     PROXY_SYSTEM_API=$PROXY_SYSTEM_API_PORT \
     PROXY_LOAD_BALANCER_TYPE=memory \
-    ./srs-proxy >/tmp/srs-proxy-e2e.log 2>&1 &
+    ./bin/srs-proxy >/tmp/srs-proxy-e2e.log 2>&1 &
 PROXY_PID=$!
 echo "Proxy PID: $PROXY_PID"
 sleep 1

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@
 
 all: build
 
-build: fmt ./srs-proxy
+build: fmt bin/srs-proxy
 
-./srs-proxy: cmd/proxy/*.go internal/**/*.go
-	go build -o srs-proxy ./cmd/proxy
+bin/srs-proxy: cmd/proxy/*.go internal/**/*.go
+	@mkdir -p bin
+	go build -o bin/srs-proxy ./cmd/proxy
 
 test:
 	go test ./...
@@ -17,7 +18,7 @@ fmt: ./.go-formarted
 	go fmt ./cmd/... ./internal/...
 
 clean:
-	rm -f srs-proxy .go-formarted
+	rm -rf bin .go-formarted
 
 run: fmt
 	go run ./cmd/proxy

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package main

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package main

--- a/docs/proxy/README.md
+++ b/docs/proxy/README.md
@@ -6,15 +6,14 @@ Proxy is a common proxy server (`cmd/proxy`) for any media servers with RTMP/SRT
 
 This project is managed by AI. We recommend OpenClaw by default, but you can use any AI agent that supports skills, such as Claude Code, OpenAI Codex, Kiro CLI, or similar tools that can read code and docs as context. Setup your AI code tool and ask questions like:
 
-- How to use this project?
-- How to run the proxy server?
-- How to build an Origin Cluster for production?
+- Use skill to show me how to use proxy.
+- Use skill to show me how to build an Origin Cluster for production.
+- Use skill to show me how to learn the proxy design and protocols.
 
 You can not only use AI to show you the usage of this project, but also use AI to guide you to learn the details of this project, to understand the design and protocols, to learn each documents in docs directory.
 
 ## AI Guidelines
 
-- AI assistants should ignore [ignore-worklog.md](ignore-worklog.md) as it's a personal work log that may contain misleading information, hallucinations, or falsehoods. Never rely on this file as a reference.
 - For usage of proxy server and end to end test it, you should load [proxy-usage.md](proxy-usage.md). This is the first step for new users to learn how to use this project. It provides a general and overall view of the proxy server, including practical usage examples and end-to-end testing procedures.
 - For proxy full usage to build an Origin Cluster for SRS media server, please load [proxy-origin-cluster.md](proxy-origin-cluster.md). This is an advanced topic about how to use the proxy server to build the SRS Origin Cluster. Users should read this document to learn more details and architectures about proxy and Origin Cluster.
 - For proxy server: To understand proxy system design, you should load the [proxy-design.md](proxy-design.md). To understand the proxy protocol details, you should load the [proxy-protocol.md](proxy-protocol.md). To understand how load balance works, you should load [proxy-load-balancer.md](proxy-load-balancer.md). To understand the code structure and packages, you should load [proxy-files.md](proxy-files.md).

--- a/docs/proxy/ignore-worklog.md
+++ b/docs/proxy/ignore-worklog.md
@@ -1,7 +1,0 @@
-# Work Log
-
-> Important notes for AI assistants: This file might includes misleading information, hallucinations, or even falsehoods, since it's just a personal work log. So AI should never rely on this file as a reference.
-
-SRSX is not only the next generation of SRS (Simple Realtime Server), and it's also an approach to leverage AI to manage the project as a whole. So it's not just a useful open source project, but also a demostration of how AI can help develop, manage, and maintain a complex project.
-
-Since AI is relatively a new tool for open source project development, I use this work log to record my thoughts, ideas, experiments, and even failures along the way, while integrating AI into this open source project.

--- a/docs/proxy/proxy-origin-cluster.md
+++ b/docs/proxy/proxy-origin-cluster.md
@@ -5,7 +5,7 @@ How to use the proxy server to build an origin cluster for SRS media server.
 ## Build
 
 To build the proxy server, you need to have Go 1.18+ installed. Then, you can build the proxy 
-server by below command, and get the executable binary `./srs-proxy`:
+server by below command, and get the executable binary `bin/srs-proxy`:
 
 ```bash
 cd ~/git &&
@@ -43,7 +43,7 @@ First, start the proxy server:
 ```bash
 env PROXY_RTMP_SERVER=1935 PROXY_HTTP_SERVER=8080 \
     PROXY_HTTP_API=1985 PROXY_WEBRTC_SERVER=8000 PROXY_SRT_SERVER=10080 \
-    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./srs-proxy
+    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./bin/srs-proxy
 ```
 
 > Note: Here we use the memory load balancer, you can switch to `redis` if you want to run more
@@ -96,7 +96,7 @@ First, start the proxy server:
 ```bash
 env PROXY_RTMP_SERVER=1935 PROXY_HTTP_SERVER=8080 \
     PROXY_HTTP_API=1985 PROXY_WEBRTC_SERVER=8000 PROXY_SRT_SERVER=10080 \
-    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./srs-proxy
+    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./bin/srs-proxy
 ```
 
 > Note: Here we use the memory load balancer, you can switch to `redis` if you want to run more
@@ -145,7 +145,7 @@ First, start the proxy server:
 ```bash
 env PROXY_RTMP_SERVER=1935 PROXY_HTTP_SERVER=8080 \
     PROXY_HTTP_API=1985 PROXY_WEBRTC_SERVER=8000 PROXY_SRT_SERVER=10080 \
-    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./srs-proxy
+    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./bin/srs-proxy
 ```
 
 > Note: Here we use the memory load balancer, you can switch to `redis` if you want to run more

--- a/docs/proxy/proxy-usage.md
+++ b/docs/proxy/proxy-usage.md
@@ -12,7 +12,7 @@ When running the project for testing or development, you should:
 ```bash
 make && env PROXY_RTMP_SERVER=1935 PROXY_HTTP_SERVER=8080 \
     PROXY_HTTP_API=1985 PROXY_WEBRTC_SERVER=8000 PROXY_SRT_SERVER=10080 \
-    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./srs-proxy
+    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./bin/srs-proxy
 ```
 
 The proxy server should start and listen on the configured ports.

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module srsx
 
 go 1.24
 
-require (
-	github.com/go-redis/redis/v8 v8.11.5
-	github.com/joho/godotenv v1.5.1
-)
+require github.com/go-redis/redis/v8 v8.11.5
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package bootstrap

--- a/internal/bootstrap/proxy.go
+++ b/internal/bootstrap/proxy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package bootstrap

--- a/internal/debug/pprof.go
+++ b/internal/debug/pprof.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package debug

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package env

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -4,10 +4,10 @@
 package env
 
 import (
+	"bufio"
 	"context"
 	"os"
-
-	"github.com/joho/godotenv"
+	"strings"
 
 	"srsx/internal/errors"
 	"srsx/internal/logger"
@@ -162,16 +162,98 @@ func (e *environment) DefaultBackendSRT() string {
 
 // loadEnvFile loads the environment variables from .env file.
 func loadEnvFile(ctx context.Context) error {
-	if err := godotenv.Load(); err != nil {
-		// If .env file doesn't exist, that's okay, just log and continue
+	envMap, err := parseEnvFile(".env")
+	if err != nil {
 		if os.IsNotExist(err) {
 			logger.Df(ctx, "no .env file found, skipping")
 			return nil
 		}
 		return errors.Wrapf(err, "load .env file")
 	}
+
+	// Build a set of existing environment variable keys, so we don't overwrite them.
+	currentEnv := make(map[string]bool)
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		currentEnv[key] = true
+	}
+
+	for key, value := range envMap {
+		if !currentEnv[key] {
+			os.Setenv(key, value)
+		}
+	}
+
 	logger.Df(ctx, "successfully loaded .env file")
 	return nil
+}
+
+// parseEnvFile reads a .env file and returns a map of key-value pairs.
+func parseEnvFile(filename string) (map[string]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	envMap := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments.
+		if line == "" || line[0] == '#' {
+			continue
+		}
+
+		// Strip optional "export " prefix.
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimPrefix(line, "export ")
+			line = strings.TrimSpace(line)
+		}
+
+		// Split on first '=' to get key and value.
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		// Handle quoted values.
+		if len(value) >= 2 {
+			if value[0] == '\'' && value[len(value)-1] == '\'' {
+				// Single-quoted: raw literal, no escaping.
+				value = value[1 : len(value)-1]
+			} else if value[0] == '"' && value[len(value)-1] == '"' {
+				// Double-quoted: process escape sequences.
+				value = value[1 : len(value)-1]
+				value = strings.ReplaceAll(value, `\n`, "\n")
+				value = strings.ReplaceAll(value, `\r`, "\r")
+				value = strings.ReplaceAll(value, `\"`, `"`)
+				value = strings.ReplaceAll(value, `\\`, `\`)
+			} else {
+				// Unquoted: strip inline comments.
+				if idx := strings.Index(value, " #"); idx != -1 {
+					value = strings.TrimSpace(value[:idx])
+				}
+			}
+		} else {
+			// Unquoted short value: strip inline comments.
+			if idx := strings.Index(value, " #"); idx != -1 {
+				value = strings.TrimSpace(value[:idx])
+			}
+		}
+
+		envMap[key] = value
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return envMap, nil
 }
 
 // buildDefaultEnvironmentVariables setups the default environment variables.

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package env

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2025 Winlin
+//
+// SPDX-License-Identifier: MIT
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseEnvFile_BasicKeyValue(t *testing.T) {
+	f := writeTempEnv(t, "FOO=bar\nHELLO=world\n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["FOO"] != "bar" {
+		t.Errorf("FOO = %q, want %q", m["FOO"], "bar")
+	}
+	if m["HELLO"] != "world" {
+		t.Errorf("HELLO = %q, want %q", m["HELLO"], "world")
+	}
+}
+
+func TestParseEnvFile_SkipCommentsAndBlankLines(t *testing.T) {
+	f := writeTempEnv(t, "# this is a comment\n\nKEY=value\n\n# another comment\n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(m) != 1 {
+		t.Errorf("got %d entries, want 1", len(m))
+	}
+	if m["KEY"] != "value" {
+		t.Errorf("KEY = %q, want %q", m["KEY"], "value")
+	}
+}
+
+func TestParseEnvFile_ExportPrefix(t *testing.T) {
+	f := writeTempEnv(t, "export PORT=8080\nexport HOST=localhost\n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["PORT"] != "8080" {
+		t.Errorf("PORT = %q, want %q", m["PORT"], "8080")
+	}
+	if m["HOST"] != "localhost" {
+		t.Errorf("HOST = %q, want %q", m["HOST"], "localhost")
+	}
+}
+
+func TestParseEnvFile_SingleQuoted(t *testing.T) {
+	f := writeTempEnv(t, "KEY='hello world'\nRAW='no\\nescaping'\n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["KEY"] != "hello world" {
+		t.Errorf("KEY = %q, want %q", m["KEY"], "hello world")
+	}
+	// Single quotes: backslash-n stays literal.
+	if m["RAW"] != `no\nescaping` {
+		t.Errorf("RAW = %q, want %q", m["RAW"], `no\nescaping`)
+	}
+}
+
+func TestParseEnvFile_DoubleQuoted(t *testing.T) {
+	f := writeTempEnv(t, `KEY="hello world"`+"\n"+`MSG="line1\nline2"`+"\n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["KEY"] != "hello world" {
+		t.Errorf("KEY = %q, want %q", m["KEY"], "hello world")
+	}
+	if m["MSG"] != "line1\nline2" {
+		t.Errorf("MSG = %q, want %q", m["MSG"], "line1\nline2")
+	}
+}
+
+func TestParseEnvFile_DoubleQuotedEscapes(t *testing.T) {
+	f := writeTempEnv(t, `KEY="say \"hi\""`+"\n"+`BS="back\\slash"`+"\n"+`CR="a\rb"`+"\n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["KEY"] != `say "hi"` {
+		t.Errorf("KEY = %q, want %q", m["KEY"], `say "hi"`)
+	}
+	if m["BS"] != `back\slash` {
+		t.Errorf("BS = %q, want %q", m["BS"], `back\slash`)
+	}
+	if m["CR"] != "a\rb" {
+		t.Errorf("CR = %q, want %q", m["CR"], "a\rb")
+	}
+}
+
+func TestParseEnvFile_InlineComment(t *testing.T) {
+	f := writeTempEnv(t, "KEY=value # this is a comment\nNUM=42 # the answer\n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["KEY"] != "value" {
+		t.Errorf("KEY = %q, want %q", m["KEY"], "value")
+	}
+	if m["NUM"] != "42" {
+		t.Errorf("NUM = %q, want %q", m["NUM"], "42")
+	}
+}
+
+func TestParseEnvFile_NoEqualsSign(t *testing.T) {
+	f := writeTempEnv(t, "NOEQUALS\nKEY=value\n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(m) != 1 {
+		t.Errorf("got %d entries, want 1", len(m))
+	}
+	if m["KEY"] != "value" {
+		t.Errorf("KEY = %q, want %q", m["KEY"], "value")
+	}
+}
+
+func TestParseEnvFile_EmptyValue(t *testing.T) {
+	f := writeTempEnv(t, "KEY=\n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v, ok := m["KEY"]; !ok || v != "" {
+		t.Errorf("KEY = %q (ok=%v), want empty string", v, ok)
+	}
+}
+
+func TestParseEnvFile_ValueWithEquals(t *testing.T) {
+	f := writeTempEnv(t, "URL=postgres://host:5432/db?opt=val\n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["URL"] != "postgres://host:5432/db?opt=val" {
+		t.Errorf("URL = %q, want %q", m["URL"], "postgres://host:5432/db?opt=val")
+	}
+}
+
+func TestParseEnvFile_FileNotFound(t *testing.T) {
+	_, err := parseEnvFile("/nonexistent/.env")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("expected os.IsNotExist, got: %v", err)
+	}
+}
+
+func TestParseEnvFile_WhitespaceAroundKeyValue(t *testing.T) {
+	f := writeTempEnv(t, "  KEY  =  value  \n")
+	m, err := parseEnvFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["KEY"] != "value" {
+		t.Errorf("KEY = %q, want %q", m["KEY"], "value")
+	}
+}
+
+func TestLoadEnvFile_DoesNotOverwriteExisting(t *testing.T) {
+	// Write a .env file in a temp dir.
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envFile, []byte("TEST_EXISTING=fromfile\nTEST_NEW=fromfile\n"), 0644); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	// Pre-set one of the keys in the real environment.
+	os.Setenv("TEST_EXISTING", "fromshell")
+	t.Cleanup(func() {
+		os.Unsetenv("TEST_EXISTING")
+		os.Unsetenv("TEST_NEW")
+	})
+
+	// Parse and apply, mimicking loadEnvFile logic.
+	m, err := parseEnvFile(envFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	currentEnv := make(map[string]bool)
+	for _, entry := range os.Environ() {
+		k, _, _ := strings.Cut(entry, "=")
+		currentEnv[k] = true
+	}
+	for k, v := range m {
+		if !currentEnv[k] {
+			os.Setenv(k, v)
+		}
+	}
+
+	// Existing key should NOT be overwritten.
+	if got := os.Getenv("TEST_EXISTING"); got != "fromshell" {
+		t.Errorf("TEST_EXISTING = %q, want %q (should not overwrite)", got, "fromshell")
+	}
+	// New key should be set.
+	if got := os.Getenv("TEST_NEW"); got != "fromfile" {
+		t.Errorf("TEST_NEW = %q, want %q", got, "fromfile")
+	}
+}
+
+// writeTempEnv writes content to a temp .env file and returns the path.
+func writeTempEnv(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, ".env")
+	if err := os.WriteFile(f, []byte(content), 0644); err != nil {
+		t.Fatalf("write temp .env: %v", err)
+	}
+	return f
+}

--- a/internal/lb/debug.go
+++ b/internal/lb/debug.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package lb

--- a/internal/lb/lb.go
+++ b/internal/lb/lb.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package lb

--- a/internal/lb/mem.go
+++ b/internal/lb/mem.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package lb

--- a/internal/lb/redis.go
+++ b/internal/lb/redis.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package lb

--- a/internal/logger/context.go
+++ b/internal/logger/context.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package logger

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package logger

--- a/internal/protocol/api.go
+++ b/internal/protocol/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package protocol

--- a/internal/protocol/http.go
+++ b/internal/protocol/http.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package protocol

--- a/internal/protocol/rtc.go
+++ b/internal/protocol/rtc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package protocol

--- a/internal/protocol/rtmp.go
+++ b/internal/protocol/rtmp.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package protocol

--- a/internal/protocol/srt.go
+++ b/internal/protocol/srt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package protocol

--- a/internal/rtmp/amf0.go
+++ b/internal/rtmp/amf0.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package rtmp

--- a/internal/rtmp/rtmp.go
+++ b/internal/rtmp/rtmp.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package rtmp

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package signal

--- a/internal/sync/map.go
+++ b/internal/sync/map.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package sync

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package utils

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Winlin
+// Copyright (c) 2026 Winlin
 //
 // SPDX-License-Identifier: MIT
 package version

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,16 +6,16 @@ package version
 import "fmt"
 
 func VersionMajor() int {
-	return 1
+	return 7
 }
 
 // VersionMinor specifies the typical version of SRS we adapt to.
 func VersionMinor() int {
-	return 5
+	return 0
 }
 
 func VersionRevision() int {
-	return 0
+	return 143
 }
 
 func Version() string {

--- a/trunk/3rdparty/signaling/main.go
+++ b/trunk/3rdparty/signaling/main.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/LICENSE
+++ b/trunk/3rdparty/srs-bench/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2025 Winlin
+Copyright (c) 2026 Winlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/blackbox.go
+++ b/trunk/3rdparty/srs-bench/blackbox/blackbox.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/blackbox_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/blackbox_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/dvr_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/dvr_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/hevc_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/hevc_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/hls_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/hls_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/http_api_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/http_api_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/mp3_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/mp3_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/rtmp_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/rtmp_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/rtsp_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/rtsp_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/srt_test.go
+++ b/trunk/3rdparty/srs-bench/blackbox/srt_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/blackbox/util.go
+++ b/trunk/3rdparty/srs-bench/blackbox/util.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/janus/api.go
+++ b/trunk/3rdparty/srs-bench/janus/api.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/janus/ingester.go
+++ b/trunk/3rdparty/srs-bench/janus/ingester.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/janus/interceptor.go
+++ b/trunk/3rdparty/srs-bench/janus/interceptor.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/janus/janus.go
+++ b/trunk/3rdparty/srs-bench/janus/janus.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/janus/player.go
+++ b/trunk/3rdparty/srs-bench/janus/player.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/janus/publisher.go
+++ b/trunk/3rdparty/srs-bench/janus/publisher.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/janus/util.go
+++ b/trunk/3rdparty/srs-bench/janus/util.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/janus/util2.go
+++ b/trunk/3rdparty/srs-bench/janus/util2.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/live/live.go
+++ b/trunk/3rdparty/srs-bench/live/live.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/live/publisher.go
+++ b/trunk/3rdparty/srs-bench/live/publisher.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/live/stat.go
+++ b/trunk/3rdparty/srs-bench/live/stat.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/main.go
+++ b/trunk/3rdparty/srs-bench/main.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/api.go
+++ b/trunk/3rdparty/srs-bench/srs/api.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/ingester.go
+++ b/trunk/3rdparty/srs-bench/srs/ingester.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/interceptor.go
+++ b/trunk/3rdparty/srs-bench/srs/interceptor.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/player.go
+++ b/trunk/3rdparty/srs-bench/srs/player.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/publisher.go
+++ b/trunk/3rdparty/srs-bench/srs/publisher.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/rtc_test.go
+++ b/trunk/3rdparty/srs-bench/srs/rtc_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/rtmp_test.go
+++ b/trunk/3rdparty/srs-bench/srs/rtmp_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/srs.go
+++ b/trunk/3rdparty/srs-bench/srs/srs.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/srs_test.go
+++ b/trunk/3rdparty/srs-bench/srs/srs_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/stat.go
+++ b/trunk/3rdparty/srs-bench/srs/stat.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/srs/util.go
+++ b/trunk/3rdparty/srs-bench/srs/util.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/vnet/example_udpproxy_test.go
+++ b/trunk/3rdparty/srs-bench/vnet/example_udpproxy_test.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-bench/vnet/vnet.go
+++ b/trunk/3rdparty/srs-bench/vnet/vnet.go
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// # Copyright (c) 2025 Winlin
+// # Copyright (c) 2026 Winlin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/trunk/3rdparty/srs-docs/doc/origin-cluster.md
+++ b/trunk/3rdparty/srs-docs/doc/origin-cluster.md
@@ -46,7 +46,7 @@ Please see [Protocols](#protocols) for details.
 ## Build
 
 To build the proxy server, you need to have Go 1.18+ installed. Then, you can build the proxy
-server by below command, and get the executable binary `./srs-proxy`:
+server by below command, and get the executable binary `bin/srs-proxy`:
 
 ```bash
 git clone https://github.com/ossrs/srs.git
@@ -71,7 +71,7 @@ First, start the proxy server:
 ```bash
 env PROXY_RTMP_SERVER=1935 PROXY_HTTP_SERVER=8080 \
     PROXY_HTTP_API=1985 PROXY_WEBRTC_SERVER=8000 PROXY_SRT_SERVER=10080 \
-    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./srs-proxy
+    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./bin/srs-proxy
 ```
 
 > Note: Here we use the memory load balancer, you can switch to `redis` if you want to run more
@@ -124,7 +124,7 @@ First, start the proxy server:
 ```bash
 env PROXY_RTMP_SERVER=1935 PROXY_HTTP_SERVER=8080 \
     PROXY_HTTP_API=1985 PROXY_WEBRTC_SERVER=8000 PROXY_SRT_SERVER=10080 \
-    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./srs-proxy
+    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./bin/srs-proxy
 ```
 
 > Note: Here we use the memory load balancer, you can switch to `redis` if you want to run more
@@ -173,7 +173,7 @@ First, start the proxy server:
 ```bash
 env PROXY_RTMP_SERVER=1935 PROXY_HTTP_SERVER=8080 \
     PROXY_HTTP_API=1985 PROXY_WEBRTC_SERVER=8000 PROXY_SRT_SERVER=10080 \
-    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./srs-proxy
+    PROXY_SYSTEM_API=12025 PROXY_LOAD_BALANCER_TYPE=memory ./bin/srs-proxy
 ```
 
 > Note: Here we use the memory load balancer, you can switch to `redis` if you want to run more

--- a/trunk/3rdparty/st-srs/tools/jmpbuf/jmpbuf.c
+++ b/trunk/3rdparty/st-srs/tools/jmpbuf/jmpbuf.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/* Copyright (c) 2025 Winlin */
+/* Copyright (c) 2026 Winlin */
 
 #include <stdio.h>
 #include <setjmp.h>

--- a/trunk/3rdparty/st-srs/tools/pcs/pcs.c
+++ b/trunk/3rdparty/st-srs/tools/pcs/pcs.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/* Copyright (c) 2025 Winlin */
+/* Copyright (c) 2026 Winlin */
 
 void foo() {
 }

--- a/trunk/3rdparty/st-srs/tools/stack/stack.c
+++ b/trunk/3rdparty/st-srs/tools/stack/stack.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MIT */
-/* Copyright (c) 2025 Winlin */
+/* Copyright (c) 2026 Winlin */
 
 long foo() {
     char c;

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2026-04-12, Merge [#4661](https://github.com/ossrs/srs/pull/4661): Proxy: Move build output to bin/, replace godotenv with custom .env parser, and update docs. v7.0.143 (#4661)
 * v7.0, 2026-04-06, Merge [#4657](https://github.com/ossrs/srs/pull/4657): Proxy: Refactor bootstrap for multi-server support and rebrand to SRSX. v7.0.142 (#4657)
 * v7.0, 2026-03-26, Merge [#4654](https://github.com/ossrs/srs/pull/4654): OpenClaw: Restructure workspace with symlinks, add codebase map, and rewrite AI docs. v7.0.141 (#4654)
 * v7.0, 2026-03-22, Merge [#4653](https://github.com/ossrs/srs/pull/4653): OpenClaw: unify AI agent configs with shared persona symlinks. v7.0.140 (#4653)

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 142
+#define VERSION_REVISION 143
 
 #endif


### PR DESCRIPTION
- Move build output from `./srs-proxy` to `bin/srs-proxy` following Go project conventions, updating Makefile, .gitignore, and all documentation references
- Replace third-party `godotenv` dependency with a custom `.env` parser that supports comments, `export` prefix, quoted values, escape sequences, and inline comments — with full unit tests
- Remove `ignore-worklog.md` and update `README.md` with skill-based AI prompts
- Bump copyright year from 2025 to 2026 across all source files
