### PR TITLE
RTMP: Clean up publish state after forward backend failures. v8.0.10

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 9
+	return 10
 }
 
 func Version() string {

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -661,6 +661,19 @@ Edge RTC disable is expected and already documented: classic Edge supports RTMP/
 
 The reported `0x01` is the HTTP-FLV header flag for video-only, not an RTMP header. SRS already supports the requested behavior: for RTC-to-HTTP-FLV playback that must advertise both tracks from the first FLV header, configure `http_remux { has_audio on; has_video on; guess_has_av off; }`; users should read the HTTP-FLV docs or ask SRS AI before opening documented-configuration issues.
 
+## #4632 — CURRENT
+
+- **Issue:** https://github.com/ossrs/srs/issues/4632
+- **Truth Record:** https://github.com/ossrs/srs/issues/4632#issuecomment-5217342826
+- **Verified:** 2026-08-07
+- **Branch:** `forge`
+- **Commit:** `ce50bbe975912458ffb85ff82f8c6795c221c8bb`
+- **Version:** SRS `8.0.9`
+- **Changes:** None
+- **Closure:** Upstream RTMP handshake timeout; issue closed.
+
+The edge established TCP, but the origin did not complete the RTMP handshake within 30 seconds. During that wait, the current publisher owns the edge stream, so another publisher for the same stream is correctly rejected as busy; the state resets after timeout. No SRS defect was confirmed.
+
 ## #4639 — CURRENT
 
 - **Issue:** https://github.com/ossrs/srs/issues/4639

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -635,6 +635,32 @@ The report provides no SRS version, configuration, logs, or network details, so 
 
 No project change is required. The reporter should use the IPv6 listener configuration and provide complete logs and configuration if the problem remains.
 
+## #4634 — CURRENT
+
+- **Issue:** https://github.com/ossrs/srs/issues/4634
+- **Truth Record:** https://github.com/ossrs/srs/issues/4634#issuecomment-5216829576
+- **Verified:** 2026-08-07
+- **Branch:** `forge`
+- **Commit:** `2bb5e4428f393d09546f53f46ffbdd246dedcd95`
+- **Version:** SRS `8.0.9`
+- **Changes:** None
+- **Closure:** Expected behavior; issue closed.
+
+Edge RTC disable is expected and already documented: classic Edge supports RTMP/HTTP-FLV, not WebRTC. Users should check Edge docs or ask SRS AI before opening usage questions already covered by docs.
+
+## #4633 — CURRENT
+
+- **Issue:** https://github.com/ossrs/srs/issues/4633
+- **Truth Record:** https://github.com/ossrs/srs/issues/4633#issuecomment-5216986292
+- **Verified:** 2026-08-07
+- **Branch:** `forge`
+- **Commit:** `2bb5e4428f393d09546f53f46ffbdd246dedcd95`
+- **Version:** SRS `8.0.9`
+- **Changes:** None
+- **Closure:** Not closed yet; usage/configuration issue, no project change.
+
+The reported `0x01` is the HTTP-FLV header flag for video-only, not an RTMP header. SRS already supports the requested behavior: for RTC-to-HTTP-FLV playback that must advertise both tracks from the first FLV header, configure `http_remux { has_audio on; has_video on; guess_has_av off; }`; users should read the HTTP-FLV docs or ask SRS AI before opening documented-configuration issues.
+
 ## #4639 — CURRENT
 
 - **Issue:** https://github.com/ossrs/srs/issues/4639

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -674,6 +674,33 @@ The reported `0x01` is the HTTP-FLV header flag for video-only, not an RTMP head
 
 The edge established TCP, but the origin did not complete the RTMP handshake within 30 seconds. During that wait, the current publisher owns the edge stream, so another publisher for the same stream is correctly rejected as busy; the state resets after timeout. No SRS defect was confirmed.
 
+## #4631 — CURRENT
+
+- **Issue:** https://github.com/ossrs/srs/issues/4631
+- **Truth Record:** https://github.com/ossrs/srs/issues/4631#issuecomment-5218171343
+- **Verified:** 2026-08-07
+- **Branch:** `forge`
+- **Commit:** `70309a6a21a2b9a148b11a03cd40ab806087e7cc`
+- **Version:** SRS `8.0.9`
+- **Changes:** Fixed on `forge`; not merged or released
+- **Verification:** Runtime reproduction and 2,190 passing unit tests
+
+### Current state
+
+A dynamic-forward backend error such as HTTP 500 correctly rejects the current publication because SRS cannot obtain valid forwarding destinations. Before the fix, that error left the live source permanently busy: later publishers received `StreamBusy`, the stream was absent from `/api/v1/streams/`, and only restarting SRS cleared it.
+
+`SrsLiveSource::on_publish()` marks the source as publishing before initializing the origin hub and querying the backend. When backend discovery failed, `acquire_publish()` returned an error, but the publishing workflow released the source only after successful acquisition. The global publish token was released; the live source's local publish state was not.
+
+### Resolution and verification
+
+The publishing workflow now releases publish state after successful or failed acquisition, except for `StreamBusy`. That exception is required because a busy stream belongs to another publisher and must not be released by the rejected session. The original backend error is still returned, and the external unpublish hook remains limited to sessions that successfully entered the publish lifecycle.
+
+The regression test performs two consecutive backend failures and verifies that both reach the backend, both return the original HTTP error, and the source is available after each attempt. Runtime verification confirmed that a publication rejected by HTTP 500 can be retried successfully after the backend recovers, without restarting SRS. All 2,190 unit tests passed.
+
+### Workaround
+
+For released versions, return HTTP 200 with `code: 0` and empty `urls` to accept publishing without forwarding. Restart SRS to clear an already stuck stream.
+
 ## #4639 — CURRENT
 
 - **Issue:** https://github.com/ossrs/srs/issues/4639

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-07, Merge [#4703](https://github.com/ossrs/srs/pull/4703): Codex: Clean up publish state after forward backend failures. v8.0.10 (#4703)
 * v8.0, 2026-08-07, Merge [#4701](https://github.com/ossrs/srs/pull/4701): Codex: Terminate SSRC group SDP lines. v8.0.9 (#4701)
 * v8.0, 2026-08-06, Merge [#4699](https://github.com/ossrs/srs/pull/4699): Codex: Reject duplicate WebRTC TCP owners. v8.0.8 (#4699)
 * v8.0, 2026-08-04, Merge [#4698](https://github.com/ossrs/srs/pull/4698): Codex: Fix browser player URLs behind reverse proxies and refresh issue records. v8.0.7 (#4698)
@@ -1459,4 +1460,3 @@ The changelog for SRS.
 * v0.1, 2013-10-17, support rtmp chunk2message protocol(recv\_message).
 
 Winlin 2021
-

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -951,10 +951,14 @@ srs_error_t SrsRtmpConn::publishing(SrsSharedPtr<SrsLiveSource> source)
         rtrd.stop();
     }
 
-    // Release and callback when acquire publishing success, if not, we should ignore, because the source
-    // is not published by this session.
-    if (acquire_err == srs_success) {
+    // Whatever the acquire result, release any publish state changed by this session.
+    // When the stream is busy, another session owns it and must never be released here.
+    if (srs_error_code(acquire_err) != ERROR_SYSTEM_STREAM_BUSY) {
         release_publish(source);
+    }
+
+    // Only notify the hook when this session acquired the stream and entered the publish lifecycle.
+    if (acquire_err == srs_success) {
         http_hooks_on_unpublish();
     }
 

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 9
+#define VERSION_REVISION 10
 
 #endif

--- a/trunk/src/utest/srs_utest_workflow_forward.cpp
+++ b/trunk/src/utest/srs_utest_workflow_forward.cpp
@@ -23,6 +23,7 @@
 
 #include <srs_utest_workflow_forward.hpp>
 
+#include <srs_app_rtmp_conn.hpp>
 #include <srs_app_utility.hpp>
 #include <srs_kernel_error.hpp>
 
@@ -43,6 +44,79 @@ ISrsBasicRtmpClient *MockAppFactoryForForwarder::create_rtmp_client(std::string 
         mock_rtmp_client_->set_url(url);
     }
     return mock_rtmp_client_;
+}
+
+MockHttpHooksForForwardBackendFailure::MockHttpHooksForForwardBackendFailure()
+{
+    on_forward_backend_count_ = 0;
+    on_forward_backend_error_ = srs_success;
+}
+
+MockHttpHooksForForwardBackendFailure::~MockHttpHooksForForwardBackendFailure()
+{
+    srs_freep(on_forward_backend_error_);
+}
+
+srs_error_t MockHttpHooksForForwardBackendFailure::on_forward_backend(std::string url, ISrsRequest *req, std::vector<std::string> &rtmp_urls)
+{
+    on_forward_backend_count_++;
+    return srs_error_copy(on_forward_backend_error_);
+}
+
+void MockHttpHooksForForwardBackendFailure::set_on_forward_backend_error(srs_error_t err)
+{
+    srs_freep(on_forward_backend_error_);
+    on_forward_backend_error_ = srs_error_copy(err);
+}
+
+// A dynamic-forward backend is an external dependency. If it fails, SRS should reject the
+// current publish attempt and roll back the partially acquired live source so the publisher
+// can retry. This regression test defines the required rollback behavior.
+VOID TEST(BasicWorkflowForwardTest, ForwardBackendFailureRollsBackPublishState)
+{
+    srs_error_t err;
+
+    SrsUniquePtr<MockAppConfig> mock_config(new MockAppConfig());
+    SrsUniquePtr<MockAppStatistic> mock_stat(new MockAppStatistic());
+    SrsUniquePtr<MockHttpHooksForForwardBackendFailure> mock_hooks(new MockHttpHooksForForwardBackendFailure());
+    SrsUniquePtr<MockRequest> req(new MockRequest("__defaultVhost__", "live", "stream1"));
+
+    mock_config->set_forward_backend("http://127.0.0.1:8085/api/v1/forward");
+    mock_hooks->set_on_forward_backend_error(srs_error_new(ERROR_HTTP_STATUS_INVALID, "mock HTTP 500"));
+
+    SrsLiveSource *raw_source = new SrsLiveSource();
+    raw_source->config_ = mock_config.get();
+    raw_source->stat_ = mock_stat.get();
+    raw_source->req_ = req->copy();
+    SrsSharedPtr<SrsLiveSource> source(raw_source);
+
+    SrsOriginHub *hub = new SrsOriginHub();
+    hub->config_ = mock_config.get();
+    hub->stat_ = mock_stat.get();
+    hub->hooks_ = mock_hooks.get();
+    HELPER_EXPECT_SUCCESS(hub->initialize(source, raw_source->req_));
+    raw_source->hub_ = hub;
+
+    SrsUniquePtr<SrsRtmpConn> conn(new SrsRtmpConn(new MockRtmpTransport(), "127.0.0.1", 1935));
+    conn->config_ = mock_config.get();
+    conn->stat_ = mock_stat.get();
+    conn->hooks_ = mock_hooks.get();
+    conn->info_->req_->vhost_ = req->vhost_;
+    conn->info_->req_->app_ = req->app_;
+    conn->info_->req_->stream_ = req->stream_;
+    conn->info_->edge_ = false;
+
+    // Each attempt should reach the backend and fail with its original error. Most importantly,
+    // the failed attempt must leave the live source available for the next publisher.
+    for (int i = 0; i < 2; i++) {
+        err = conn->publishing(source);
+        EXPECT_TRUE(err != srs_success);
+        EXPECT_EQ(ERROR_HTTP_STATUS_INVALID, srs_error_code(err));
+        srs_freep(err);
+
+        EXPECT_TRUE(source->can_publish(false));
+    }
+    EXPECT_EQ(2, mock_hooks->on_forward_backend_count_);
 }
 
 // This test is used to verify the basic workflow of the forwarding.

--- a/trunk/src/utest/srs_utest_workflow_forward.hpp
+++ b/trunk/src/utest/srs_utest_workflow_forward.hpp
@@ -48,4 +48,18 @@ public:
     virtual ISrsBasicRtmpClient *create_rtmp_client(std::string url, srs_utime_t cto, srs_utime_t sto);
 };
 
+// Mock the dynamic-forward HTTP boundary without opening a real socket.
+class MockHttpHooksForForwardBackendFailure : public MockHttpHooks
+{
+public:
+    int on_forward_backend_count_;
+    srs_error_t on_forward_backend_error_;
+
+public:
+    MockHttpHooksForForwardBackendFailure();
+    virtual ~MockHttpHooksForForwardBackendFailure();
+    virtual srs_error_t on_forward_backend(std::string url, ISrsRequest *req, std::vector<std::string> &rtmp_urls);
+    void set_on_forward_backend_error(srs_error_t err);
+};
+
 #endif


### PR DESCRIPTION
## Summary

- Fix #4631 by releasing partially acquired RTMP publish state after a non-busy acquisition error.
- Preserve an existing publisher when a new session is rejected with `StreamBusy`.
- Add regression coverage for repeated dynamic-forward backend failures.
- Record the verified Truth Records for #4632, #4633, and #4634.

## Behavior

A dynamic-forward backend error still rejects the current publication. SRS now cleans up the partial publish state so the same stream can retry after the backend recovers, without restarting SRS.

The external unpublish hook remains limited to sessions that successfully acquired the stream and entered the publish lifecycle.

## Verification

- Targeted forward-backend rollback test passed.
- Complete C++ unit suite passed: 2,190 tests from 274 suites.
- Runtime verification passed: HTTP 500 rejected the first publication, and the same stream published successfully after backend recovery without restarting SRS.

Fixes #4631
