### PR TITLE
Fix #4639: Terminate SSRC group SDP lines. v8.0.9

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 8
+	return 9
 }
 
 func Version() string {

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -634,3 +634,49 @@ rtmp {
 The report provides no SRS version, configuration, logs, or network details, so an SRS bug cannot be established. This is most likely a deployment or listener-configuration issue.
 
 No project change is required. The reporter should use the IPv6 listener configuration and provide complete logs and configuration if the problem remains.
+
+## #4639 — CURRENT
+
+- **Issue:** https://github.com/ossrs/srs/issues/4639
+- **Truth Record:** Pending maintainer publication
+- **Verified:** 2026-08-07
+- **Branch:** `forge`
+- **Commit:** `9be7486e751a67bb809cc9926e4a19da262e25b7`, with a staged candidate fix
+- **Version:** SRS `8.0.8`; issue reported against SRS `6.0-r0`
+- **Environment:** macOS arm64, Apple Clang, ASAN utest build
+- **Supersedes:** `NO_TRUTH` 2026-02-28 — report identified concatenated SDP lines when downlink SSRC groups are present, but had no maintainer verification.
+
+### Confirmed facts
+
+RFC 8866 defines CRLF as the SDP line terminator. Parsers should tolerate LF-only lines, but this bug is neither CRLF nor LF: `SrsSSRCGroup::encode()` emitted no line terminator.
+
+The defect is local to `SrsSSRCGroup::encode()` in `trunk/src/protocol/srs_protocol_sdp.cpp`. Before the fix, encoding an SSRC group followed by another SDP attribute produced concatenated output:
+
+```text
+a=ssrc-group:FID 12345 67890a=ssrc:12345 cname:test-cname\r\n
+```
+
+Other SDP encoders already append `kCRLF`; this is not a general SDP encoding problem.
+
+### Fix and regression coverage
+
+The candidate fix adds `os << kCRLF;` after the SSRC group SSRC list.
+
+Regression coverage:
+
+- `ProtocolSdpTest.SrsSSRCGroupEncode` now requires the exact output `a=ssrc-group:FID 12345 67890\r\n`.
+- `ProtocolSdpTest.SrsSSRCGroupEncodeBeforeSsrcInfo` verifies that a following `a=ssrc:` line is separated, not concatenated.
+
+Before the production fix, both regression tests failed. After the fix:
+
+- `make utest -j4` passed.
+- `ASAN_OPTIONS=detect_leaks=0 ./objs/srs_utest --gtest_filter='ProtocolSdpTest.SrsSSRCGroupEncode*'` passed: 2 tests passed.
+- `ASAN_OPTIONS=detect_leaks=0 ./objs/srs_utest` passed: 2240 tests passed.
+
+### Conclusion
+
+#4639 is a real narrow SDP formatting bug in `SrsSSRCGroup::encode()`. The root cause is a missing line terminator after the encoded `a=ssrc-group:` attribute. The local code change fixes the concatenation by appending `kCRLF`.
+
+### Unknowns
+
+Current `SrsMediaDesc::encode()` does not appear to serialize `ssrc_groups_` in the normal media-description path, so the exact runtime path from the report depends on the downlink SSRC-group usage path.

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-07, Merge [#4701](https://github.com/ossrs/srs/pull/4701): Codex: Terminate SSRC group SDP lines. v8.0.9 (#4701)
 * v8.0, 2026-08-06, Merge [#4699](https://github.com/ossrs/srs/pull/4699): Codex: Reject duplicate WebRTC TCP owners. v8.0.8 (#4699)
 * v8.0, 2026-08-04, Merge [#4698](https://github.com/ossrs/srs/pull/4698): Codex: Fix browser player URLs behind reverse proxies and refresh issue records. v8.0.7 (#4698)
 * v8.0, 2026-08-03, Merge [#4694](https://github.com/ossrs/srs/pull/4694): Codex: Add configurable proxy origin registration TTL. v8.0.6 (#4694)

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 8
+#define VERSION_REVISION 9
 
 #endif

--- a/trunk/src/protocol/srs_protocol_sdp.cpp
+++ b/trunk/src/protocol/srs_protocol_sdp.cpp
@@ -297,6 +297,7 @@ srs_error_t SrsSSRCGroup::encode(std::ostringstream &os)
     for (int i = 0; i < (int)ssrcs_.size(); i++) {
         os << " " << ssrcs_[i];
     }
+    os << kCRLF;
 
     return err;
 }

--- a/trunk/src/utest/srs_utest_manual_protocol3.cpp
+++ b/trunk/src/utest/srs_utest_manual_protocol3.cpp
@@ -2112,7 +2112,7 @@ VOID TEST(ProtocolSdpTest, SrsSSRCGroupEncode)
     HELPER_EXPECT_SUCCESS(ssrc_group.encode(os));
 
     std::string result = os.str();
-    EXPECT_TRUE(result.find("a=ssrc-group:FID 12345 67890") != std::string::npos);
+    EXPECT_STREQ("a=ssrc-group:FID 12345 67890\r\n", result.c_str());
 
     // Test invalid semantic (should fail)
     SrsSSRCGroup invalid_group;
@@ -2131,6 +2131,26 @@ VOID TEST(ProtocolSdpTest, SrsSSRCGroupEncode)
     std::ostringstream os3;
     srs_error_t encode_err2 = empty_group.encode(os3);
     HELPER_EXPECT_FAILED(encode_err2);
+}
+
+VOID TEST(ProtocolSdpTest, SrsSSRCGroupEncodeBeforeSsrcInfo)
+{
+    srs_error_t err = srs_success;
+
+    std::vector<uint32_t> ssrcs;
+    ssrcs.push_back(12345);
+    ssrcs.push_back(67890);
+
+    SrsSSRCGroup ssrc_group("FID", ssrcs);
+    SrsSSRCInfo ssrc_info(12345, "test-cname", "", "");
+
+    std::ostringstream os;
+    HELPER_EXPECT_SUCCESS(ssrc_group.encode(os));
+    HELPER_EXPECT_SUCCESS(ssrc_info.encode(os));
+
+    EXPECT_STREQ("a=ssrc-group:FID 12345 67890\r\n"
+                 "a=ssrc:12345 cname:test-cname\r\n",
+                 os.str().c_str());
 }
 
 VOID TEST(ProtocolSdpTest, SrsMediaDescUpdateMsid)


### PR DESCRIPTION
## Summary

Fix #4639 by appending the SDP line terminator after `SrsSSRCGroup::encode()` writes an `a=ssrc-group:` attribute.

Before this fix, an SSRC group followed by another SDP attribute could be serialized as one concatenated line, for example:

```text
a=ssrc-group:FID 12345 67890a=ssrc:12345 cname:test-cname
```

This was a narrow encoder bug: other SDP encoders already append `kCRLF`.

## Changes

- Add the missing `kCRLF` after encoded SSRC group lines.
- Tighten the existing SSRC group unit test to require the exact CRLF-terminated output.
- Add a regression test for an SSRC group followed by an `a=ssrc:` line.
- Record the verified Truth Record for #4639 in the AI issue records.

## Verification

```bash
make utest -j4
ASAN_OPTIONS=detect_leaks=0 ./objs/srs_utest --gtest_filter='ProtocolSdpTest.SrsSSRCGroupEncode*'
ASAN_OPTIONS=detect_leaks=0 ./objs/srs_utest
```

Results:

- Targeted SSRC group tests passed: 2 tests.
- Full C++ utest suite passed: 2240 tests.
