### PR TITLE
Codex: Fix duplicated RTMP callback parameters. v8.0.13

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 12
+	return 13
 }
 
 func Version() string {

--- a/skills/srs-develop/references/issues.md
+++ b/skills/srs-develop/references/issues.md
@@ -913,3 +913,42 @@ The fix has not yet been merged or released. Confirmation against a fresh captur
 - **Closure:** Networking/configuration usage error; issue closed with no project changes.
 
 The origin registered a private IP that the remote proxy could not reach. Set `SRS_DEVICE_IP` to an origin IP reachable by the proxy, and read the documentation or ask SRS AI for deployment guidance.
+
+## #4622 [BUG] RTMP callback parameters duplicated when tcUrl is parsed twice
+
+- **Issue:** https://github.com/ossrs/srs/issues/4622
+- **Truth Record:** https://github.com/ossrs/srs/issues/4622#issuecomment-5240365106
+- **Verified:** 2026-08-10
+- **Fix commit:** `778623fa6459a7080847a5ddee83f1f43bd1eb48`
+- **Version:** SRS `8.0.12`
+
+### Confirmed problem
+
+SRS parses an RTMP request during connection and again after identifying the publish stream. When `tcUrl` contains a query parameter, the second parsing could append that parameter again.
+
+For example:
+
+```text
+Input:  ?token=abc
+Output: ?token=abc?token=abc
+```
+
+Parameters supplied only through the publish stream work correctly. The defect occurs when parameters previously extracted from `tcUrl` are reused during the second parsing.
+
+### Root cause
+
+`srs_net_url_parse_tcurl()` uses `stream` and `param` as both inputs and outputs. On the second call, the old implementation rebuilt the URL from:
+
+```text
+tcUrl + identified stream + previously extracted param
+```
+
+It did not recognize that `param` was already contained in `tcUrl`. The HTTP callback merely serialized the resulting duplicated value.
+
+### Conclusion
+
+Issue #4622 is a confirmed SRS bug.
+
+Commit `778623fa6459a7080847a5ddee83f1f43bd1eb48` makes URL reconstruction idempotent, avoids appending parameters already contained in `tcUrl`, preserves legacy RTMP URL compatibility, and adds regression coverage.
+
+All 2,247 ASAN unit tests passed. Merge, release, whole-server callback verification, and reporter confirmation remain pending.

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-10, Merge [#4708](https://github.com/ossrs/srs/pull/4708): Codex: Fix duplicated RTMP HTTP callback parameters. v8.0.13 (#4708)
 * v8.0, 2026-08-09, Merge [#4706](https://github.com/ossrs/srs/pull/4706): RTC2RTMP: Deduplicate AVC and HEVC sequence headers. v8.0.12 (#4706)
 * v8.0, 2026-08-09, Merge [#4704](https://github.com/ossrs/srs/pull/4704): Codex: Fix MP4 DVR timing for repeated DTS samples. v8.0.11 (#4704)
 * v8.0, 2026-08-07, Merge [#4703](https://github.com/ossrs/srs/pull/4703): Codex: Clean up publish state after forward backend failures. v8.0.10 (#4703)

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 12
+#define VERSION_REVISION 13
 
 #endif

--- a/trunk/src/protocol/srs_protocol_utility.cpp
+++ b/trunk/src/protocol/srs_protocol_utility.cpp
@@ -43,42 +43,96 @@ using namespace std;
 #include <srs_protocol_http_stack.hpp>
 #include <srs_protocol_st.hpp>
 
-void srs_net_url_parse_tcurl(string tcUrl, string &schema, string &host, string &vhost, string &app, string &stream, int &port, string &param)
+// Normalize a query parameter so it can be appended directly to a URL.
+// For example, "token=abc" becomes "?token=abc", while "?token=abc" and
+// an empty parameter are returned unchanged.
+static string srs_net_url_normalize_param(const string &param)
 {
-    // Build the full URL with stream and param if provided
-    string fullUrl = tcUrl;
-    fullUrl += stream.empty() ? "/" : (stream.at(0) == '/' ? stream : "/" + stream);
-    fullUrl += param.empty() ? "" : (param.at(0) == '?' ? param : "?" + param);
+    if (param.empty() || param.at(0) == '?') {
+        return param;
+    }
+    return "?" + param;
+}
 
-    // For compatibility, transform legacy ...vhost... format
-    //      rtmp://ip/app...vhost...VHOST/stream
-    // to query parameter format:
-    //      rtmp://ip/app?vhost=VHOST/stream
-    fullUrl = srs_strings_replace(fullUrl, "...vhost...", "?vhost=");
+// Reconstruct the complete URL from the RTMP connect tcUrl, publish stream,
+// and previously discovered parameter. For example:
+//      tcUrl="rtmp://localhost/live", stream="livestream", param="?token=abc"
+// becomes:
+//      rtmp://localhost/live/livestream?token=abc
+//
+// The request may be parsed twice. If tcUrl already contains param, this
+// function does not append it again. If stream repeats the same parameter,
+// the duplicate suffix is removed before rebuilding the URL.
+static string srs_net_url_build_full_url(const string &tcUrl, string stream, const string &param)
+{
+    string normalized_param = srs_net_url_normalize_param(param);
+    bool param_in_tcurl = !normalized_param.empty() && tcUrl.find(normalized_param) != string::npos;
 
-    // Convert legacy RTMP URL format to standard format
-    // Legacy: rtmp://ip/app/app2?vhost=xxx/stream
-    // Standard: rtmp://ip/app/app2/stream?vhost=xxx
-    fullUrl = srs_net_url_convert_legacy_rtmp_url(fullUrl);
-
-    // Remove the _definst_ of FMLE URL.
-    if (fullUrl.find("/_definst_") != string::npos) {
-        fullUrl = srs_strings_replace(fullUrl, "/_definst_", "");
+    // RTMP parses the request once for connect and again after identifying the
+    // publish stream. Do not append parameters derived from tcUrl back to it.
+    if (param_in_tcurl && srs_strings_ends_with(stream, normalized_param)) {
+        stream = stream.substr(0, stream.size() - normalized_param.size());
     }
 
-    // Parse the standard URL using SrsHttpUri.
+    string full_url = tcUrl;
+    full_url += stream.empty() ? "/" : (stream.at(0) == '/' ? stream : "/" + stream);
+    if (!param_in_tcurl) {
+        full_url += normalized_param;
+    }
+    return full_url;
+}
+
+// Convert legacy RTMP and FMLE URL forms to the standard form understood by
+// SrsHttpUri. For example:
+//      rtmp://localhost/live?vhost=example.com/livestream
+// becomes:
+//      rtmp://localhost/live/livestream?vhost=example.com
+// It also converts the old "...vhost..." marker and removes "/_definst_".
+static string srs_net_url_normalize_legacy_url(string url)
+{
+    // Legacy vhost marker: rtmp://ip/app...vhost...VHOST/stream
+    url = srs_strings_replace(url, "...vhost...", "?vhost=");
+
+    // Legacy query placement: rtmp://ip/app/app2?vhost=xxx/stream
+    url = srs_net_url_convert_legacy_rtmp_url(url);
+
+    // FMLE inserts this virtual instance into the application path.
+    if (url.find("/_definst_") != string::npos) {
+        url = srs_strings_replace(url, "/_definst_", "");
+    }
+    return url;
+}
+
+// Parse an RTMP tcUrl together with its publish stream and parameters into the
+// request fields used by SRS. Both stream and param are inputs and outputs.
+// For example, this input:
+//      tcUrl="rtmp://localhost:1935/live"
+//      stream="livestream?token=abc", param=""
+// produces:
+//      schema="rtmp", host="localhost", vhost="localhost", port=1935
+//      app="live", stream="livestream", param="?token=abc"
+//
+// The function first reconstructs and normalizes one complete URL, parses it
+// once with SrsHttpUri, and then extracts the individual request fields.
+void srs_net_url_parse_tcurl(string tcUrl, string &schema, string &host, string &vhost, string &app, string &stream, int &port, string &param)
+{
+    // Reconstruct one complete URL, then normalize legacy RTMP forms before parsing.
+    string full_url = srs_net_url_build_full_url(tcUrl, stream, param);
+    full_url = srs_net_url_normalize_legacy_url(full_url);
+
+    // Parse the normalized URL once, then copy each component to the request.
     SrsHttpUri uri;
     srs_error_t err = srs_success;
-    if ((err = uri.initialize(fullUrl)) != srs_success) {
-        srs_warn("Ignore parse url=%s err %s", fullUrl.c_str(), srs_error_desc(err).c_str());
+    if ((err = uri.initialize(full_url)) != srs_success) {
+        srs_warn("Ignore parse url=%s err %s", full_url.c_str(), srs_error_desc(err).c_str());
         srs_freep(err);
         return;
     }
 
-    // Extract basic URL components
     schema = uri.get_schema();
     host = uri.get_host();
     port = uri.get_port();
+
     SrsPath path;
     stream = path.filepath_base(uri.get_path());
     param = uri.get_query().empty() ? "" : "?" + uri.get_query();
@@ -106,6 +160,12 @@ void srs_net_url_parse_tcurl(string tcUrl, string &schema, string &host, string 
     }
 }
 
+// Move a query placed before the final stream path to the standard URL suffix.
+// Some legacy RTMP clients send:
+//      rtmp://localhost/live?vhost=example.com/livestream
+// This function converts it to:
+//      rtmp://localhost/live/livestream?vhost=example.com
+// A URL whose query is already after the stream path is returned unchanged.
 string srs_net_url_convert_legacy_rtmp_url(const string &url)
 {
     // Check if this is a legacy RTMP URL format: rtmp://ip/app/app2?vhost=xxx/stream

--- a/trunk/src/utest/srs_utest_manual_rtmp.cpp
+++ b/trunk/src/utest/srs_utest_manual_rtmp.cpp
@@ -3785,3 +3785,50 @@ VOID TEST(ProtocolRTMPTest, DiscoveryUrl)
         EXPECT_STREQ("?k=v", param.c_str());
     }
 }
+
+static void srs_utest_issue4622_discover(string tcUrl, string publish_stream, string &app, string &stream, string &param)
+{
+    string schema, host, vhost;
+    int port = 0;
+
+    // SrsRtmpServer::connect_app parses the complete tcUrl first.
+    srs_net_url_parse_tcurl(tcUrl, schema, host, vhost, app, stream, port, param);
+
+    // The RTMP publish name overwrites stream, then stream_service_cycle parses
+    // the request again and, if necessary, recovers the stream name from app.
+    stream = publish_stream;
+    srs_net_url_parse_tcurl(tcUrl, schema, host, vhost, app, stream, port, param);
+    if (stream.empty()) {
+        srs_net_url_guess_stream(app, param, stream);
+    }
+}
+
+VOID TEST(ReproduceIssue4622, ParamInFullTcUrlWithEmptyPublishStream)
+{
+    string app, stream, param;
+    srs_utest_issue4622_discover("rtmp://localhost:1935/live/livestream2?token=tokenGoesHere", "", app, stream, param);
+
+    EXPECT_STREQ("live", app.c_str());
+    EXPECT_STREQ("livestream2", stream.c_str());
+    EXPECT_STREQ("?token=tokenGoesHere", param.c_str());
+}
+
+VOID TEST(ReproduceIssue4622, ParamInAppTcUrlWithNamedPublishStream)
+{
+    string app, stream, param;
+    srs_utest_issue4622_discover("rtmp://localhost:1935/live?token=tokenGoesHere", "livestream2", app, stream, param);
+
+    EXPECT_STREQ("live", app.c_str());
+    EXPECT_STREQ("livestream2", stream.c_str());
+    EXPECT_STREQ("?token=tokenGoesHere", param.c_str());
+}
+
+VOID TEST(ReproduceIssue4622, SameParamInTcUrlAndPublishStream)
+{
+    string app, stream, param;
+    srs_utest_issue4622_discover("rtmp://localhost:1935/live?token=tokenGoesHere", "livestream2?token=tokenGoesHere", app, stream, param);
+
+    EXPECT_STREQ("live", app.c_str());
+    EXPECT_STREQ("livestream2", stream.c_str());
+    EXPECT_STREQ("?token=tokenGoesHere", param.c_str());
+}


### PR DESCRIPTION
## Summary

- Fix duplicated RTMP query parameters in HTTP callbacks when SRS parses the request during connect and again after identifying the publish stream.
- Make RTMP URL reconstruction idempotent when parameters are already present in `tcUrl` or repeated in the publish stream.
- Refactor RTMP URL parsing into focused helpers for parameter normalization, URL reconstruction, and legacy URL normalization.
- Add regression coverage for full-stream `tcUrl`, app-level `tcUrl`, and parameters present in both RTMP fields.

Fixes #4622.

## Root cause

`SrsRtmpServer::connect_app()` first parsed `tcUrl` and stored its query in `req->param_`. After `identify_client()` supplied the publish stream, `SrsRtmpConn::stream_service_cycle()` parsed the request again. The parser appended the previously extracted parameter back to a `tcUrl` that already contained it, producing callback values such as:

```text
?token=abc?token=abc
```

## Fix

Normalize parameters before reconstructing the complete RTMP URL. When `tcUrl` already contains the parameter, do not append it again; when the publish stream repeats the same parameter, remove the duplicate suffix. Legacy RTMP query placement and FMLE `/_definst_` paths are then normalized before parsing with `SrsHttpUri`.
