### PR TITLE
RTC2RTMP: Only emit video sequence header when parameter sets change. #4695

### DIFF
--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -2131,6 +2131,15 @@ srs_error_t SrsRtcFrameBuilder::do_packet_sequence_header_avc(SrsRtpPacket *pkt,
         return srs_error_wrap(err, "mux sequence header");
     }
 
+    // WebRTC publishers (libwebrtc) repeat SPS/PPS with every IDR, so this is reached
+    // once per keyframe interval. Re-emitting an identical sequence header each time
+    // makes HLS mark the open segment (SrsHlsMuxer::on_sequence_header) and stamp
+    // #EXT-X-DISCONTINUITY before every segment. RTMP encoders send the sequence
+    // header once; match that contract and only emit when the bytes change.
+    if (sh == last_sh_) {
+        return err;
+    }
+
     // h264 packet to flv packet.
     char *flv = NULL;
     int nb_flv = 0;
@@ -2153,6 +2162,10 @@ srs_error_t SrsRtcFrameBuilder::do_packet_sequence_header_avc(SrsRtpPacket *pkt,
     if ((err = frame_target_->on_frame(&msg)) != srs_success) {
         return err;
     }
+
+    // Record only after a successful emit, so a failed emit is retried on the
+    // next keyframe instead of being remembered as delivered.
+    last_sh_ = sh;
 
     return err;
 }
@@ -2230,6 +2243,13 @@ srs_error_t SrsRtcFrameBuilder::do_packet_sequence_header_hevc(SrsRtpPacket *pkt
         return srs_error_wrap(err, "mux sequence header");
     }
 
+    // Same dedup as the AVC path: WebRTC publishers repeat parameter sets with
+    // every IDR; only emit the sequence header when the bytes change, else HLS
+    // stamps #EXT-X-DISCONTINUITY before every segment.
+    if (sh == last_sh_) {
+        return err;
+    }
+
     char *flv = NULL;
     int nb_flv = 0;
     if ((err = hevc->mux_hevc2flv_enhanced(sh, SrsVideoAvcFrameTypeKeyFrame, SrsVideoHEVCFrameTraitPacketTypeSequenceStart, pkt->get_avsync_time(),
@@ -2250,6 +2270,10 @@ srs_error_t SrsRtcFrameBuilder::do_packet_sequence_header_hevc(SrsRtpPacket *pkt
     if ((err = frame_target_->on_frame(&msg)) != srs_success) {
         return err;
     }
+
+    // Record only after a successful emit, so a failed emit is retried on the
+    // next keyframe instead of being remembered as delivered.
+    last_sh_ = sh;
 
     return err;
 }

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -600,6 +600,14 @@ SRS_DECLARE_PRIVATE: // clang-format on
     SrsRtpPacket *obs_whip_sps_;
     SrsRtpPacket *obs_whip_pps_;
 
+// clang-format off
+SRS_DECLARE_PRIVATE: // clang-format on
+    // The last emitted video sequence header (avcC/hvcC bytes). WebRTC publishers
+    // (libwebrtc) repeat SPS/PPS with every IDR; re-emitting the sequence header per
+    // keyframe makes HLS stamp #EXT-X-DISCONTINUITY before every segment. Only
+    // re-emit when the bytes actually change.
+    std::string last_sh_;
+
 public:
     SrsRtcFrameBuilder(ISrsAppFactory *factory, ISrsFrameTarget *target);
     virtual ~SrsRtcFrameBuilder();

--- a/trunk/src/utest/srs_utest_ai09.cpp
+++ b/trunk/src/utest/srs_utest_ai09.cpp
@@ -2317,7 +2317,11 @@ VOID TEST(RtcFrameBuilderTest, PacketSequenceHeaderAvc_NoSTAPANoRawPayload)
     EXPECT_EQ(0, target.on_frame_count_);
 }
 
-// Test SrsRtcFrameBuilder::packet_sequence_header_avc comprehensive coverage
+// Test SrsRtcFrameBuilder::packet_sequence_header_avc comprehensive coverage.
+// Pins the sequence-header dedup contract: identical repeated parameter sets are
+// not re-emitted (libwebrtc repeats SPS/PPS with every IDR; re-emitting makes HLS
+// stamp #EXT-X-DISCONTINUITY before every segment), changed parameter sets are
+// emitted, and a failed emit is retried on the next arrival.
 VOID TEST(RtcFrameBuilderTest, PacketSequenceHeaderAvc_ComprehensiveCoverage)
 {
     srs_error_t err;
@@ -2341,19 +2345,51 @@ VOID TEST(RtcFrameBuilderTest, PacketSequenceHeaderAvc_ComprehensiveCoverage)
     HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(pps_pkt.get()));
     EXPECT_EQ(1, target.on_frame_count_);
 
-    // Reset target for next test
-    target.reset();
-
-    // Test 3: Process STAP-A with both SPS and PPS (should generate frame immediately)
+    // Test 3: STAP-A repeating the SAME SPS/PPS must NOT re-emit the sequence
+    // header — the bytes are identical to what was already delivered.
     SrsUniquePtr<SrsRtpPacket> stap_pkt(create_stap_a_packet_with_sps_pps());
     HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(stap_pkt.get()));
-    EXPECT_EQ(1, target.on_frame_count_);
+    EXPECT_EQ(1, target.on_frame_count_); // No change: identical bytes deduped
 
     // Test 4: Process non-SPS/PPS packet (should do nothing)
     uint8_t idr_data[] = {0x65, 0x88, 0x84, 0x00, 0x10};
     SrsUniquePtr<SrsRtpPacket> idr_pkt(create_raw_payload_packet(SrsAvcNaluTypeIDR, idr_data, sizeof(idr_data)));
     HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(idr_pkt.get()));
     EXPECT_EQ(1, target.on_frame_count_); // No change
+
+    // Test 5: CHANGED parameter sets (e.g. resolution switch) must emit again.
+    uint8_t sps2_data[] = {0x67, 0x42, 0x00, 0x28, 0x9a, 0x66, 0x02, 0x80};
+    SrsUniquePtr<SrsRtpPacket> sps2_pkt(create_raw_payload_packet(SrsAvcNaluTypeSPS, sps2_data, sizeof(sps2_data)));
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(sps2_pkt.get()));
+    SrsUniquePtr<SrsRtpPacket> pps2_pkt(create_raw_payload_packet(SrsAvcNaluTypePPS, pps_data, sizeof(pps_data)));
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(pps2_pkt.get()));
+    EXPECT_EQ(2, target.on_frame_count_); // Changed bytes: new emit
+
+    // Test 6: A FAILED emit must be retried on the next parameter-set arrival,
+    // because the header is recorded as delivered only after a successful emit.
+    target.frame_error_ = srs_error_new(ERROR_RTC_RTP_MUXER, "mock frame target error");
+    uint8_t sps3_data[] = {0x67, 0x42, 0x00, 0x33, 0x9a, 0x66, 0x02, 0x80};
+    SrsUniquePtr<SrsRtpPacket> sps3_pkt(create_raw_payload_packet(SrsAvcNaluTypeSPS, sps3_data, sizeof(sps3_data)));
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(sps3_pkt.get()));
+    SrsUniquePtr<SrsRtpPacket> pps3_pkt(create_raw_payload_packet(SrsAvcNaluTypePPS, pps_data, sizeof(pps_data)));
+    HELPER_EXPECT_FAILED(builder.packet_sequence_header_avc(pps3_pkt.get()));
+    EXPECT_EQ(3, target.on_frame_count_); // Emit was attempted and failed
+
+    // Clear the failure; the same (still-undelivered) header arrives again and
+    // must be emitted this time, not treated as a duplicate.
+    srs_freep(target.frame_error_);
+    SrsUniquePtr<SrsRtpPacket> sps4_pkt(create_raw_payload_packet(SrsAvcNaluTypeSPS, sps3_data, sizeof(sps3_data)));
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(sps4_pkt.get()));
+    SrsUniquePtr<SrsRtpPacket> pps4_pkt(create_raw_payload_packet(SrsAvcNaluTypePPS, pps_data, sizeof(pps_data)));
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(pps4_pkt.get()));
+    EXPECT_EQ(4, target.on_frame_count_); // Retry succeeded
+
+    // And once delivered, repeating that header again is deduped as usual.
+    SrsUniquePtr<SrsRtpPacket> sps5_pkt(create_raw_payload_packet(SrsAvcNaluTypeSPS, sps3_data, sizeof(sps3_data)));
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(sps5_pkt.get()));
+    SrsUniquePtr<SrsRtpPacket> pps5_pkt(create_raw_payload_packet(SrsAvcNaluTypePPS, pps_data, sizeof(pps_data)));
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(pps5_pkt.get()));
+    EXPECT_EQ(4, target.on_frame_count_); // No change: deduped after success
 }
 
 // Test SrsRtcFrameBuilder::on_rtp with exact sync state transitions


### PR DESCRIPTION
Fixes #4695 — the WebRTC-to-RTMP bridge re-emits the video sequence header on every keyframe, so HLS stamps `#EXT-X-DISCONTINUITY` before every segment.

Emit the sequence header only when the muxed avcC/hvcC bytes actually change, and record it only after a successful emit so a failed emit is retried on the next keyframe. Covers both the AVC and HEVC paths of `SrsRtcFrameBuilder`.

Verified: a backport of the same fix onto 5.0.213 removes the per-segment discontinuity on-device (libwebrtc WHIP publish, two soak runs) with an RTMP publish through the same config unchanged as baseline; a mid-stream resolution change still stamps exactly one discontinuity. This branch applies cleanly to develop and compiles (ubuntu:focal, `./configure && make`). The HEVC hunk is the same logic but not runtime-tested (no HEVC WHIP publisher at hand).