### PR TITLE
Backport #4699: Reject duplicate WebRTC TCP owners. v7.0.152

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ cmake-build-debug
 /skills/llm-switcher
 /skills/*workspace*
 /memory/202*.md
+/tasks

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 150
+	return 152
 }
 
 func Version() string {

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2026-08-07, Merge [#4699](https://github.com/ossrs/srs/pull/4699): Codex: Reject duplicate WebRTC TCP owners. v7.0.152 (#4699)
 * v7.0, 2026-08-03, Merge [#4692](https://github.com/ossrs/srs/pull/4692): Codex: Fix live source cleanup race before publisher activation. v7.0.151 (#4692)
 * v7.0, 2026-05-19, Merge [#4678](https://github.com/ossrs/srs/pull/4678): Edge: Fix HTTP-FLV 404 and RTMP late-join missing sequence headers. v7.0.150 (#4678)
 * v7.0, 2026-05-17, Merge [#4676](https://github.com/ossrs/srs/pull/4676): Proxy: Fix RTC/SRT reader goroutine leak; unwrap legacy WHEP JSON envelope; add WHEP pprof guide. v7.0.149 (#4676)

--- a/trunk/src/app/srs_app_rtc_network.cpp
+++ b/trunk/src/app/srs_app_rtc_network.cpp
@@ -492,7 +492,7 @@ srs_error_t SrsRtcUdpNetwork::write(void *buf, size_t size, ssize_t *nwrite)
     return sendonly_skt_->sendto(buf, size, SRS_UTIME_NO_TIMEOUT);
 }
 
-SrsRtcTcpNetwork::SrsRtcTcpNetwork(ISrsRtcConnection *conn, ISrsEphemeralDelta *delta) : owner_(new SrsRtcTcpConn())
+SrsRtcTcpNetwork::SrsRtcTcpNetwork(ISrsRtcConnection *conn, ISrsEphemeralDelta *delta)
 {
     conn_ = conn;
     delta_ = delta;
@@ -504,7 +504,9 @@ SrsRtcTcpNetwork::SrsRtcTcpNetwork(ISrsRtcConnection *conn, ISrsEphemeralDelta *
 
 SrsRtcTcpNetwork::~SrsRtcTcpNetwork()
 {
-    owner_->interrupt();
+    if (owner_.get()) {
+        owner_->interrupt();
+    }
     srs_freep(transport_);
 }
 
@@ -957,13 +959,11 @@ srs_error_t SrsRtcTcpConn::handshake()
 
     // Should support only one TCP candidate.
     SrsRtcTcpNetwork *network = dynamic_cast<SrsRtcTcpNetwork *>(session->tcp());
-    if (network->owner().get() != this) {
-        network->set_owner(*wrapper_);
-        session_ = session;
-    }
-    if (network->owner().get() != this) {
+    if (network->owner().get()) {
         return srs_error_new(ERROR_RTC_TCP_UNIQUE, "only support one network");
     }
+    network->set_owner(*wrapper_);
+    session_ = session;
 
     // For each binding request, update the TCP socket.
     if (ping.is_binding_request()) {

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 151
+#define VERSION_REVISION 152
 
 #endif


### PR DESCRIPTION
## Summary

- Backport #4699 to SRS 7.0 for issue #4642.
- Reject a duplicate WebRTC-over-TCP owner before changing RTC TCP ownership or storing `session_`.
- Bump SRS 7.0 release version to `v7.0.152`.
- Add the SRS 7.0 changelog entry.

## Root cause

The WebRTC-over-TCP handshake allowed a second TCP connection for the same RTC session to replace the first connection as the RTC TCP network owner before the uniqueness check ran.

That could leave the first connection alive with a raw `session_` pointer while RTC network teardown only interrupted the newer owner. The first connection could later dereference stale session memory around `session_->tcp()`.

## Fix

The TCP owner is now empty initially. The first handshake claims the owner slot. Any later handshake for the same RTC session fails with `ERROR_RTC_TCP_UNIQUE` before ownership/session state changes.

## Links

- Original fix PR: https://github.com/ossrs/srs/pull/4699
- Issue: https://github.com/ossrs/srs/issues/4642
- Truth Record: https://github.com/ossrs/srs/issues/4642#issuecomment-5207071995
