### PR TITLE
RTC2RTMP: Deduplicate AVC and HEVC sequence headers. v8.0.12

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 11
+	return 12
 }
 
 func Version() string {

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -904,3 +904,12 @@ A deterministic H.264/FLV sample was generated with four RTMP video packets per 
 The report is a confirmed SRS MP4 DVR timing bug caused by treating a legitimate zero DTS delta as an uninitialized `stts` entry. It is fixed and regression-tested in commit `2f1f67a8125ae4051ed46e74143b15acc7a5ce54` on the local `forge` branch.
 
 The fix has not yet been merged or released. Confirmation against a fresh capture of the reporter's original RTMP input and confirmation in a released SRS version remain pending.
+
+## #4623 [USAGE] Private origin address registered across unrelated networks
+
+- **Issue:** https://github.com/ossrs/srs/issues/4623
+- **Truth Record:** https://github.com/ossrs/srs/issues/4623#issuecomment-5234472135
+- **Verified:** 2026-08-09
+- **Closure:** Networking/configuration usage error; issue closed with no project changes.
+
+The origin registered a private IP that the remote proxy could not reach. Set `SRS_DEVICE_IP` to an origin IP reachable by the proxy, and read the documentation or ask SRS AI for deployment guidance.

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -779,6 +779,15 @@ The available evidence is consistent with that old defect, but does not prove it
 
 **Conclusion:** No new bug is confirmed in the current version. Please upgrade to a current SRS release, use `stream=test`, and report back with complete logs and publishing details if the problem remains.
 
+## #4624 [FIXED] Live source removed during publisher activation
+
+- **Issue:** https://github.com/ossrs/srs/issues/4624
+- **Truth Record:** https://github.com/ossrs/srs/issues/4624#issuecomment-5234396855
+- **Verified:** 2026-08-09
+- **Changes:** None
+
+SRS `v6.0-r0` had a live-source cleanup race during publisher activation. It is fixed in SRS `7.0.151+` and `8.0.5+`; affected users should upgrade to a current SRS release.
+
 ## #4628 [USAGE] Kick HLS viewers through the client API
 
 - **Issue:** https://github.com/ossrs/srs/issues/4628

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-09, Merge [#4706](https://github.com/ossrs/srs/pull/4706): RTC2RTMP: Deduplicate AVC and HEVC sequence headers. v8.0.12 (#4706)
 * v8.0, 2026-08-09, Merge [#4704](https://github.com/ossrs/srs/pull/4704): Codex: Fix MP4 DVR timing for repeated DTS samples. v8.0.11 (#4704)
 * v8.0, 2026-08-07, Merge [#4703](https://github.com/ossrs/srs/pull/4703): Codex: Clean up publish state after forward backend failures. v8.0.10 (#4703)
 * v8.0, 2026-08-07, Merge [#4701](https://github.com/ossrs/srs/pull/4701): Codex: Terminate SSRC group SDP lines. v8.0.9 (#4701)

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -1834,6 +1834,7 @@ srs_error_t SrsRtcFrameBuilder::initialize(ISrsRequest *r, SrsAudioCodecId audio
     }
 
     video_codec_ = video_codec;
+    last_video_sequence_header_.clear();
 
     return err;
 }
@@ -1841,6 +1842,7 @@ srs_error_t SrsRtcFrameBuilder::initialize(ISrsRequest *r, SrsAudioCodecId audio
 srs_error_t SrsRtcFrameBuilder::on_publish()
 {
     is_first_audio_ = true;
+    last_video_sequence_header_.clear();
 
     return srs_success;
 }
@@ -2131,6 +2133,13 @@ srs_error_t SrsRtcFrameBuilder::do_packet_sequence_header_avc(SrsRtpPacket *pkt,
         return srs_error_wrap(err, "mux sequence header");
     }
 
+    // WebRTC publishers may repeat unchanged SPS/PPS with every keyframe. If we
+    // emit the same RTMP sequence header again, HLS marks the open segment as a
+    // discontinuity, so only forward the header when its content changes.
+    if (sh == last_video_sequence_header_) {
+        return err;
+    }
+
     // h264 packet to flv packet.
     char *flv = NULL;
     int nb_flv = 0;
@@ -2153,6 +2162,8 @@ srs_error_t SrsRtcFrameBuilder::do_packet_sequence_header_avc(SrsRtpPacket *pkt,
     if ((err = frame_target_->on_frame(&msg)) != srs_success) {
         return err;
     }
+
+    last_video_sequence_header_ = sh;
 
     return err;
 }
@@ -2230,6 +2241,13 @@ srs_error_t SrsRtcFrameBuilder::do_packet_sequence_header_hevc(SrsRtpPacket *pkt
         return srs_error_wrap(err, "mux sequence header");
     }
 
+    // HEVC publishers may likewise repeat unchanged VPS/SPS/PPS with every
+    // keyframe. Suppress the duplicate RTMP sequence header to avoid marking
+    // each open HLS segment as a discontinuity.
+    if (sh == last_video_sequence_header_) {
+        return err;
+    }
+
     char *flv = NULL;
     int nb_flv = 0;
     if ((err = hevc->mux_hevc2flv_enhanced(sh, SrsVideoAvcFrameTypeKeyFrame, SrsVideoHEVCFrameTraitPacketTypeSequenceStart, pkt->get_avsync_time(),
@@ -2250,6 +2268,8 @@ srs_error_t SrsRtcFrameBuilder::do_packet_sequence_header_hevc(SrsRtpPacket *pkt
     if ((err = frame_target_->on_frame(&msg)) != srs_success) {
         return err;
     }
+
+    last_video_sequence_header_ = sh;
 
     return err;
 }

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -600,6 +600,12 @@ SRS_DECLARE_PRIVATE: // clang-format on
     SrsRtpPacket *obs_whip_sps_;
     SrsRtpPacket *obs_whip_pps_;
 
+// clang-format off
+SRS_DECLARE_PRIVATE: // clang-format on
+    // Last video sequence header delivered to the RTMP target. WebRTC publishers
+    // may repeat unchanged parameter sets with every keyframe.
+    std::string last_video_sequence_header_;
+
 public:
     SrsRtcFrameBuilder(ISrsAppFactory *factory, ISrsFrameTarget *target);
     virtual ~SrsRtcFrameBuilder();

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 11
+#define VERSION_REVISION 12
 
 #endif

--- a/trunk/src/utest/srs_utest_ai09.cpp
+++ b/trunk/src/utest/srs_utest_ai09.cpp
@@ -1845,6 +1845,49 @@ SrsRtpPacket *create_raw_payload_packet(SrsAvcNaluType nalu_type, const uint8_t 
     return pkt;
 }
 
+// Reproduce #4695: WebRTC publishers may repeat unchanged AVC SPS/PPS with
+// every keyframe. The RTC-to-RTMP bridge should not emit an identical video
+// sequence header more than once.
+VOID TEST(ReproduceIssue4695, AvcDoesNotEmitIdenticalSequenceHeaderTwice)
+{
+    srs_error_t err;
+
+    MockRtcFrameTarget target;
+    SrsRtcFrameBuilder builder(_srs_app_factory, &target);
+
+    SrsUniquePtr<MockRtcRequest> req(new MockRtcRequest());
+    HELPER_EXPECT_SUCCESS(builder.initialize(req.get(), SrsAudioCodecIdAAC, SrsVideoCodecIdAVC));
+
+    SrsUniquePtr<SrsRtpPacket> first(create_stap_a_packet_with_sps_pps());
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(first.get()));
+    EXPECT_EQ(1, target.on_frame_count_);
+
+    SrsUniquePtr<SrsRtpPacket> repeated(create_stap_a_packet_with_sps_pps());
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(repeated.get()));
+    EXPECT_EQ(1, target.on_frame_count_);
+}
+
+// Reproduce #4695 for HEVC: unchanged VPS/SPS/PPS repeated with a keyframe
+// should not produce another RTC-to-RTMP video sequence header.
+VOID TEST(ReproduceIssue4695, HevcDoesNotEmitIdenticalSequenceHeaderTwice)
+{
+    srs_error_t err;
+
+    MockRtcFrameTarget target;
+    SrsRtcFrameBuilder builder(_srs_app_factory, &target);
+
+    SrsUniquePtr<MockRtcRequest> req(new MockRtcRequest());
+    HELPER_EXPECT_SUCCESS(builder.initialize(req.get(), SrsAudioCodecIdAAC, SrsVideoCodecIdHEVC));
+
+    SrsUniquePtr<SrsRtpPacket> first(create_hevc_stap_packet_with_vps_sps_pps());
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_hevc(first.get()));
+    EXPECT_EQ(1, target.on_frame_count_);
+
+    SrsUniquePtr<SrsRtpPacket> repeated(create_hevc_stap_packet_with_vps_sps_pps());
+    HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_hevc(repeated.get()));
+    EXPECT_EQ(1, target.on_frame_count_);
+}
+
 // Test SrsRtcFrameBuilder::packet_sequence_header_avc with STAP-A payload containing SPS and PPS
 VOID TEST(RtcFrameBuilderTest, PacketSequenceHeaderAvc_STAPAPayload_WithSPSAndPPS)
 {
@@ -2344,16 +2387,17 @@ VOID TEST(RtcFrameBuilderTest, PacketSequenceHeaderAvc_ComprehensiveCoverage)
     // Reset target for next test
     target.reset();
 
-    // Test 3: Process STAP-A with both SPS and PPS (should generate frame immediately)
+    // Test 3: Process STAP-A with the same SPS and PPS. The identical sequence
+    // header was already delivered above, so it should be suppressed.
     SrsUniquePtr<SrsRtpPacket> stap_pkt(create_stap_a_packet_with_sps_pps());
     HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(stap_pkt.get()));
-    EXPECT_EQ(1, target.on_frame_count_);
+    EXPECT_EQ(0, target.on_frame_count_);
 
     // Test 4: Process non-SPS/PPS packet (should do nothing)
     uint8_t idr_data[] = {0x65, 0x88, 0x84, 0x00, 0x10};
     SrsUniquePtr<SrsRtpPacket> idr_pkt(create_raw_payload_packet(SrsAvcNaluTypeIDR, idr_data, sizeof(idr_data)));
     HELPER_EXPECT_SUCCESS(builder.packet_sequence_header_avc(idr_pkt.get()));
-    EXPECT_EQ(1, target.on_frame_count_); // No change
+    EXPECT_EQ(0, target.on_frame_count_); // No change
 }
 
 // Test SrsRtcFrameBuilder::on_rtp with exact sync state transitions


### PR DESCRIPTION
## Summary

- Suppress repeated, byte-identical AVC and HEVC sequence headers in the RTC-to-RTMP bridge.
- Reset sequence-header deduplication state for each publication and retain state only after successful delivery.
- Prevent unchanged WebRTC parameter sets from marking every open HLS segment as discontinuous.
- Add H.264 and H.265 regression tests for repeated parameter sets and update the existing AVC expectation.
- Synchronize the authorized Truth Records for #4623 and #4624.

Fixes #4695.

## Verification

- `make utest -j4`
- `ASAN_OPTIONS=detect_leaks=0 ./objs/srs_utest --gtest_filter='ReproduceIssue4695.*:RtcFrameBuilderTest.PacketSequenceHeaderAvc_ComprehensiveCoverage'` — 3 tests passed
- `ASAN_OPTIONS=detect_leaks=0 ./objs/srs_utest` — 2,244 tests passed
- `git diff --check`

The full WHIP-to-HLS workflow was not reproduced locally.
