### PR TITLE
Backport #4701: Terminate SSRC group SDP lines. v7.0.153

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 152
+	return 153
 }
 
 func Version() string {

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2026-08-07, Merge [#4701](https://github.com/ossrs/srs/pull/4701): Codex: Terminate SSRC group SDP lines. v7.0.153 (#4701)
 * v7.0, 2026-08-07, Merge [#4699](https://github.com/ossrs/srs/pull/4699): Codex: Reject duplicate WebRTC TCP owners. v7.0.152 (#4699)
 * v7.0, 2026-08-03, Merge [#4692](https://github.com/ossrs/srs/pull/4692): Codex: Fix live source cleanup race before publisher activation. v7.0.151 (#4692)
 * v7.0, 2026-05-19, Merge [#4678](https://github.com/ossrs/srs/pull/4678): Edge: Fix HTTP-FLV 404 and RTMP late-join missing sequence headers. v7.0.150 (#4678)

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 152
+#define VERSION_REVISION 153
 
 #endif

--- a/trunk/src/protocol/srs_protocol_sdp.cpp
+++ b/trunk/src/protocol/srs_protocol_sdp.cpp
@@ -297,6 +297,7 @@ srs_error_t SrsSSRCGroup::encode(std::ostringstream &os)
     for (int i = 0; i < (int)ssrcs_.size(); i++) {
         os << " " << ssrcs_[i];
     }
+    os << kCRLF;
 
     return err;
 }

--- a/trunk/src/utest/srs_utest_manual_protocol3.cpp
+++ b/trunk/src/utest/srs_utest_manual_protocol3.cpp
@@ -2112,7 +2112,7 @@ VOID TEST(ProtocolSdpTest, SrsSSRCGroupEncode)
     HELPER_EXPECT_SUCCESS(ssrc_group.encode(os));
 
     std::string result = os.str();
-    EXPECT_TRUE(result.find("a=ssrc-group:FID 12345 67890") != std::string::npos);
+    EXPECT_STREQ("a=ssrc-group:FID 12345 67890\r\n", result.c_str());
 
     // Test invalid semantic (should fail)
     SrsSSRCGroup invalid_group;
@@ -2131,6 +2131,26 @@ VOID TEST(ProtocolSdpTest, SrsSSRCGroupEncode)
     std::ostringstream os3;
     srs_error_t encode_err2 = empty_group.encode(os3);
     HELPER_EXPECT_FAILED(encode_err2);
+}
+
+VOID TEST(ProtocolSdpTest, SrsSSRCGroupEncodeBeforeSsrcInfo)
+{
+    srs_error_t err = srs_success;
+
+    std::vector<uint32_t> ssrcs;
+    ssrcs.push_back(12345);
+    ssrcs.push_back(67890);
+
+    SrsSSRCGroup ssrc_group("FID", ssrcs);
+    SrsSSRCInfo ssrc_info(12345, "test-cname", "", "");
+
+    std::ostringstream os;
+    HELPER_EXPECT_SUCCESS(ssrc_group.encode(os));
+    HELPER_EXPECT_SUCCESS(ssrc_info.encode(os));
+
+    EXPECT_STREQ("a=ssrc-group:FID 12345 67890\r\n"
+                 "a=ssrc:12345 cname:test-cname\r\n",
+                 os.str().c_str());
 }
 
 VOID TEST(ProtocolSdpTest, SrsMediaDescUpdateMsid)


### PR DESCRIPTION
## Summary

Backport #4701 / #4639 to the SRS 7.0 release branch.

This fixes the narrow SDP encoder bug where `SrsSSRCGroup::encode()` wrote an `a=ssrc-group:` attribute without any line terminator. When another SDP attribute followed, the output could become one concatenated line:

```text
a=ssrc-group:FID 12345 67890a=ssrc:12345 cname:test-cname
```

## Changes

- Add the missing `kCRLF` after encoded SSRC group lines.
- Tighten the existing SSRC group unit test to require CRLF-terminated output.
- Add a regression test for an SSRC group followed by an `a=ssrc:` line.
- Bump SRS 7.0 to `v7.0.153`.
- Add the 7.0 changelog entry.

No AI issue-record update is included in this backport.

## Verification

```bash
./configure --utest --sanitizer=on --build-cache=off
make utest -j4
ASAN_OPTIONS=detect_leaks=0 ./objs/srs_utest --gtest_filter='ProtocolSdpTest.SrsSSRCGroupEncode*'
ASAN_OPTIONS=detect_leaks=0 ./objs/srs_utest
```

Results:

- Targeted SSRC group tests passed: 2 tests.
- Full SRS 7.0 C++ utest suite passed: 2187 tests.
