### PR TITLE
protocol: Guard JSON parser value allocation against integer overflow

### DIFF
--- a/trunk/src/protocol/srs_protocol_json.cpp
+++ b/trunk/src/protocol/srs_protocol_json.cpp
@@ -395,7 +395,7 @@ static int new_value(json_state *state,
                      json_type type)
 {
     json_value *value;
-    int values_size;
+    unsigned long values_size;
 
     if (!state->first_pass) {
         value = *top = *alloc;
@@ -410,6 +410,12 @@ static int new_value(json_state *state,
             if (value->u.array.length == 0)
                 break;
 
+            /* Guard the allocation-size multiplication against overflow, the same way
+             * string/array length is bounded against state->uint_max elsewhere here. */
+            if (value->u.array.length > state->ulong_max / sizeof(json_value *)) {
+                return 0;
+            }
+
             if (!(value->u.array.values = (json_value **)json_alloc(state, value->u.array.length * sizeof(json_value *), 0))) {
                 return 0;
             }
@@ -421,6 +427,11 @@ static int new_value(json_state *state,
 
             if (value->u.object.length == 0)
                 break;
+
+            /* Same overflow guard as above, for the object entries allocation. */
+            if (value->u.object.length > state->ulong_max / sizeof(*value->u.object.values)) {
+                return 0;
+            }
 
             values_size = sizeof(*value->u.object.values) * value->u.object.length;
 


### PR DESCRIPTION
This patch was written by Claude Sonnet 5 (Anthropic); I reviewed the change and the reasoning before submitting.

`new_value()` in `trunk/src/protocol/srs_protocol_json.cpp` (the ported json-parser) computes the allocation size for array and object values as `length * sizeof(entry)` and passes that straight into `json_alloc()` with no overflow check. A JSON document with a very large array or object length can wrap this multiplication, so the parser ends up allocating a much smaller buffer than `length` while still writing `length` entries into it afterwards, a heap buffer overflow.

The object branch has a second, platform-independent instance of the same class of bug: `values_size` was declared as a plain `int`, so the `size_t` product of `sizeof(*value->u.object.values) * value->u.object.length` gets silently truncated on assignment even on 64-bit builds, before it ever reaches `json_alloc()`.

This file already bounds the string and array/object length counters against `state->uint_max` while parsing (see the `e_overflow` checks a bit further down), but that only protects the counters themselves from wrapping during increment, not the later multiplication by `sizeof(...)` at allocation time.

The fix adds the same kind of bound already used in this file (`state->ulong_max`, already computed and already used inside `json_alloc()`) right before each multiplication in `new_value()`, and widens `values_size` to `unsigned long` to match what `json_alloc()` expects. On overflow, `new_value()` now returns 0, which every call site already treats as an allocation failure via `goto e_alloc_failure`, so no new error path had to be introduced.

I compiled `srs_protocol_json.cpp` directly through the project's own Makefile target (`-ansi -Wall -g -O0`, generated via `./configure`) with no warnings, and then ran a full `make` on macOS/arm64, which built the complete `srs` binary successfully with this change included.
