### PR TITLE
Fix live source cleanup race before publisher activation. v8.0.5

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 4
+	return 5
 }
 
 func Version() string {

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -206,3 +206,114 @@ This is a valid missing feature with a confirmed initialization bug, not a regre
 **Conclusion**
 
 The publisher used stream `livestream`, but WHEP requested `livestream.flv`. WHEP treats `.flv` as part of the stream name; it is only appropriate for HTTP-FLV URLs. Use `stream=livestream`. This is user URL misuse, not an SRS bug, and the existing documentation is sufficient.
+
+## #4656 — CURRENT
+
+- Issue: https://github.com/ossrs/srs/issues/4656
+- Truth Record: https://github.com/ossrs/srs/issues/4656#issuecomment-5161223806
+- Verified: 2026-08-02
+- Branch: `forge`
+- Commit: `4843c69d8df2aea45bde8f73e5ed2fa72e3a924f`, with an uncommitted candidate fix
+- Version: SRS `8.0.4`; another user reported the problem on SRS `6.0.166`
+- Environment: macOS 26.5.2, arm64; FFmpeg/FFprobe 8.1.1
+- Supersedes: None; no previous authorized Truth Record
+- Changes: Candidate fix and regression tests, not committed or released
+
+### Reported problem
+
+An affected stream can continue receiving publisher data while new RTMP and HTTP-FLV players receive no media. SRS logs show players creating a consumer with `active=0`. HLS can continue playing the same stream.
+
+Restarting SRS, or kicking the publisher and allowing it to republish, restores playback. A [second report](https://github.com/ossrs/srs/issues/4656#issuecomment-4610706424) described the same intermittent behavior on SRS 6.0.166.
+
+### Confirmed root cause
+
+The publisher acquires its global stream publish token before fetching the live source.
+
+A race is possible after the publisher fetches source **A** but before `acquire_publish()` activates it:
+
+1. The publisher acquires the stream publish token.
+2. It fetches source **A** from the live-source manager.
+3. It yields before calling `acquire_publish()`.
+4. Because source **A** is not active yet, the cleanup timer can consider it dead and erase it from the manager's source pool.
+5. The publisher still retains a shared pointer to source **A**, so it later activates and publishes media into **A**.
+6. A new player cannot find **A** in the pool and creates source **B** for the same stream URL.
+7. Source **B** has no publisher, so the player gets `active=0` and no media.
+
+HLS can continue because the publisher and its existing HLS pipeline still reference source **A**, while new RTMP and HTTP-FLV players use source **B**.
+
+### Deterministic reproduction
+
+A test-only environment variable was added before `acquire_publish()`:
+
+```bash
+SRS_TEST_PUBLISH_BEFORE_ACQUIRE_DELAY=30000
+```
+
+With a cleanup delay shorter than 30 seconds, this forces the pending publisher to yield long enough for source cleanup.
+
+Without the cleanup fix:
+
+- SRS removes source **A** during the injected delay.
+- The publisher subsequently activates its retained source **A**.
+- New RTMP and HTTP-FLV consumers report `active=0` and receive no stream.
+- HLS continues from source **A**.
+
+This reproduces the defining symptoms of #4656.
+
+### Candidate fix
+
+The existing stream publish token now acts as a liveness guard for the pending source.
+
+`SrsStreamPublishTokenManager` exposes whether a stream URL's token is acquired. Live-source cleanup removes a dead source only when its publish token is not acquired:
+
+```cpp
+bool is_stream_acquired = _srs_stream_publish_tokens &&
+    _srs_stream_publish_tokens->is_acquired(it->first);
+
+if (source->stream_is_dead() && !is_stream_acquired) {
+    // Remove the dead source.
+}
+```
+
+This preserves the source-pool entry while a publisher owns the stream token, including while it yields before activation. Normal cleanup resumes after the token is released.
+
+### Verification
+
+With the candidate fix and the 30-second injected delay:
+
+- The source was not removed during the delay.
+- The publisher activated the same source retained in the pool.
+- HTTP-FLV playback succeeded with H.264 video and AAC audio.
+- RTMP playback succeeded with H.264 video and AAC audio.
+- Players created consumers with `active=1`.
+
+The deterministic unit regression test directly creates the dangerous state: a dead source in the pool with an acquired publish token.
+
+Negative control:
+
+```text
+Without cleanup guard:
+Expected pool size: 1
+Actual pool size:   0
+FAILED: ReproduceIssue4656.PublishTokenKeepsPendingLiveSource
+```
+
+With the cleanup guard restored:
+
+```text
+PASSED: ReproduceIssue4656.PublishTokenKeepsPendingLiveSource
+```
+
+The complete unit-test suite passed: 2,188 tests from 274 suites. A normal non-ASan SRS production build also succeeded.
+
+### Conclusion
+
+This is a confirmed source-lifecycle race. A publisher can activate a source that the live-source manager has already removed, causing the publisher and new players to reference different source objects for the same stream URL.
+
+Keeping the source in the manager while its publish token is acquired is the smallest direct fix. The deterministic reproduction, negative-control test, fixed regression test, protocol playback checks, complete unit-test suite, and production build all support the fix.
+
+The candidate change remains uncommitted and unreleased pending maintainer review.
+
+### Unknowns
+
+The original deployments did not provide enough scheduling-level evidence to prove that every reported occurrence followed this exact race. However, the deterministic reproduction matches the reported publisher-active, player-`active=0`, and HLS-still-playing behavior.

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-02, Merge [#4692](https://github.com/ossrs/srs/pull/4692): Codex: Fix live source cleanup race before publisher activation. v8.0.5 (#4692)
 * v8.0, 2026-07-26, Merge [#4689](https://github.com/ossrs/srs/pull/4689): Codex: Improve proxy tooling and maintainer workflows. v8.0.4 (#4689)
 * v8.0, 2026-05-28, Merge [#4680](https://github.com/ossrs/srs/pull/4680): RTMP: Fix chunk timestamp/basic-header decoding and harden packet unmarshal. v8.0.3 (#4680)
 * v8.0, 2026-05-19, Merge [#4678](https://github.com/ossrs/srs/pull/4678): Edge: Fix HTTP-FLV 404 and RTMP late-join missing sequence headers. v8.0.2 (#4678)

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -932,6 +932,13 @@ srs_error_t SrsRtmpConn::publishing(SrsSharedPtr<SrsLiveSource> source)
         return srs_error_wrap(err, "rtmp: callback on publish");
     }
 
+    // Test-only delay to reproduce a race between source cleanup and publisher activation.
+    srs_utime_t test_publish_delay = (srs_utime_t)(::atoi(srs_getenv("SRS_TEST_PUBLISH_BEFORE_ACQUIRE_DELAY").c_str()) * SRS_UTIME_MILLISECONDS);
+    if (test_publish_delay > 0) {
+        srs_warn("test: delay before acquire publish, delay=%dms", srsu2msi(test_publish_delay));
+        srs_usleep(test_publish_delay);
+    }
+
     // TODO: FIXME: Should refine the state of publishing.
     srs_error_t acquire_err = acquire_publish(source);
     if ((err = acquire_err) == srs_success) {

--- a/trunk/src/app/srs_app_rtmp_source.cpp
+++ b/trunk/src/app/srs_app_rtmp_source.cpp
@@ -24,6 +24,7 @@ using namespace std;
 #include <srs_app_rtc_source.hpp>
 #include <srs_app_server.hpp>
 #include <srs_app_statistic.hpp>
+#include <srs_app_stream_token.hpp>
 #include <srs_core_autofree.hpp>
 #include <srs_kernel_buffer.hpp>
 #include <srs_kernel_codec.hpp>
@@ -1744,9 +1745,14 @@ srs_error_t SrsLiveSourceManager::notify(int event, srs_utime_t interval, srs_ut
             return srs_error_wrap(err, "source cycle, id=[%s]", cid.c_str());
         }
 
+        // A publisher may yield after fetching the source but before activating it.
+        // Keep the source in the pool while its publish token is still acquired.
+        const string &stream_url = it->first;
+        bool is_stream_acquired = _srs_stream_publish_tokens->is_acquired(stream_url);
+
         // When source expired, remove it.
         // @see https://github.com/ossrs/srs/issues/713
-        if (source->stream_is_dead()) {
+        if (source->stream_is_dead() && !is_stream_acquired) {
             SrsContextId cid = source->source_id();
             if (cid.empty())
                 cid = source->pre_source_id();

--- a/trunk/src/app/srs_app_stream_token.cpp
+++ b/trunk/src/app/srs_app_stream_token.cpp
@@ -145,3 +145,16 @@ void SrsStreamPublishTokenManager::release_token(const std::string &stream_url)
     // Erase from map first, then delete the token
     tokens_.erase(it);
 }
+
+bool SrsStreamPublishTokenManager::is_acquired(const std::string &stream_url)
+{
+    SrsLocker(&mutex_);
+
+    std::map<std::string, SrsStreamPublishToken *>::iterator it = tokens_.find(stream_url);
+    if (it == tokens_.end()) {
+        return false;
+    }
+
+    SrsStreamPublishToken *token = it->second;
+    return token->is_acquired();
+}

--- a/trunk/src/app/srs_app_stream_token.hpp
+++ b/trunk/src/app/srs_app_stream_token.hpp
@@ -77,6 +77,7 @@ public:
 public:
     virtual srs_error_t acquire_token(ISrsRequest *req, SrsStreamPublishToken *&token) = 0;
     virtual void release_token(const std::string &stream_url) = 0;
+    virtual bool is_acquired(const std::string &stream_url) = 0;
 };
 
 // The global stream publish token manager ensures only one publisher
@@ -107,6 +108,9 @@ public:
     // This is called automatically when the token is destroyed.
     // @param stream_url The stream URL to release the token for
     void release_token(const std::string &stream_url);
+
+    // Whether a publisher currently owns the token for the stream URL.
+    bool is_acquired(const std::string &stream_url);
 };
 
 // Global instance accessor

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 4
+#define VERSION_REVISION 5
 
 #endif

--- a/trunk/src/utest/srs_utest_ai07.cpp
+++ b/trunk/src/utest/srs_utest_ai07.cpp
@@ -10,6 +10,7 @@
 #include <srs_app_rtc_source.hpp>
 #include <srs_app_rtmp_source.hpp>
 #include <srs_app_srt_source.hpp>
+#include <srs_app_stream_token.hpp>
 #ifdef SRS_RTSP
 #include <srs_app_rtsp_source.hpp>
 #endif
@@ -4641,6 +4642,48 @@ VOID TEST(ReproduceIssue4449, RtmpLiveSourceNotifyDeletesNewlyCreatedSource)
     // After fix: the newly created source should NOT be deleted by notify
     EXPECT_EQ(pool_size_before, pool_size_after);
     EXPECT_EQ(1, pool_size_after);
+}
+
+// Reproduce issue 4656: A publisher owns a source but yields before on_publish(),
+// so the cleanup timer must not remove that source from the manager.
+VOID TEST(ReproduceIssue4656, PublishTokenKeepsPendingLiveSource)
+{
+    srs_error_t err;
+
+    SrsUniquePtr<SrsLiveSourceManager> manager(new SrsLiveSourceManager());
+    HELPER_EXPECT_SUCCESS(manager->initialize());
+
+    SrsUniquePtr<SrsRequest> req(new SrsRequest());
+    req->host_ = "localhost";
+    req->vhost_ = "test.vhost";
+    req->app_ = "live";
+    req->stream_ = "pending-publisher";
+
+    SrsSharedPtr<SrsLiveSource> source;
+    HELPER_EXPECT_SUCCESS(manager->fetch_or_create(req.get(), source));
+
+    // Make the inactive source eligible for immediate cleanup.
+    source->stream_die_at_ = srs_time_now_cached() - 10 * SRS_UTIME_MINUTES;
+    EXPECT_TRUE(source->stream_is_dead());
+
+    SrsStreamPublishTokenManager tokens;
+    SrsStreamPublishTokenManager *previous_tokens = _srs_stream_publish_tokens;
+    _srs_stream_publish_tokens = &tokens;
+
+    SrsStreamPublishToken *token = NULL;
+    HELPER_EXPECT_SUCCESS(tokens.acquire_token(req.get(), token));
+
+    // The pending publisher token pins the source in the manager.
+    HELPER_EXPECT_SUCCESS(manager->notify(0, 0, 0));
+    EXPECT_EQ(1, (int)manager->pool_.size());
+    EXPECT_EQ(source.get(), manager->fetch(req.get()).get());
+
+    // Once the pending publisher leaves, normal cleanup resumes.
+    srs_freep(token);
+    HELPER_EXPECT_SUCCESS(manager->notify(0, 0, 0));
+    EXPECT_EQ(0, (int)manager->pool_.size());
+
+    _srs_stream_publish_tokens = previous_tokens;
 }
 
 // Test SRT source for the same issue

--- a/trunk/src/utest/srs_utest_ai18.cpp
+++ b/trunk/src/utest/srs_utest_ai18.cpp
@@ -2331,6 +2331,11 @@ void MockStreamPublishTokenManager::release_token(const std::string &stream_url)
     release_token_count_++;
 }
 
+bool MockStreamPublishTokenManager::is_acquired(const std::string &stream_url)
+{
+    return token_to_return_ && token_to_return_->stream_url() == stream_url && token_to_return_->is_acquired();
+}
+
 void MockStreamPublishTokenManager::set_acquire_token_error(srs_error_t err)
 {
     srs_freep(acquire_token_error_);

--- a/trunk/src/utest/srs_utest_ai18.hpp
+++ b/trunk/src/utest/srs_utest_ai18.hpp
@@ -231,6 +231,7 @@ public:
 public:
     virtual srs_error_t acquire_token(ISrsRequest *req, SrsStreamPublishToken *&token);
     virtual void release_token(const std::string &stream_url);
+    virtual bool is_acquired(const std::string &stream_url);
     void set_acquire_token_error(srs_error_t err);
     void reset();
 };

--- a/trunk/src/utest/srs_utest_manual_stream_token.cpp
+++ b/trunk/src/utest/srs_utest_manual_stream_token.cpp
@@ -80,6 +80,24 @@ VOID TEST(StreamTokenTest, SingleTokenAcquisition)
     srs_freep(token);
 }
 
+VOID TEST(StreamTokenTest, QueryTokenAcquisition)
+{
+    srs_error_t err;
+
+    SrsStreamPublishTokenManager manager;
+    MockStreamTokenRequest req("/live/stream1");
+
+    EXPECT_FALSE(manager.is_acquired("/live/stream1"));
+
+    SrsStreamPublishToken *token = NULL;
+    HELPER_EXPECT_SUCCESS(manager.acquire_token(&req, token));
+    EXPECT_TRUE(manager.is_acquired("/live/stream1"));
+    EXPECT_FALSE(manager.is_acquired("/live/stream2"));
+
+    srs_freep(token);
+    EXPECT_FALSE(manager.is_acquired("/live/stream1"));
+}
+
 VOID TEST(StreamTokenTest, DuplicateTokenRejection)
 {
     srs_error_t err;


### PR DESCRIPTION
## Summary

Fixes #4656.

Prevent the live-source cleanup timer from removing a source while a publisher owns that stream's publish token but has not activated the source yet.

## Root cause

A publisher can acquire the stream publish token, fetch live source **A**, and then yield before `acquire_publish()` marks the source active. During that interval, cleanup can consider **A** dead and remove it from the source pool.

The publisher still holds a shared pointer and later publishes into **A**, but new players fetch or create source **B** for the same stream URL. Those players create consumers with `active=0` and receive no RTMP or HTTP-FLV media, while HLS attached to **A** can continue working.

## Changes

- Add the test-only `SRS_TEST_PUBLISH_BEFORE_ACQUIRE_DELAY` environment variable to force the publisher to yield before source activation.
- Expose the acquired state of a stream publish token through `SrsStreamPublishTokenManager`.
- Keep a dead live source in the source pool while its publish token remains acquired.
- Add unit coverage for querying token state and retaining a pending publisher's source.
- Record the verified findings and reproduction evidence in the issue Truth Record.

## Verification

- Reproduced the failure deterministically with a 30-second pre-activation delay: new RTMP and HTTP-FLV players received no stream and logged `active=0`, while HLS continued.
- With the fix, the source remained in the pool and RTMP and HTTP-FLV playback succeeded with H.264 video and AAC audio; consumers logged `active=1`.
- Verified the regression test fails when the cleanup guard is removed and passes when restored.
- Passed all 2,188 unit tests from 274 suites.
- Successfully built the normal non-ASan SRS server.
