### PR TITLE
Player: Fix reverse-proxy URLs and refresh issue records. v8.0.7

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 6
+	return 7
 }
 
 func Version() string {

--- a/skills/internal-codemap-for-srs/SKILL.md
+++ b/skills/internal-codemap-for-srs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: internal-codemap-for-srs
-description: Route SRS code tasks to the smallest relevant trusted codebase map and verification guidance. Use whenever support, development, debugging, review, or maintenance work requires locating, choosing, reading, modifying, testing, or verifying SRS code. Covers the first-generation C++ origin and edge media server, its State Threads dependency, the next-generation Go server, and the test, E2E, and benchmark structure. Use as the code-navigation dependency of srs-support and srs-develop; the parent skill remains responsible for the user-facing workflow and result.
+description: Route SRS code tasks to the smallest relevant trusted codebase map and verification guidance. Use whenever support, development, debugging, review, or maintenance work requires locating, choosing, reading, modifying, testing, or verifying SRS code. Covers the first-generation C++ origin and edge media server, its State Threads dependency, the next-generation Go server, browser publishers and players for WHIP, WHEP, HTTP-FLV, and HLS, and the test, E2E, and benchmark structure. Use as the code-navigation dependency of srs-support and srs-develop; the parent skill remains responsible for the user-facing workflow and result.
 ---
 
 # SRS Internal Code Map
@@ -23,13 +23,14 @@ Route code work to focused codebase maps. The parent skill owns the user-facing 
 |---|---|---|
 | C++ media server | The task concerns the first-generation origin or edge server, `trunk/src/`, `trunk/conf/`, protocols, media processing, or State Threads | `references/cpp-server.md` |
 | Next-generation Go server | The task concerns the Go proxy, future Go origin or edge services, `cmd/`, or `internal/` | `references/go-server.md` |
+| Browser publishers and players | The task concerns browser publishing or playback with WHIP, WHEP, HTTP-FLV, or HLS, including code under `trunk/research/players/` | `references/browser-clients.md` |
 | Testing and verification | The task requires choosing or running unit, black-box, E2E, proxy, reproduction, or benchmark verification | `references/testing.md` |
 
 For a comparison or migration across generations, load both server maps. Add the testing reference only when verification is required.
 
 ## Workflow
 
-1. Classify the request as C++ media server, next-generation Go server, testing and verification, or an explicit combination.
+1. Classify the request as C++ media server, next-generation Go server, browser publishers and players, testing and verification, or an explicit combination.
 2. If the server generation is unclear and choosing incorrectly could change the result, ask the user to clarify. Do not guess.
 3. Load the selected reference file or files.
 4. Use their descriptions to identify the responsible module and the smallest relevant file set.

--- a/skills/internal-codemap-for-srs/references/browser-clients.md
+++ b/skills/internal-codemap-for-srs/references/browser-clients.md
@@ -1,0 +1,25 @@
+# Browser Publisher and Player Code Map
+
+Use this reference after `skills/internal-codemap-for-srs/SKILL.md` routes a task to browser publishers and players. The listed module directory defines the trusted navigation scope for WHIP, WHEP, HTTP-FLV, and HLS browser clients.
+
+## Browser Client Code
+
+`trunk/research/players/` — Browser research and demonstration clients for publishing and playback.
+
+- `whip.html` — WHIP publisher page: media capture, publishing controls, codec selection, bearer token, session display, and teardown.
+- `whep.html` — WHEP player page: playback controls, audio/video selection, codec selection, bearer token, session display, and teardown.
+- `rtc_publisher.html` and `rtc_player.html` — Older WebRTC publisher and player pages that translate the stream URL to WHIP or WHEP and use the shared SDK.
+- `srs_player.html` — HTML5 live player for HTTP-FLV and HLS; also handles HTTP-TS, MPEG-DASH, MP4, AAC, and MP3 playback.
+- `js/srs.sdk.js` — Shared WebRTC SDK implementing WHIP publishing and WHEP playback, including SDP exchange, media tracks, authorization, session resources, and teardown.
+- `js/srs.page.js` — Shared page initialization and default URL construction for WHIP, WHEP, HTTP-FLV, and the browser demos.
+- `js/srs.utility.js`, `js/winlin.utility.js`, and `js/srs.log.js` — Shared URL parsing, query-string, utility, and logging helpers used by the pages.
+- `js/mpegts-1.7.3.min.js` and `js/hls-1.4.14.min.js` — Bundled third-party playback runtimes used by the HTTP-FLV and HLS player. Inspect these vendored files only when the task specifically concerns the dependency itself.
+
+For other pages or assets in this module, list filenames only within `trunk/research/players/`, choose the smallest relevant set, then read or search only those files.
+
+## Boundaries
+
+- Use this map for browser-side publisher and player behavior.
+- Use `references/cpp-server.md` for the corresponding server-side WebRTC, HTTP-FLV, or HLS implementation.
+- Use `references/go-server.md` when the browser client is exercising the next-generation Go proxy.
+- Add `references/testing.md` when reproduction or verification requires server, protocol, E2E, or benchmark tests.

--- a/skills/internal-codemap-for-srs/references/testing.md
+++ b/skills/internal-codemap-for-srs/references/testing.md
@@ -2,6 +2,14 @@
 
 Use this reference after `skills/internal-codemap-for-srs/SKILL.md` determines that a task requires tests, verification, reproduction, or benchmarking.
 
+## Browser Client Verification
+
+Browser player URL generation is verified independently with Node.js and does not require a running SRS server:
+
+```bash
+node skills/srs-develop/scripts/browser-page-url-test.js
+```
+
 ## C++ Media Server Verification
 
 `trunk/src/utest/` — Unit tests for internal functions, classes, parsers, codecs, and configuration without starting SRS. Links directly against SRS source and uses mocks such as `MockSrsConfig`.

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -383,3 +383,20 @@ Issue #4647 is resolved in SRS 8.0.6. Operators can configure the origin-registr
 ### Unknowns
 
 No dedicated E2E test waits for a short configured lifetime to expire in real time. The TTL parsing and both load-balancer applications are covered by unit tests, while the complete default-configuration proxy workflows are covered by E2E tests.
+
+## #4646 — CURRENT
+
+- **Issue:** https://github.com/ossrs/srs/issues/4646
+- **Truth Record:** https://github.com/ossrs/srs/issues/4646#issuecomment-5180281566
+- **Verified:** 2026-08-04
+- **Branch:** `forge`
+- **Commit:** `ae221b5e2c13bbfb9f51ffe70ed57ae32da423cf`
+- **Version:** SRS `8.0.6`
+- **Environment:** macOS 26.5.2, arm64; Go 1.25.0
+- **Changes/tests:** None
+
+SRS Proxy supports registering origins but does not provide APIs for querying registered origins or stream-to-origin mappings.
+
+An origin query API would be valuable for debugging and verifying registrations. A stream mapping API would also be useful. However, these APIs—and other operational APIs—need careful, comprehensive design.
+
+This is a valuable feature request, but it is deferred while higher-priority bugs are addressed. Keep the issue open and revisit it when there is time to design the API properly.

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -400,3 +400,87 @@ SRS Proxy supports registering origins but does not provide APIs for querying re
 An origin query API would be valuable for debugging and verifying registrations. A stream mapping API would also be useful. However, these APIs—and other operational APIs—need careful, comprehensive design.
 
 This is a valuable feature request, but it is deferred while higher-priority bugs are addressed. Keep the issue open and revisit it when there is time to design the API properly.
+
+## #4645 — CURRENT
+
+- **Issue:** https://github.com/ossrs/srs/issues/4645
+- **Truth Record:** https://github.com/ossrs/srs/issues/4645#issuecomment-5180983219
+- **Verified:** 2026-08-04
+- **Branch:** `forge`
+- **Commit:** `df73ac14de5e26bec66fa4ded4b9a159dec4b9f1`, with a staged candidate fix
+- **Version:** SRS `8.0.6`
+- **Environment:** macOS 26.5.2, arm64; Node.js 22.22.0
+- **Supersedes:** None; no previous authorized Truth Record
+- **Release state:** Uncommitted and unreleased
+
+### Reported problem
+
+The browser HTTP-FLV/HLS player generated incorrect media URLs when accessed through HTTP or HTTPS reverse proxies.
+
+Without explicit query overrides, `build_default_flv_url()` always selected HTTP port 8080. HTTPS selected port 1935. This could bypass the public reverse proxy, produce mixed-content requests, or target a closed port.
+
+### Confirmed root cause
+
+The browser player constructed its default media endpoint from inconsistent inputs:
+
+- Hostname came from `window.location.hostname`.
+- Scheme defaulted to `http`.
+- Port defaulted to 8080 for HTTP and 1935 otherwise.
+- The public page protocol and port were ignored.
+
+`is_default_port()` itself was correct. Explicit HTTP port 80 and HTTPS port 443 were already omitted properly.
+
+`parse_query_string()` was also working as designed: optional `schema`, `server`, `port`, `vhost`, `app`, and `stream` properties appear only when supplied in the query string.
+
+### Candidate fix
+
+`trunk/research/players/js/srs.page.js` now:
+
+1. Uses the player page's protocol and public port by default.
+2. Omits standard HTTP port 80 and HTTPS port 443.
+3. Preserves direct SRS access on port 8080.
+4. Preserves explicit `schema`, `server`, `port`, and `vhost` overrides.
+5. Uses the standard port for an explicitly selected protocol when it differs from the page protocol.
+
+### Regression coverage
+
+Added:
+
+```text
+skills/srs-develop/scripts/browser-page-url-test.js
+```
+
+Run with:
+
+```bash
+node skills/srs-develop/scripts/browser-page-url-test.js
+```
+
+The testing command is recorded in:
+
+```text
+skills/internal-codemap-for-srs/references/testing.md
+```
+
+All six cases passed:
+
+- Direct SRS HTTP server on port 8080
+- Public HTTP origin on port 80
+- Public HTTPS origin on port 443
+- Custom reverse-proxy port
+- Explicit protocol change without a port
+- Explicit target overrides
+
+JavaScript syntax checks and `git diff --check` also passed.
+
+### Conclusion
+
+The default browser URL-generation bug is confirmed, and the staged candidate fixes it for player URLs without explicit target overrides.
+
+The fix is uncommitted and unreleased pending maintainer review.
+
+### Remaining unknowns
+
+- A real browser/reverse-proxy playback test has not been performed.
+- The issue's example page URL explicitly contains `port=8080`. Explicit overrides remain authoritative. If another page or console automatically inserts that parameter, its URL generator requires a separate fix.
+- The reporter did not provide the exact SRS version, browser, or complete reverse-proxy configuration.

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -317,3 +317,69 @@ The candidate change remains uncommitted and unreleased pending maintainer revie
 ### Unknowns
 
 The original deployments did not provide enough scheduling-level evidence to prove that every reported occurrence followed this exact race. However, the deterministic reproduction matches the reported publisher-active, player-`active=0`, and HLS-still-playing behavior.
+
+## #4647 — CURRENT
+
+- **Issue:** https://github.com/ossrs/srs/issues/4647
+- **Truth Record:** https://github.com/ossrs/srs/issues/4647#issuecomment-5173896319
+- **Verified:** 2026-08-03
+- **Branch:** `develop`
+- **Commit:** `b6b70164cd3bc665040d387105a77420ced22fd3`
+- **Version:** SRS `8.0.6`
+- **Environment:** macOS 26.5.2, arm64; Go 1.25.0
+- **Merged PR:** https://github.com/ossrs/srs/pull/4694
+- **Earlier PR:** https://github.com/ossrs/srs/pull/4650 — closed without merging
+- **Supersedes:** None; no previous authorized Truth Record
+
+### Reported problem
+
+The proxy used a fixed 300-second lifetime for origin registrations. Some deployments have shorter heartbeat and failover requirements and need to configure this lifetime.
+
+### Current state
+
+SRS Proxy now supports:
+
+```bash
+PROXY_ORIGIN_SERVER_TTL=45s
+```
+
+The value accepts positive Go duration syntax such as `45s` or `2m`. Invalid, zero, and negative values cause load-balancer initialization to fail. When unset, the default remains 300 seconds.
+
+One parser, `parseOriginServerTTL`, owns the default and validation. Both memory and Redis load balancers obtain the configured value during initialization.
+
+### Load-balancer behavior
+
+- **Memory load balancer:** Origins with heartbeats inside the configured lifetime are preferred. As before, if no origins are healthy, it falls back to all registered origins.
+- **Redis load balancer:** The configured lifetime is applied directly to each origin-registration Redis key. An expired registration is unavailable for new routing.
+- Stream mappings remain persistent and are not controlled by this setting.
+
+### Scope decision
+
+Only the origin-registration lifetime is configurable.
+
+The fixed 120-second HLS and WebRTC session-cache lifetimes remain unchanged. They represent internal transient session state, are unrelated to origin heartbeat/failover requirements, and currently have no demonstrated need for operator configuration.
+
+The earlier PR #4650 proposed configuring all three lifetimes. The merged implementation intentionally uses only `PROXY_ORIGIN_SERVER_TTL`.
+
+### Verification
+
+- Proxy unit tests with coverage passed: **65.5%**
+- Single-origin RTMP E2E passed
+- Multi-origin memory load-balancer E2E passed
+- Proxy-edge-origin E2E passed
+- Redis multi-proxy E2E passed
+- RTMP transmux E2E passed
+- SRT proxy E2E passed
+- WHIP proxy E2E passed
+- Final targeted `internal/lb` unit tests passed
+- `git diff --check` passed
+
+Unit coverage verifies the default, custom duration, invalid value, zero, and negative cases. It also verifies configured memory-LB health selection and the Redis registration-key TTL.
+
+### Conclusion
+
+Issue #4647 is resolved in SRS 8.0.6. Operators can configure the origin-registration lifetime consistently for memory and Redis load balancers while the default behavior remains backward compatible.
+
+### Unknowns
+
+No dedicated E2E test waits for a short configured lifetime to expire in real time. The TTL parsing and both load-balancer applications are covered by unit tests, while the complete default-configuration proxy workflows are covered by E2E tests.

--- a/skills/srs-develop/scripts/browser-page-url-test.js
+++ b/skills/srs-develop/scripts/browser-page-url-test.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2013-2026 The SRS Authors
+//
+// SPDX-License-Identifier: MIT
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const projectRoot = path.resolve(__dirname, '../../..');
+const playerJs = path.join(projectRoot, 'trunk/research/players/js');
+const utilitySource = fs.readFileSync(path.join(playerJs, 'winlin.utility.js'), 'utf8');
+const pageSource = fs.readFileSync(path.join(playerJs, 'srs.page.js'), 'utf8');
+
+function buildDefaultFlvUrl(rawUrl) {
+    const pageUrl = new URL(rawUrl);
+    const context = {
+        window: {
+            location: {
+                host: pageUrl.host,
+                hostname: pageUrl.hostname,
+                port: pageUrl.port,
+                pathname: pageUrl.pathname,
+                search: pageUrl.search,
+                hash: pageUrl.hash,
+                protocol: pageUrl.protocol,
+            },
+        },
+        console,
+    };
+
+    vm.createContext(context);
+    vm.runInContext(utilitySource, context);
+    vm.runInContext(pageSource, context);
+
+    return context.build_default_flv_url();
+}
+
+const cases = [
+    {
+        name: 'keeps the direct SRS HTTP server port',
+        page: 'http://live.example.com:8080/players/srs_player.html',
+        expected: 'http://live.example.com:8080/live/livestream.flv',
+    },
+    {
+        name: 'uses the public HTTP origin',
+        page: 'http://live.example.com/players/srs_player.html?stream=tv.flv',
+        expected: 'http://live.example.com/live/tv.flv',
+    },
+    {
+        name: 'uses the public HTTPS origin',
+        page: 'https://live.example.com/players/srs_player.html?stream=tv.flv',
+        expected: 'https://live.example.com/live/tv.flv',
+    },
+    {
+        name: 'uses a custom reverse-proxy port',
+        page: 'https://live.example.com:8443/players/srs_player.html?stream=tv.flv',
+        expected: 'https://live.example.com:8443/live/tv.flv',
+    },
+    {
+        name: 'uses the default port when schema overrides the page protocol',
+        page: 'http://live.example.com:8080/players/srs_player.html?schema=https&stream=tv.flv',
+        expected: 'https://live.example.com/live/tv.flv',
+    },
+    {
+        name: 'preserves explicit target overrides',
+        page: 'http://live.example.com/players/srs_player.html?schema=https&server=media.example.com&port=9443&vhost=tenant.example.com&app=show&stream=main.flv',
+        expected: 'https://media.example.com:9443/show/main.flv?vhost=tenant.example.com',
+    },
+];
+
+for (const testCase of cases) {
+    assert.equal(buildDefaultFlvUrl(testCase.page), testCase.expected, testCase.name);
+    console.log(`PASS: ${testCase.name}`);
+}

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-04, Merge [#4698](https://github.com/ossrs/srs/pull/4698): Codex: Fix browser player URLs behind reverse proxies and refresh issue records. v8.0.7 (#4698)
 * v8.0, 2026-08-03, Merge [#4694](https://github.com/ossrs/srs/pull/4694): Codex: Add configurable proxy origin registration TTL. v8.0.6 (#4694)
 * v8.0, 2026-08-02, Merge [#4692](https://github.com/ossrs/srs/pull/4692): Codex: Fix live source cleanup race before publisher activation. v8.0.5 (#4692)
 * v8.0, 2026-07-26, Merge [#4689](https://github.com/ossrs/srs/pull/4689): Codex: Improve proxy tooling and maintainer workflows. v8.0.4 (#4689)

--- a/trunk/research/players/js/srs.page.js
+++ b/trunk/research/players/js/srs.page.js
@@ -47,26 +47,41 @@ function user_extra_params(query, params, rtc) {
     return queries;
 }
 
+function default_port_for_schema(schema) {
+    if (schema === 'http') {
+        return 80;
+    }
+    if (schema === 'https') {
+        return 443;
+    }
+    if (schema === 'webrtc') {
+        return 1985;
+    }
+    if (schema === 'rtmp') {
+        return 1935;
+    }
+    return 0;
+}
+
 function is_default_port(schema, port) {
-    return (schema === 'http' && port === 80)
-        || (schema === 'https' && port === 443)
-        || (schema === 'webrtc' && port === 1985)
-        || (schema === 'rtmp' && port === 1935);
+    return default_port_for_schema(schema) === port;
 }
 
 /**
 @param server the ip of server. default to window.location.hostname
 @param vhost the vhost of HTTP-FLV. default to window.location.hostname
-@param port the port of HTTP-FLV. default to 1935
+@param port the port of HTTP-FLV. default to the current page port
 @param app the app of HTTP-FLV. default to live.
 @param stream the stream of HTTP-FLV. default to livestream.flv
 */
 function build_default_flv_url() {
     var query = parse_query_string();
 
-    var schema = (!query.schema)? "http":query.schema;
+    var location_schema = window.location.protocol.replace(':', '');
+    var schema = query.schema || location_schema || "http";
     var server = (!query.server)? window.location.hostname:query.server;
-    var port = (!query.port)? (schema==="http"? 8080:1935) : Number(query.port);
+    var port = Number(query.port || ((query.schema && query.schema !== location_schema)?
+        default_port_for_schema(schema) : (window.location.port || default_port_for_schema(schema))));
     var vhost = (!query.vhost)? window.location.hostname:query.vhost;
     var app = (!query.app)? "live":query.app;
     var stream = (!query.stream)? "livestream.flv":query.stream;

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 6
+#define VERSION_REVISION 7
 
 #endif


### PR DESCRIPTION
Summary:

- Fix the browser player's default HTTP-FLV/HLS URL construction to use the public page protocol and port while preserving explicit target overrides.
- Keep direct SRS access on port 8080, omit standard HTTP/HTTPS ports, and support custom reverse-proxy ports.
- Add an AI-owned Node.js regression script for browser URL generation and route browser-client work through the internal code map.

The regression script passes all six scenarios:

- Direct SRS HTTP server on port 8080
- Public HTTP origin on port 80
- Public HTTPS origin on port 443
- Custom reverse-proxy port
- Explicit protocol change without a port
- Explicit target overrides
