### PR TITLE
Fix #4642: Reject duplicate WebRTC TCP owners. v8.0.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ cmake-build-debug
 /skills/llm-switcher
 /skills/*workspace*
 /memory/202*.md
+/tasks

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 7
+	return 8
 }
 
 func Version() string {

--- a/skills/internal-codemap-for-srs/SKILL.md
+++ b/skills/internal-codemap-for-srs/SKILL.md
@@ -9,13 +9,20 @@ Route code work to focused codebase maps. The parent skill owns the user-facing 
 
 ## Core Rules
 
-- Work from the current working directory. Do not search parent directories or discover alternate repository roots.
+- Use the current working directory as the project root. Do not search parent directories or discover alternate repository roots.
 - Use the Reference Router before reading, searching, or modifying code, configuration, tests, or verification scripts.
 - Treat only files and module directories listed by the selected reference as trusted navigation scope.
 - Never grep the repository root or broad trees such as `trunk/src/`, `cmd/`, or `internal/`.
 - When a selected reference lists a module directory rather than every file, list filenames only inside that module, choose the smallest relevant set, then read or search only those files.
 - If no route covers the task, report that the code router does not cover it. Do not discover a new route ad hoc.
 - Use `skills/internal-docs-for-srs/SKILL.md` for project documentation. Do not route documentation here.
+
+## Path Resolution
+
+- Resolve bundled paths beginning with `references/`, `scripts/`, `assets/`, or `agents/` relative to the directory containing this `SKILL.md`, not the current working directory.
+- Resolve repository paths such as `trunk/`, `internal/`, `cmd/`, or `skills/` relative to the current working directory.
+- Use the currently invoked skill directory. Do not search for alternate copies under tool-specific directories such as `.agents/`, `.kiro/`, or `.claude/`.
+- Before reporting a routed file as missing, check its fully resolved path directly.
 
 ## Reference Router
 
@@ -32,7 +39,7 @@ For a comparison or migration across generations, load both server maps. Add the
 
 1. Classify the request as C++ media server, next-generation Go server, browser publishers and players, testing and verification, or an explicit combination.
 2. If the server generation is unclear and choosing incorrectly could change the result, ask the user to clarify. Do not guess.
-3. Load the selected reference file or files.
+3. Resolve the selected path according to [Path Resolution](#path-resolution), then load the reference file or files.
 4. Use their descriptions to identify the responsible module and the smallest relevant file set.
 5. Read or search only those files. Add a second routed module only when evidence shows a dependency crosses the first module boundary.
 6. Return control to the parent skill for support, development, debugging, review, or maintenance.

--- a/skills/internal-docs-for-srs/SKILL.md
+++ b/skills/internal-docs-for-srs/SKILL.md
@@ -9,13 +9,20 @@ Route SRS tasks to focused documentation references. The parent skill owns the u
 
 ## Core Rules
 
-- Work from the current working directory. Do not search parent directories or discover alternate repository roots.
+- Use the current working directory as the project root. Do not search parent directories or discover alternate repository roots.
 - Use the Reference Router before loading any reference or bundled document.
 - Load only the references and bundled documents relevant to the task. Do not load everything.
 - Treat only project files listed in this skill or a selected reference as trusted documentation.
 - If no route covers the task, report that the documentation router does not cover it. Do not scan or broadly grep documentation directories.
 - Select the smallest relevant set of project documents from their descriptions.
 - Keep trusted document routing in this skill. Do not duplicate topic-to-file tables in dependent skills.
+
+## Path Resolution
+
+- Resolve bundled paths beginning with `references/`, `scripts/`, `assets/`, or `agents/` relative to the directory containing this `SKILL.md`, not the current working directory.
+- Resolve repository paths such as `trunk/`, `internal/`, `cmd/`, or `skills/` relative to the current working directory.
+- Use the currently invoked skill directory. Do not search for alternate copies under tool-specific directories such as `.agents/`, `.kiro/`, or `.claude/`.
+- Before reporting a routed file as missing, check its fully resolved path directly.
 
 ## Reference Router
 
@@ -85,7 +92,7 @@ If a task spans multiple areas, load only the required references or bundled doc
 ## Workflow
 
 1. Classify the documentation need with the Reference Router.
-2. Load the selected project or bundled document directly from the router.
+2. Resolve the selected path according to [Path Resolution](#path-resolution), then load the project or bundled document directly.
 3. Load only the documents required for the task.
 4. Return control to the parent skill for answering, development, troubleshooting, review, or editing.
 

--- a/skills/srs-develop/SKILL.md
+++ b/skills/srs-develop/SKILL.md
@@ -14,6 +14,14 @@ description: Develop, modify, debug, and maintain the next-generation SRS media 
 - `skills/internal-docs-for-srs/SKILL.md` — Route and load project documentation. This skill remains responsible for the development workflow and final result.
 - `skills/internal-codemap-for-srs/SKILL.md` — Route code navigation and verification to the relevant server map. This skill remains responsible for the development workflow and final result.
 
+## Path Resolution
+
+- Use the current working directory as the project root. Do not search parent directories or discover alternate repository roots.
+- Resolve bundled paths beginning with `references/`, `scripts/`, `assets/`, or `agents/` relative to the directory containing this `SKILL.md`, not the current working directory.
+- Resolve repository paths such as `trunk/`, `internal/`, `cmd/`, or `skills/` relative to the current working directory.
+- Use the currently invoked skill directory. Do not search for alternate copies under tool-specific directories such as `.agents/`, `.kiro/`, or `.claude/`.
+- Before reporting a routed file as missing, check its fully resolved path directly.
+
 ## Git Workflow
 
 Apply these rules whenever a task produces a commit:

--- a/skills/srs-develop/SKILL.md
+++ b/skills/srs-develop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: srs-develop
-description: Develop, modify, debug, and maintain the next-generation SRS media server written in Go. This is the AI-maintained successor to the first-generation C++ SRS server. Currently, planned changes are supported for the Go proxy server only; the next-generation Go origin and edge server workflows are not yet supported. Use for all development tasks, for example, adding features, fixing bugs, refactoring code, understanding code architecture, reviewing changes, and writing tests for the Go codebase. NOT for end-user support, usage questions, configuration help, or learning how to use SRS — use the srs-support skill for those. Only activate when the task is explicitly about developing or modifying the Go SRS codebase.
+description: Develop, modify, debug, review, maintain, and explain the SRS codebase. Use for planned changes to the next-generation Go server, bug maintenance, issue triage, pull-request review, and Learn Code questions about how existing C++ or Go SRS code works, including architecture, control flow, and implementation details. Planned feature development is currently supported only for the Go proxy server; the C++ server is in maintenance mode, and planned Go origin and edge development is not yet supported. NOT for end-user support, usage questions, or configuration help — use the srs-support skill for those.
 ---
 
 # SRS Development
@@ -65,7 +65,7 @@ Route the user's request to exactly ONE task type. Follow that task only. Do not
 | **Develop Code** | User wants to add, modify, refactor code, or update docs — any planned change | → [Develop Code](#task-develop-code) | ✅ Supported |
 | **Scan Issues** | User wants recent issues needing maintainer attention | → [Scan Issues](#task-scan-issues) | ✅ Supported |
 | **Fix a Bug** | User reports something broken, unexpected behavior, or an error | → [Fix a Bug](#task-fix-a-bug) | ✅ Supported |
-| **Learn Code** | User wants to understand how code works — no changes intended | → [Learn Code](#task-learn-code) | ❌ Not yet supported |
+| **Learn Code** | User wants to understand how code works — no changes intended | → [Learn Code](#task-learn-code) | ✅ Supported |
 | **Review a PR** | User wants to review an existing pull request | → [Review a PR](#task-review-a-pr) | ✅ Supported |
 
 **If the routed task is not yet supported**, stop and tell the user:
@@ -140,7 +140,34 @@ Use this only when verification shows user misuse already covered by the documen
 
 **Prerequisite:** You must arrive here via the [Task Router](#task-router). Do not execute this task directly — always complete the Task Router first to confirm this is the correct task type.
 
-**Not yet supported.** Will be added in a future update.
+**Scope:** Explain how existing SRS code works without modifying the project. Cover implementation, architecture, control flow, data flow, module boundaries, and behavior grounded in the current code and project documentation. This task may examine either the C++ media server or the next-generation Go server.
+
+### Step 1: Route and read documentation first
+
+1. Load `skills/internal-docs-for-srs/SKILL.md` and use its Reference Router before reading project documentation.
+2. Classify the question by server generation, service, protocol, or feature. Select and read the smallest relevant document set for design intent, architecture, and documented behavior.
+3. If the documentation router has no matching route, or a fully resolved routed file is unavailable, record the documentation gap and continue to code routing. Do not broadly search documentation directories or invent intent.
+
+### Step 2: Route to the responsible code
+
+1. Load `skills/internal-codemap-for-srs/SKILL.md` and use its Reference Router to select the relevant server map. If choosing the wrong server generation would materially change the answer, ask the user to clarify.
+2. Use the selected map descriptions to identify the owning module and the smallest relevant file set. When the map lists a directory, list filenames only in that directory before selecting files.
+3. Read or search only the selected files. Add another routed module only when evidence shows that the implementation crosses the first module boundary.
+
+### Step 3: Trace and reconcile the implementation
+
+1. Trace the narrowest useful path from the feature entry point, such as configuration, API, listener, protocol handler, or public interface, through its owning module and required lower-level dependencies.
+2. Separate the common implementation path from protocol-specific or service-specific behavior. Identify defaults, platform-dependent behavior, fallbacks, and limitations when relevant.
+3. Compare documentation with code. Investigate material conflicts instead of silently preferring either source. Clearly separate confirmed behavior, reasonable inference, and unknowns.
+4. Use the testing and verification map only when the user requests runtime verification or static evidence is insufficient for an important claim. Do not change code or tests as part of Learn Code.
+
+### Step 4: Answer the question
+
+1. Answer the user's question directly before describing the investigation.
+2. State the examined server generation and, when behavior may vary by revision, the current branch and commit.
+3. Cite the responsible files with focused line ranges and explain how their responsibilities connect. Do not return an unstructured file dump.
+4. Report relevant documentation gaps, code/document conflicts, limitations, and unresolved questions.
+5. Make no project changes. If the investigation reveals a likely bug or desired change, report it and let the user start a separate Fix a Bug or Develop Code task.
 
 ---
 

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -485,6 +485,134 @@ The fix is uncommitted and unreleased pending maintainer review.
 - The issue's example page URL explicitly contains `port=8080`. Explicit overrides remain authoritative. If another page or console automatically inserts that parameter, its URL generator requires a separate fix.
 - The reporter did not provide the exact SRS version, browser, or complete reverse-proxy configuration.
 
+## #4642 — CURRENT
+
+- **Issue:** https://github.com/ossrs/srs/issues/4642
+- **Truth Record:** https://github.com/ossrs/srs/issues/4642#issuecomment-5207071995
+- **Title:** `Bug: SIGSEGV in SrsRtcTcpConn when WebRTC-over-TCP viewer disconnects (v6.0.184)`
+- **Verified:** 2026-08-06
+- **Issue state:** Open, no comments before this Truth Record, label `TransByAI`
+- **Reported version:** SRS `6.0.184` / `63edbef90864d425a6303c64bae9600631a4c0f9`
+- **Current checked source:** SRS `8.0.7`, remote `develop` `ee0c5cd98a38966a982d675f6533e85acdbca6dd`
+- **Unfixed baseline:** `d5ab7db9a9ff7471fedb4ff857fba0645c4dc85e`
+- **Candidate fix:** `5f4d5c9a40501d8e0e46ddbe304806a34c51a637` on branch `forge`
+- **Verification:** macOS 26.5.2 arm64, ASAN-enabled C++ utests
+- **Runtime reproduction:** Not done; no browser/Docker production SIGSEGV was reproduced
+- **Release state:** Fix is local only; not merged or released
+
+### Summary
+
+The issue's exact explanation is wrong: since PR #4083 in SRS `6.0.127`, the recorded WebRTC-over-TCP owner is interrupted during RTC network destruction, and `SrsRtcTcpConn::interrupt()` clears that owner's `session_` pointer.
+
+But the code still had a real ownership bug that can explain the reported crash location.
+
+### Confirmed bug
+
+Before the fix, a second TCP connection for the same RTC session could replace the first connection as owner before the code checked uniqueness:
+
+```cpp
+if (network->owner().get() != this) {
+    network->set_owner(*wrapper_);
+    session_ = session;
+}
+if (network->owner().get() != this) {
+    return srs_error_new(ERROR_RTC_TCP_UNIQUE, "only support one network");
+}
+```
+
+Bad sequence:
+
+1. Connection A handshakes and stores the RTC session pointer.
+2. Connection B handshakes for the same RTC session.
+3. B replaces A as network owner.
+4. A still has a raw `session_` pointer, but teardown will only interrupt B.
+5. A can later dereference stale memory at `session_->tcp()`, matching the reported crash area.
+
+The dummy owner was not the direct cause. The direct cause was **replace before reject**. The dummy owner made that pattern easier to write because the first real connection had to replace something.
+
+### Regression test
+
+Added utest:
+
+```text
+ReproduceIssue4642.RejectSecondTcpConnForSameRtcSession
+```
+
+It creates one mock RTC session and two TCP connections with the same ICE username.
+
+Expected behavior:
+
+- A succeeds and becomes owner.
+- B fails with `ERROR_RTC_TCP_UNIQUE`.
+- A remains owner.
+- B never stores the session pointer.
+
+On the unfixed baseline, the test failed because B succeeded, replaced A, and stored the session pointer. This reproduces the stale-pointer prerequisite deterministically without intentionally crashing the test process.
+
+### Fix
+
+The fix makes the TCP owner empty initially, then rejects any second owner before changing state:
+
+```cpp
+SrsRtcTcpNetwork *network = dynamic_cast<SrsRtcTcpNetwork *>(session->tcp());
+if (network->owner().get()) {
+    return srs_error_new(ERROR_RTC_TCP_UNIQUE, "only support one network");
+}
+network->set_owner(*wrapper_);
+session_ = session;
+```
+
+The network destructor now checks for an owner before interrupting it:
+
+```cpp
+if (owner_.get()) {
+    owner_->interrupt();
+}
+```
+
+### Verification after fix
+
+Build:
+
+```bash
+cd trunk
+./configure --utest --gb28181=on --sanitizer=on --build-cache=off
+make utest
+```
+
+Targeted tests:
+
+```bash
+ASAN_OPTIONS=detect_leaks=0 ./objs/srs_utest \
+  --gtest_filter='RtcTcpConnTest.*:ReproduceIssue4642.*'
+```
+
+Result: 5 tests passed.
+
+Full C++ utest suite:
+
+```bash
+ASAN_OPTIONS=detect_leaks=0 ./objs/srs_utest
+```
+
+Result: 2239 tests passed.
+
+### Conclusion
+
+This issue is **partially confirmed**.
+
+- Not confirmed: the issue's exact claim that `session_` is never cleared for the recorded owner.
+- Confirmed: a second TCP connection could displace the first owner and leave the first connection with a stale raw session pointer.
+- Fixed locally: duplicate TCP owners are rejected before ownership/session state changes.
+- Still needed before closing: review, merge, release, and ideally reporter/runtime confirmation that the original SIGSEGV used this two-connection path.
+
+### Unknowns
+
+- Whether the reporter's deployment actually created two TCP connections for one RTC session.
+- Whether every reported crash followed this path.
+- The reporter's exact Docker image digest.
+- Whether a production ASAN reproducer would show the same sequence.
+
 ## #4641 — CURRENT
 
 - **Issue:** https://github.com/ossrs/srs/issues/4641

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -484,3 +484,25 @@ The fix is uncommitted and unreleased pending maintainer review.
 - A real browser/reverse-proxy playback test has not been performed.
 - The issue's example page URL explicitly contains `port=8080`. Explicit overrides remain authoritative. If another page or console automatically inserts that parameter, its URL generator requires a separate fix.
 - The reporter did not provide the exact SRS version, browser, or complete reverse-proxy configuration.
+
+## #4641 — CURRENT
+
+- **Issue:** https://github.com/ossrs/srs/issues/4641
+- **Truth Record:** https://github.com/ossrs/srs/issues/4641#issuecomment-5203763730
+- **Verified:** 2026-08-06
+- **Branch:** `forge`
+- **Commit:** `ee0c5cd98a38966a982d675f6533e85acdbca6dd`
+- **Version:** SRS `8.0.7`
+- **Changes:** None
+
+SRS supports IPv6 RTMP listening since v7.0.67. Configure it explicitly:
+
+```conf
+rtmp {
+    listen [::]:1935;
+}
+```
+
+The report provides no SRS version, configuration, logs, or network details, so an SRS bug cannot be established. This is most likely a deployment or listener-configuration issue.
+
+No project change is required. The reporter should use the IPv6 listener configuration and provide complete logs and configuration if the problem remains.

--- a/skills/srs-support/SKILL.md
+++ b/skills/srs-support/SKILL.md
@@ -33,11 +33,18 @@ Follow these four steps in order for every question.
 
 ## Step 1: Setup
 
-All files are in the current working directory. Find everything from here — no discovery logic needed.
+Use the current working directory as the project root. Do not search parent directories or discover alternate repository roots.
 
 Available directories: `trunk/`, `cmd/`, `internal/`, `cmake/`, `memory/`, `skills/`
 
 All AI tools — OpenClaw, Codex, Claude Code, Kiro CLI — see the same relative paths.
+
+### Path Resolution
+
+- Resolve bundled paths beginning with `references/`, `scripts/`, `assets/`, or `agents/` relative to the directory containing this `SKILL.md`, not the current working directory.
+- Resolve repository paths such as `trunk/`, `internal/`, `cmd/`, or `skills/` relative to the current working directory.
+- Use the currently invoked skill directory. Do not search for alternate copies under tool-specific directories such as `.agents/`, `.kiro/`, or `.claude/`.
+- Before reporting a routed file as missing, check its fully resolved path directly.
 
 ## Step 2: Load Knowledge
 

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-06, Merge [#4699](https://github.com/ossrs/srs/pull/4699): Codex: Reject duplicate WebRTC TCP owners. v8.0.8 (#4699)
 * v8.0, 2026-08-04, Merge [#4698](https://github.com/ossrs/srs/pull/4698): Codex: Fix browser player URLs behind reverse proxies and refresh issue records. v8.0.7 (#4698)
 * v8.0, 2026-08-03, Merge [#4694](https://github.com/ossrs/srs/pull/4694): Codex: Add configurable proxy origin registration TTL. v8.0.6 (#4694)
 * v8.0, 2026-08-02, Merge [#4692](https://github.com/ossrs/srs/pull/4692): Codex: Fix live source cleanup race before publisher activation. v8.0.5 (#4692)

--- a/trunk/src/app/srs_app_rtc_network.cpp
+++ b/trunk/src/app/srs_app_rtc_network.cpp
@@ -492,7 +492,7 @@ srs_error_t SrsRtcUdpNetwork::write(void *buf, size_t size, ssize_t *nwrite)
     return sendonly_skt_->sendto(buf, size, SRS_UTIME_NO_TIMEOUT);
 }
 
-SrsRtcTcpNetwork::SrsRtcTcpNetwork(ISrsRtcConnection *conn, ISrsEphemeralDelta *delta) : owner_(new SrsRtcTcpConn())
+SrsRtcTcpNetwork::SrsRtcTcpNetwork(ISrsRtcConnection *conn, ISrsEphemeralDelta *delta)
 {
     conn_ = conn;
     delta_ = delta;
@@ -504,7 +504,9 @@ SrsRtcTcpNetwork::SrsRtcTcpNetwork(ISrsRtcConnection *conn, ISrsEphemeralDelta *
 
 SrsRtcTcpNetwork::~SrsRtcTcpNetwork()
 {
-    owner_->interrupt();
+    if (owner_.get()) {
+        owner_->interrupt();
+    }
     srs_freep(transport_);
 }
 
@@ -957,13 +959,11 @@ srs_error_t SrsRtcTcpConn::handshake()
 
     // Should support only one TCP candidate.
     SrsRtcTcpNetwork *network = dynamic_cast<SrsRtcTcpNetwork *>(session->tcp());
-    if (network->owner().get() != this) {
-        network->set_owner(*wrapper_);
-        session_ = session;
-    }
-    if (network->owner().get() != this) {
+    if (network->owner().get()) {
         return srs_error_new(ERROR_RTC_TCP_UNIQUE, "only support one network");
     }
+    network->set_owner(*wrapper_);
+    session_ = session;
 
     // For each binding request, update the TCP socket.
     if (ping.is_binding_request()) {

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 7
+#define VERSION_REVISION 8
 
 #endif

--- a/trunk/src/utest/srs_utest_ai23.cpp
+++ b/trunk/src/utest/srs_utest_ai23.cpp
@@ -3897,50 +3897,50 @@ void MockRtcConnectionForTcpConnHandshake::reset()
     on_binding_request_called_ = false;
 }
 
+static std::string build_rtc_tcp_stun_binding_request(std::string username)
+{
+    char stun_buf[128];
+    memset(stun_buf, 0, sizeof(stun_buf));
+
+    int username_len = (int)username.size();
+    int username_padded = (username_len + 3) / 4 * 4;
+    int message_size = 4 + username_padded;
+    int stun_size = 20 + message_size;
+
+    // STUN header: BindingRequest, message length, magic cookie and transaction ID.
+    stun_buf[0] = 0x00;
+    stun_buf[1] = 0x01;
+    stun_buf[2] = (message_size >> 8) & 0xff;
+    stun_buf[3] = message_size & 0xff;
+    stun_buf[4] = 0x21;
+    stun_buf[5] = 0x12;
+    stun_buf[6] = 0xa4;
+    stun_buf[7] = 0x42;
+    for (int i = 8; i < 20; ++i) {
+        stun_buf[i] = i - 8;
+    }
+
+    // USERNAME attribute.
+    stun_buf[20] = 0x00;
+    stun_buf[21] = 0x06;
+    stun_buf[22] = (username_len >> 8) & 0xff;
+    stun_buf[23] = username_len & 0xff;
+    memcpy(stun_buf + 24, username.data(), username_len);
+
+    // RFC4571 frame: two-byte packet length followed by the STUN packet.
+    std::string frame;
+    frame.push_back((stun_size >> 8) & 0xff);
+    frame.push_back(stun_size & 0xff);
+    frame.append(stun_buf, stun_size);
+    return frame;
+}
+
 // Test SrsRtcTcpConn::handshake - major use scenario
 VOID TEST(RtcTcpConnTest, HandshakeWithStunBindingRequest)
 {
     srs_error_t err;
 
-    // Create a STUN binding request packet manually
-    // STUN header: message type (2) + message length (2) + magic cookie (4) + transaction ID (12) = 20 bytes
-    // Plus username attribute: type (2) + length (2) + value (padded to 4-byte boundary)
-    char stun_buf[128];
-    memset(stun_buf, 0, sizeof(stun_buf));
-
-    // STUN header
-    stun_buf[0] = 0x00;
-    stun_buf[1] = 0x01; // BindingRequest
-    stun_buf[2] = 0x00;
-    stun_buf[3] = 0x10; // message length = 16 (username attribute: 4 + 12)
-
-    // Magic cookie (0x2112A442)
-    stun_buf[4] = 0x21;
-    stun_buf[5] = 0x12;
-    stun_buf[6] = 0xA4;
-    stun_buf[7] = 0x42;
-
-    // Transaction ID (12 bytes)
-    for (int i = 8; i < 20; i++) {
-        stun_buf[i] = i - 8;
-    }
-
-    // Username attribute: type=0x0006, length=12, value="test:session"
-    stun_buf[20] = 0x00;
-    stun_buf[21] = 0x06; // Username attribute type
-    stun_buf[22] = 0x00;
-    stun_buf[23] = 0x0C; // Length = 12
-    memcpy(stun_buf + 24, "test:session", 12);
-
-    int stun_size = 36; // 20 (header) + 16 (username attribute)
-
-    // Prepare read data: 2-byte length prefix + STUN packet
-    std::string read_data;
-    uint8_t len_prefix[2];
-    len_prefix[0] = (stun_size >> 8) & 0xFF;
-    len_prefix[1] = stun_size & 0xFF;
-    read_data.append((char *)len_prefix, 2);
-    read_data.append(stun_buf, stun_size);
+    std::string read_data = build_rtc_tcp_stun_binding_request("test:session");
 
     // Create mock socket with read data
     SrsUniquePtr<MockProtocolReadWriterForTcpNetwork> mock_io(new MockProtocolReadWriterForTcpNetwork());
@@ -4004,6 +4004,64 @@ VOID TEST(RtcTcpConnTest, HandshakeWithStunBindingRequest)
     tcp_conn->skt_ = NULL;
     tcp_conn->conn_manager_ = NULL;
     tcp_conn->wrapper_ = NULL;
+    tcp_network->sendonly_skt_ = NULL;
+    mock_session->tcp_network_ = NULL;
+    mock_conn_manager->session_to_return_ = NULL;
+}
+
+// Issue #4642: A second TCP connection for the same RTC session must not
+// displace the first owner, otherwise the first connection keeps a stale
+// session pointer after the session interrupts only the recorded owner.
+VOID TEST(ReproduceIssue4642, RejectSecondTcpConnForSameRtcSession)
+{
+    srs_error_t err;
+    std::string read_data = build_rtc_tcp_stun_binding_request("test:session");
+
+    SrsUniquePtr<MockResourceManagerForTcpConnHandshake> mock_conn_manager(new MockResourceManagerForTcpConnHandshake());
+    SrsUniquePtr<MockRtcConnectionForTcpConnHandshake> mock_session(new MockRtcConnectionForTcpConnHandshake());
+    SrsUniquePtr<MockEphemeralDelta> mock_delta(new MockEphemeralDelta());
+    SrsUniquePtr<SrsRtcTcpNetwork> tcp_network(new SrsRtcTcpNetwork(mock_session.get(), mock_delta.get()));
+
+    mock_session->tcp_network_ = tcp_network.get();
+    mock_conn_manager->session_to_return_ = mock_session.get();
+
+    SrsUniquePtr<MockProtocolReadWriterForTcpNetwork> io_a(new MockProtocolReadWriterForTcpNetwork());
+    SrsUniquePtr<MockProtocolReadWriterForTcpNetwork> io_b(new MockProtocolReadWriterForTcpNetwork());
+    io_a->set_read_data(read_data);
+    io_b->set_read_data(read_data);
+
+    SrsRtcTcpConn *raw_a = new SrsRtcTcpConn(io_a.get(), "192.168.1.10", 10000);
+    SrsRtcTcpConn *raw_b = new SrsRtcTcpConn(io_b.get(), "192.168.1.11", 10001);
+    SrsUniquePtr<SrsSharedResource<ISrsRtcTcpConn> > wrapper_a(new SrsSharedResource<ISrsRtcTcpConn>(raw_a));
+    SrsUniquePtr<SrsSharedResource<ISrsRtcTcpConn> > wrapper_b(new SrsSharedResource<ISrsRtcTcpConn>(raw_b));
+
+    raw_a->conn_manager_ = mock_conn_manager.get();
+    raw_a->wrapper_ = wrapper_a.get();
+    raw_b->conn_manager_ = mock_conn_manager.get();
+    raw_b->wrapper_ = wrapper_b.get();
+
+    HELPER_EXPECT_SUCCESS(raw_a->handshake());
+    EXPECT_EQ(raw_a, tcp_network->owner().get());
+    EXPECT_EQ(mock_session.get(), raw_a->session_);
+
+    err = raw_b->handshake();
+    EXPECT_TRUE(err != srs_success);
+    if (err != srs_success) {
+        EXPECT_EQ(ERROR_RTC_TCP_UNIQUE, srs_error_code(err));
+        srs_freep(err);
+    }
+
+    EXPECT_EQ(raw_a, tcp_network->owner().get());
+    EXPECT_EQ(mock_session.get(), raw_a->session_);
+    EXPECT_TRUE(raw_b->session_ == NULL);
+
+    // Prevent the connection and mock socket owners from deleting the same sockets.
+    raw_a->skt_ = NULL;
+    raw_b->skt_ = NULL;
+    raw_a->conn_manager_ = NULL;
+    raw_b->conn_manager_ = NULL;
+    raw_a->wrapper_ = NULL;
+    raw_b->wrapper_ = NULL;
     tcp_network->sendonly_skt_ = NULL;
     mock_session->tcp_network_ = NULL;
     mock_conn_manager->session_to_return_ = NULL;


### PR DESCRIPTION
The reported explanation that `session_` is never cleared for the recorded owner is not correct after PR #4083. However, the TCP handshake still had a real ownership bug: connection B could replace connection A as the RTC TCP network owner before the uniqueness check ran.

That left A alive with a raw `session_` pointer while teardown only interrupted B. A could later dereference stale memory at `session_->tcp()`, matching the reported crash area.

## Fix

The first TCP handshake now claims an empty owner slot. Later handshakes for the same RTC session fail with `ERROR_RTC_TCP_UNIQUE` before changing ownership or storing `session_`.

## Regression coverage

Added:

```text
ReproduceIssue4642.RejectSecondTcpConnForSameRtcSession
```

The test verifies:

- A succeeds and becomes owner.
- B fails with `ERROR_RTC_TCP_UNIQUE`.
- A remains owner.
- B never stores the session pointer.

On the unfixed baseline, this test failed because B succeeded, replaced A, and stored the session pointer.
