### PR TITLE
Codex: Add configurable proxy origin registration TTL. v8.0.6

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -59,6 +59,8 @@ type ProxyEnvironment interface {
 	RedisDB() string
 	// Optional Redis key prefix
 	RedisKeyPrefix() string
+	// Origin server registration lifetime
+	OriginServerTTL() string
 	// Default backend enabled
 	DefaultBackendEnabled() string
 	// Default backend IP
@@ -148,6 +150,10 @@ func (e *proxyEnvironment) RedisDB() string {
 
 func (e *proxyEnvironment) RedisKeyPrefix() string {
 	return getEnv("PROXY_REDIS_KEY_PREFIX")
+}
+
+func (e *proxyEnvironment) OriginServerTTL() string {
+	return getEnv("PROXY_ORIGIN_SERVER_TTL")
 }
 
 func (e *proxyEnvironment) DefaultBackendEnabled() string {
@@ -309,6 +315,8 @@ func buildDefaultEnvironmentVariables(ctx context.Context) {
 	setEnvDefault("PROXY_REDIS_DB", "0")
 	// Optional prefix for all Redis keys.
 	setEnvDefault("PROXY_REDIS_KEY_PREFIX", "")
+	// Origin server registration and health-check lifetime.
+	setEnvDefault("PROXY_ORIGIN_SERVER_TTL", "300s")
 
 	// Whether enable the default backend server, for debugging.
 	setEnvDefault("PROXY_DEFAULT_BACKEND_ENABLED", "off")
@@ -332,7 +340,8 @@ func buildDefaultEnvironmentVariables(ctx context.Context) {
 		"PROXY_DEFAULT_BACKEND_HTTP=%v, PROXY_DEFAULT_BACKEND_API=%v, "+
 		"PROXY_DEFAULT_BACKEND_RTC=%v, PROXY_DEFAULT_BACKEND_SRT=%v, "+
 		"PROXY_LOAD_BALANCER_TYPE=%v, PROXY_REDIS_HOST=%v, PROXY_REDIS_PORT=%v, "+
-		"PROXY_REDIS_PASSWORD=%v, PROXY_REDIS_DB=%v, PROXY_REDIS_KEY_PREFIX=%v",
+		"PROXY_REDIS_PASSWORD=%v, PROXY_REDIS_DB=%v, PROXY_REDIS_KEY_PREFIX=%v, "+
+		"PROXY_ORIGIN_SERVER_TTL=%v",
 		getEnv("GO_PPROF"),
 		getEnv("PROXY_FORCE_QUIT_TIMEOUT"), getEnv("PROXY_GRACE_QUIT_TIMEOUT"),
 		getEnv("PROXY_HTTP_API"), getEnv("PROXY_HTTP_SERVER"), getEnv("PROXY_RTMP_SERVER"),
@@ -343,6 +352,7 @@ func buildDefaultEnvironmentVariables(ctx context.Context) {
 		getEnv("PROXY_DEFAULT_BACKEND_RTC"), getEnv("PROXY_DEFAULT_BACKEND_SRT"),
 		getEnv("PROXY_LOAD_BALANCER_TYPE"), getEnv("PROXY_REDIS_HOST"), getEnv("PROXY_REDIS_PORT"),
 		getEnv("PROXY_REDIS_PASSWORD"), getEnv("PROXY_REDIS_DB"), getEnv("PROXY_REDIS_KEY_PREFIX"),
+		getEnv("PROXY_ORIGIN_SERVER_TTL"),
 	)
 }
 

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -338,6 +338,7 @@ func TestNewProxyEnvironment_AppliesDefaultsAndAccessors(t *testing.T) {
 		{"RedisPassword", env.RedisPassword(), ""},
 		{"RedisDB", env.RedisDB(), "0"},
 		{"RedisKeyPrefix", env.RedisKeyPrefix(), ""},
+		{"OriginServerTTL", env.OriginServerTTL(), "300s"},
 		{"DefaultBackendEnabled", env.DefaultBackendEnabled(), "off"},
 		{"DefaultBackendIP", env.DefaultBackendIP(), "127.0.0.1"},
 		{"DefaultBackendRTMP", env.DefaultBackendRTMP(), "1935"},
@@ -358,6 +359,7 @@ func TestNewProxyEnvironment_PreservesPreSetValues(t *testing.T) {
 	withFakeOpen(t, "", os.ErrNotExist)
 	setEnv("PROXY_HTTP_API", "9999")
 	setEnv("PROXY_REDIS_KEY_PREFIX", "xxx")
+	setEnv("PROXY_ORIGIN_SERVER_TTL", "45s")
 
 	env, err := NewProxyEnvironment(context.Background())
 	if err != nil {
@@ -368,6 +370,9 @@ func TestNewProxyEnvironment_PreservesPreSetValues(t *testing.T) {
 	}
 	if got := env.RedisKeyPrefix(); got != "xxx" {
 		t.Errorf("RedisKeyPrefix() = %q, want %q", got, "xxx")
+	}
+	if got := env.OriginServerTTL(); got != "45s" {
+		t.Errorf("OriginServerTTL() = %q, want %q", got, "45s")
 	}
 }
 

--- a/internal/env/envfakes/fake_proxy_environment.go
+++ b/internal/env/envfakes/fake_proxy_environment.go
@@ -137,6 +137,16 @@ type FakeProxyEnvironment struct {
 	loadBalancerTypeReturnsOnCall map[int]struct {
 		result1 string
 	}
+	OriginServerTTLStub        func() string
+	originServerTTLMutex       sync.RWMutex
+	originServerTTLArgsForCall []struct {
+	}
+	originServerTTLReturns struct {
+		result1 string
+	}
+	originServerTTLReturnsOnCall map[int]struct {
+		result1 string
+	}
 	RedisDBStub        func() string
 	redisDBMutex       sync.RWMutex
 	redisDBArgsForCall []struct {
@@ -926,6 +936,59 @@ func (fake *FakeProxyEnvironment) LoadBalancerTypeReturnsOnCall(i int, result1 s
 		})
 	}
 	fake.loadBalancerTypeReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeProxyEnvironment) OriginServerTTL() string {
+	fake.originServerTTLMutex.Lock()
+	ret, specificReturn := fake.originServerTTLReturnsOnCall[len(fake.originServerTTLArgsForCall)]
+	fake.originServerTTLArgsForCall = append(fake.originServerTTLArgsForCall, struct {
+	}{})
+	stub := fake.OriginServerTTLStub
+	fakeReturns := fake.originServerTTLReturns
+	fake.recordInvocation("OriginServerTTL", []interface{}{})
+	fake.originServerTTLMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeProxyEnvironment) OriginServerTTLCallCount() int {
+	fake.originServerTTLMutex.RLock()
+	defer fake.originServerTTLMutex.RUnlock()
+	return len(fake.originServerTTLArgsForCall)
+}
+
+func (fake *FakeProxyEnvironment) OriginServerTTLCalls(stub func() string) {
+	fake.originServerTTLMutex.Lock()
+	defer fake.originServerTTLMutex.Unlock()
+	fake.OriginServerTTLStub = stub
+}
+
+func (fake *FakeProxyEnvironment) OriginServerTTLReturns(result1 string) {
+	fake.originServerTTLMutex.Lock()
+	defer fake.originServerTTLMutex.Unlock()
+	fake.OriginServerTTLStub = nil
+	fake.originServerTTLReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeProxyEnvironment) OriginServerTTLReturnsOnCall(i int, result1 string) {
+	fake.originServerTTLMutex.Lock()
+	defer fake.originServerTTLMutex.Unlock()
+	fake.OriginServerTTLStub = nil
+	if fake.originServerTTLReturnsOnCall == nil {
+		fake.originServerTTLReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.originServerTTLReturnsOnCall[i] = struct {
 		result1 string
 	}{result1}
 }

--- a/internal/lb/lb.go
+++ b/internal/lb/lb.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// If server heartbeat in this duration, it's alive.
+// ServerAliveDuration is the default origin registration lifetime.
 const ServerAliveDuration = 300 * time.Second
 
 // If HLS streaming update in this duration, it's alive.
@@ -18,6 +18,21 @@ const HLSAliveDuration = 120 * time.Second
 
 // If WebRTC streaming update in this duration, it's alive.
 const RTCAliveDuration = 120 * time.Second
+
+func parseOriginServerTTL(value string) (time.Duration, error) {
+	if value == "" {
+		return ServerAliveDuration, nil
+	}
+
+	ttl, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid PROXY_ORIGIN_SERVER_TTL %q: %w", value, err)
+	}
+	if ttl <= 0 {
+		return 0, fmt.Errorf("invalid PROXY_ORIGIN_SERVER_TTL %q: must be positive", value)
+	}
+	return ttl, nil
+}
 
 // OriginServer represents a backend origin server.
 type OriginServer struct {

--- a/internal/lb/lb_test.go
+++ b/internal/lb/lb_test.go
@@ -10,6 +10,37 @@ import (
 	"time"
 )
 
+func TestParseOriginServerTTL(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		value   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "default", value: "", want: ServerAliveDuration},
+		{name: "custom", value: "45s", want: 45 * time.Second},
+		{name: "invalid", value: "soon", wantErr: true},
+		{name: "zero", value: "0s", wantErr: true},
+		{name: "negative", value: "-1s", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseOriginServerTTL(tt.value)
+			if tt.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "PROXY_ORIGIN_SERVER_TTL") {
+					t.Fatalf("parseOriginServerTTL(%q) error = %v, want configuration error", tt.value, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseOriginServerTTL(%q): %v", tt.value, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseOriginServerTTL(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOriginServerID(t *testing.T) {
 	for _, tt := range []struct {
 		name string

--- a/internal/lb/mem.go
+++ b/internal/lb/mem.go
@@ -35,6 +35,9 @@ type memoryLoadBalancer struct {
 	// goroutine re-Updates its registration. Struct field for test injection
 	// (avoids racing a package global across concurrent tests).
 	keepaliveInterval time.Duration
+	// originServerTTL is the period during which an origin registration is
+	// considered healthy.
+	originServerTTL time.Duration
 }
 
 // NewMemoryLoadBalancer creates a new memory-based load balancer.
@@ -48,35 +51,44 @@ func NewMemoryLoadBalancer(environment env.ProxyEnvironment) OriginLoadBalancer 
 		rtcStreamURL:      sync.NewMap[string, RTCConnection](),
 		rtcUfrag:          sync.NewMap[string, RTCConnection](),
 		keepaliveInterval: 30 * time.Second,
+		originServerTTL:   ServerAliveDuration,
 	}
 }
 
 func (v *memoryLoadBalancer) Initialize(ctx context.Context) error {
+	originServerTTL, err := parseOriginServerTTL(v.environment.OriginServerTTL())
+	if err != nil {
+		return err
+	}
+	v.originServerTTL = originServerTTL
+
 	server, err := NewDefaultOriginServerForDebugging(v.environment)
 	if err != nil {
 		return errors.Wrapf(err, "initialize default SRS")
 	}
 
-	if server != nil {
-		if err := v.Update(ctx, server); err != nil {
-			return errors.Wrapf(err, "update default SRS %+v", server)
-		}
+	if server == nil {
+		return nil
+	}
 
-		// Keep alive.
-		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(v.keepaliveInterval):
-					if err := v.Update(ctx, server); err != nil {
-						logger.Warn(ctx, "update default SRS %+v failed, %+v", server, err)
-					}
+	if err := v.Update(ctx, server); err != nil {
+		return errors.Wrapf(err, "update default SRS %+v", server)
+	}
+
+	// Keep alive.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(v.keepaliveInterval):
+				if err := v.Update(ctx, server); err != nil {
+					logger.Warn(ctx, "update default SRS %+v failed, %+v", server, err)
 				}
 			}
-		}()
-		logger.Debug(ctx, "MemoryLB: Initialize default SRS media server, %+v", server)
-	}
+		}
+	}()
+	logger.Debug(ctx, "MemoryLB: Initialize default SRS media server, %+v", server)
 	return nil
 }
 
@@ -94,7 +106,7 @@ func (v *memoryLoadBalancer) Pick(ctx context.Context, streamURL string) (*Origi
 	// Gather all servers that were alive within the last few seconds.
 	var servers []*OriginServer
 	v.servers.Range(func(key string, server *OriginServer) bool {
-		if time.Since(server.UpdatedAt) < ServerAliveDuration {
+		if time.Since(server.UpdatedAt) < v.originServerTTL {
 			servers = append(servers, server)
 		}
 		return true

--- a/internal/lb/mem_test.go
+++ b/internal/lb/mem_test.go
@@ -172,6 +172,29 @@ func TestMemLB_Pick_AliveServer_Sticky(t *testing.T) {
 	}
 }
 
+func TestMemLB_Pick_ConfiguredOriginServerTTL(t *testing.T) {
+	env := &envfakes.FakeProxyEnvironment{}
+	env.OriginServerTTLReturns("1m")
+	env.DefaultBackendEnabledReturns("off")
+	lb := NewMemoryLoadBalancer(env).(*memoryLoadBalancer)
+	if err := lb.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	stale := &OriginServer{ServerID: "stale", PID: "1", UpdatedAt: time.Now().Add(-2 * time.Minute)}
+	alive := &OriginServer{ServerID: "alive", PID: "1", UpdatedAt: time.Now()}
+	_ = lb.Update(context.Background(), stale)
+	_ = lb.Update(context.Background(), alive)
+
+	got, err := lb.Pick(context.Background(), "url1")
+	if err != nil {
+		t.Fatalf("Pick: %v", err)
+	}
+	if got != alive {
+		t.Fatalf("Pick returned %v, want the origin within the configured TTL %v", got, alive)
+	}
+}
+
 func TestMemLB_Pick_OnlyDeadServers_Fallback(t *testing.T) {
 	lb := newMem()
 	// UpdatedAt long past => not alive. Tests the fallback "use all servers" branch.

--- a/internal/lb/redis.go
+++ b/internal/lb/redis.go
@@ -30,6 +30,8 @@ type redisLoadBalancer struct {
 	// keepaliveInterval is the period at which the default-backend keep-alive
 	// goroutine re-Updates its registration. Struct field for test injection.
 	keepaliveInterval time.Duration
+	// originServerTTL is the Redis expiration applied to origin registrations.
+	originServerTTL time.Duration
 }
 
 // NewRedisLoadBalancer creates a new Redis-based load balancer.
@@ -38,10 +40,17 @@ func NewRedisLoadBalancer(environment env.ProxyEnvironment) OriginLoadBalancer {
 		environment:       environment,
 		newClient:         redisclient.New,
 		keepaliveInterval: 30 * time.Second,
+		originServerTTL:   ServerAliveDuration,
 	}
 }
 
 func (v *redisLoadBalancer) Initialize(ctx context.Context) error {
+	originServerTTL, err := parseOriginServerTTL(v.environment.OriginServerTTL())
+	if err != nil {
+		return err
+	}
+	v.originServerTTL = originServerTTL
+
 	redisDatabase, err := strconv.Atoi(v.environment.RedisDB())
 	if err != nil {
 		return errors.Wrapf(err, "invalid PROXY_REDIS_DB %v", v.environment.RedisDB())
@@ -94,7 +103,7 @@ func (v *redisLoadBalancer) Update(ctx context.Context, server *OriginServer) er
 	}
 
 	key := v.redisKeyServer(server.ID())
-	if err = v.rdb.Set(ctx, key, b, ServerAliveDuration).Err(); err != nil {
+	if err = v.rdb.Set(ctx, key, b, v.originServerTTL).Err(); err != nil {
 		return errors.Wrapf(err, "set key=%v server %+v", key, server)
 	}
 

--- a/internal/lb/redis_test.go
+++ b/internal/lb/redis_test.go
@@ -179,6 +179,45 @@ func TestRedisLB_Initialize_Success(t *testing.T) {
 	}
 }
 
+func TestRedisLB_Update_UsesConfiguredOriginServerTTL(t *testing.T) {
+	fake := &redisclientfakes.FakeRedisClient{}
+	fake.PingReturns(statusCmd(nil))
+	fake.SetReturns(statusCmd(nil))
+	fake.GetReturns(stringErr(redis.Nil))
+
+	env := &envfakes.FakeProxyEnvironment{}
+	env.RedisDBReturns("0")
+	env.OriginServerTTLReturns("45s")
+	lb := withFakeClient(env, fake)
+	if err := lb.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	server := &OriginServer{ServerID: "s", ServiceID: "v", PID: "1"}
+	if err := lb.Update(context.Background(), server); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := fake.SetCallCount(); got != 2 {
+		t.Fatalf("Set call count = %d, want 2", got)
+	}
+
+	_, serverKey, _, serverTTL := fake.SetArgsForCall(0)
+	if want := lb.redisKeyServer(server.ID()); serverKey != want {
+		t.Fatalf("server key = %q, want %q", serverKey, want)
+	}
+	if serverTTL != 45*time.Second {
+		t.Fatalf("server TTL = %v, want %v", serverTTL, 45*time.Second)
+	}
+
+	_, serversKey, _, serversTTL := fake.SetArgsForCall(1)
+	if want := lb.redisKeyServers(); serversKey != want {
+		t.Fatalf("server-index key = %q, want %q", serversKey, want)
+	}
+	if serversTTL != 0 {
+		t.Fatalf("server-index TTL = %v, want no expiration", serversTTL)
+	}
+}
+
 // ----------------------------------------------------------------------------
 // Update.
 // ----------------------------------------------------------------------------

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 5
+	return 6
 }
 
 func Version() string {

--- a/skills/internal-docs-for-srs/references/proxy/features.md
+++ b/skills/internal-docs-for-srs/references/proxy/features.md
@@ -102,10 +102,11 @@ parses the minimum needed to route, then proxies traffic to the chosen backend.
 - **Stream-level stickiness** — the first request for a stream URL picks a
   backend; every later request for that stream routes to the same backend.
   Stream→server mappings never expire.
-- **Health-based selection** — servers with a heartbeat within 300s
-  (`ServerAliveDuration`) are preferred; selection among them is random for even
-  distribution. The memory LB falls back to all registered servers when none are
-  healthy; the Redis LB expires dead servers via a 300s TTL instead.
+- **Health-based selection** — servers with a heartbeat within
+  `PROXY_ORIGIN_SERVER_TTL` (default `300s`) are preferred; selection among them
+  is random for even distribution. The memory LB falls back to all registered
+  servers when none are healthy; the Redis LB expires dead servers using the
+  configured TTL instead.
 - **HLS session state** — dual-indexed by stream URL and by `spbhid`. In Redis,
   entries expire after 120s (`HLSAliveDuration`); the memory LB keeps them
   in-process without expiration.

--- a/skills/internal-docs-for-srs/references/proxy/proxy-load-balancer.md
+++ b/skills/internal-docs-for-srs/references/proxy/proxy-load-balancer.md
@@ -85,7 +85,6 @@ The load balancer uses a clean interface-based architecture:
 
 ```bash
 PROXY_LOAD_BALANCER_TYPE=memory
-PROXY_ORIGIN_SERVER_TTL=300s
 ```
 
 ## Redis Load Balancer
@@ -113,8 +112,6 @@ PROXY_REDIS_HOST=127.0.0.1
 PROXY_REDIS_PORT=6379
 PROXY_REDIS_PASSWORD=
 PROXY_REDIS_DB=0
-PROXY_REDIS_KEY_PREFIX=
-PROXY_ORIGIN_SERVER_TTL=300s
 ```
 
 3. Redis Key Design

--- a/skills/internal-docs-for-srs/references/proxy/proxy-load-balancer.md
+++ b/skills/internal-docs-for-srs/references/proxy/proxy-load-balancer.md
@@ -85,6 +85,7 @@ The load balancer uses a clean interface-based architecture:
 
 ```bash
 PROXY_LOAD_BALANCER_TYPE=memory
+PROXY_ORIGIN_SERVER_TTL=300s
 ```
 
 ## Redis Load Balancer
@@ -113,6 +114,7 @@ PROXY_REDIS_PORT=6379
 PROXY_REDIS_PASSWORD=
 PROXY_REDIS_DB=0
 PROXY_REDIS_KEY_PREFIX=
+PROXY_ORIGIN_SERVER_TTL=300s
 ```
 
 3. Redis Key Design
@@ -123,7 +125,7 @@ default, preserving the key names below. When set to `xxx`, keys use the form
 prefix.
 
 **Server Keys**:
-- `srs-proxy-server:{serverID}` - Server registration (300s TTL)
+- `srs-proxy-server:{serverID}` - Server registration (`PROXY_ORIGIN_SERVER_TTL`, default 300s)
 - `srs-proxy-all-servers` - Server list index (no expiration)
 
 **Stream Mapping Keys**:
@@ -137,11 +139,15 @@ prefix.
 
 ## Expiration and Cleanup
 
-**Server Heartbeat**: 300 seconds
+**Server Heartbeat**: `PROXY_ORIGIN_SERVER_TTL` (default 300 seconds)
 - Servers must send updates every 30 seconds (recommended)
-- Considered dead if no update within 300 seconds
+- Considered dead if no update within the configured lifetime
 - Memory LB: filtered during selection
 - Redis LB: automatic TTL expiration
+
+The configured lifetime must be longer than the origin heartbeat interval, with
+enough margin for transient delays. It accepts Go duration syntax such as `45s`
+or `2m` and must be positive.
 
 **Session State**: 120 seconds
 - HLS and WebRTC sessions expire after 120 seconds of inactivity

--- a/skills/internal-docs-for-srs/references/proxy/proxy-protocol.md
+++ b/skills/internal-docs-for-srs/references/proxy/proxy-protocol.md
@@ -45,7 +45,8 @@ heartbeat {
 When heartbeat is enabled:
 - SRS automatically registers itself on startup
 - Sends periodic heartbeats (default: every 30 seconds) to keep the registration alive
-- Proxy marks servers as unavailable if heartbeats stop (after 300 seconds)
+- Proxy marks servers as unavailable if heartbeats stop (after
+  `PROXY_ORIGIN_SERVER_TTL`, default 300 seconds)
 - No manual intervention required - fully automatic
 
 For multi-proxy deployments, configure every proxy to use the same shared Redis instance. An
@@ -53,7 +54,7 @@ origin only needs to send each heartbeat to one proxy because that proxy writes 
 to shared Redis, where all proxies can read it. However, SRS accepts only one `heartbeat.url`, so
 the URL should point to a highly available frontend such as an NLB or VIP that routes the System
 API to a healthy proxy. If it points directly to one proxy and that proxy fails, SRS does not try
-another proxy and the registration expires after 300 seconds.
+another proxy and the registration expires after `PROXY_ORIGIN_SERVER_TTL` (default 300 seconds).
 
 This is the **recommended approach** for production deployments with SRS backend servers.
 
@@ -81,8 +82,10 @@ curl -X POST http://127.0.0.1:12025/api/v1/srs/register \
 #{"code":0,"pid":"53783"}
 ```
 
-A single request only registers the backend until its 300-second TTL expires. Custom integrations
-must repeat the request periodically to maintain the heartbeat.
+A single request only registers the backend until its configured TTL expires. Custom integrations
+must repeat the request periodically to maintain the heartbeat. Configure the lifetime with
+`PROXY_ORIGIN_SERVER_TTL` using a positive Go duration such as `45s` or `2m`; it must remain longer
+than the heartbeat interval. The default is `300s`.
 
 ### Registration Fields
 

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-03, Merge [#4694](https://github.com/ossrs/srs/pull/4694): Codex: Add configurable proxy origin registration TTL. v8.0.6 (#4694)
 * v8.0, 2026-08-02, Merge [#4692](https://github.com/ossrs/srs/pull/4692): Codex: Fix live source cleanup race before publisher activation. v8.0.5 (#4692)
 * v8.0, 2026-07-26, Merge [#4689](https://github.com/ossrs/srs/pull/4689): Codex: Improve proxy tooling and maintainer workflows. v8.0.4 (#4689)
 * v8.0, 2026-05-28, Merge [#4680](https://github.com/ossrs/srs/pull/4680): RTMP: Fix chunk timestamp/basic-header decoding and harden packet unmarshal. v8.0.3 (#4680)

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 5
+#define VERSION_REVISION 6
 
 #endif


### PR DESCRIPTION
Fixes #4647. Add `PROXY_ORIGIN_SERVER_TTL` so operators can tune how long an origin registration remains healthy instead of relying on the fixed 300-second lifetime. The default remains `300s`, preserving existing behavior.