### PR TITLE
Codex: Fix live source cleanup race before publisher activation. v7.0.151

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2026-08-03, Merge [#4692](https://github.com/ossrs/srs/pull/4692): Codex: Fix live source cleanup race before publisher activation. v7.0.151 (#4692)
 * v7.0, 2026-05-19, Merge [#4678](https://github.com/ossrs/srs/pull/4678): Edge: Fix HTTP-FLV 404 and RTMP late-join missing sequence headers. v7.0.150 (#4678)
 * v7.0, 2026-05-17, Merge [#4676](https://github.com/ossrs/srs/pull/4676): Proxy: Fix RTC/SRT reader goroutine leak; unwrap legacy WHEP JSON envelope; add WHEP pprof guide. v7.0.149 (#4676)
 * v7.0, 2026-05-17, Merge [#4675](https://github.com/ossrs/srs/pull/4675): Proxy: Refactor for testability; add SRT/WHIP E2E and unit tests. v7.0.148 (#4675)

--- a/trunk/src/app/srs_app_rtmp_source.cpp
+++ b/trunk/src/app/srs_app_rtmp_source.cpp
@@ -24,6 +24,7 @@ using namespace std;
 #include <srs_app_rtc_source.hpp>
 #include <srs_app_server.hpp>
 #include <srs_app_statistic.hpp>
+#include <srs_app_stream_token.hpp>
 #include <srs_core_autofree.hpp>
 #include <srs_kernel_buffer.hpp>
 #include <srs_kernel_codec.hpp>
@@ -1744,9 +1745,13 @@ srs_error_t SrsLiveSourceManager::notify(int event, srs_utime_t interval, srs_ut
             return srs_error_wrap(err, "source cycle, id=[%s]", cid.c_str());
         }
 
+        // A publisher may yield after fetching the source but before activating it.
+        // Keep the source in the pool while its publish token is still acquired.
+        bool is_stream_acquired = _srs_stream_publish_tokens->is_acquired(it->first);
+
         // When source expired, remove it.
         // @see https://github.com/ossrs/srs/issues/713
-        if (source->stream_is_dead()) {
+        if (source->stream_is_dead() && !is_stream_acquired) {
             SrsContextId cid = source->source_id();
             if (cid.empty())
                 cid = source->pre_source_id();

--- a/trunk/src/app/srs_app_stream_token.cpp
+++ b/trunk/src/app/srs_app_stream_token.cpp
@@ -145,3 +145,16 @@ void SrsStreamPublishTokenManager::release_token(const std::string &stream_url)
     // Erase from map first, then delete the token
     tokens_.erase(it);
 }
+
+bool SrsStreamPublishTokenManager::is_acquired(const std::string &stream_url)
+{
+    SrsLocker(&mutex_);
+
+    std::map<std::string, SrsStreamPublishToken *>::iterator it = tokens_.find(stream_url);
+    if (it == tokens_.end()) {
+        return false;
+    }
+
+    SrsStreamPublishToken *token = it->second;
+    return token->is_acquired();
+}

--- a/trunk/src/app/srs_app_stream_token.hpp
+++ b/trunk/src/app/srs_app_stream_token.hpp
@@ -107,6 +107,9 @@ public:
     // This is called automatically when the token is destroyed.
     // @param stream_url The stream URL to release the token for
     void release_token(const std::string &stream_url);
+
+    // Whether a publisher currently owns the token for the stream URL.
+    bool is_acquired(const std::string &stream_url);
 };
 
 // Global instance accessor

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 150
+#define VERSION_REVISION 151
 
 #endif


### PR DESCRIPTION
## Summary

Backport #4692 to the `7.0release` branch for #4656.

Prevent the live-source cleanup timer from removing a source while a publisher owns that stream's publish token but has not activated the source yet.

## Root cause

A publisher can acquire the stream publish token, fetch live source **A**, and then yield before `acquire_publish()` marks it active. During that interval, cleanup can consider **A** dead and remove it from the source pool.

The publisher still holds a shared pointer and later publishes into **A**, but new players fetch or create source **B** for the same stream URL. Those players create consumers with `active=0` and receive no RTMP or HTTP-FLV media, while HLS attached to **A** can continue working.

## Changes

- Expose the acquired state of a stream token through the concrete `SrsStreamPublishTokenManager`.
- Keep a dead live source in the source pool while its publish token remains acquired.
- Bump SRS 7 from `7.0.150` to `7.0.151`.
- Add the corresponding SRS 7 changelog entry.

## Backport scope

This is a minimal production-only backport. It intentionally excludes the test-delay environment variable, unit-test changes, and AI Truth Record included in #4692.
