### PR TITLE
HTTP-FLV: Preserve forwarded client IP behind a reverse proxy. v8.0.14

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 13
+	return 14
 }
 
 func Version() string {

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-10, Merge [#4711](https://github.com/ossrs/srs/pull/4711): Codex: Preserve forwarded HTTP-FLV client IP behind a reverse proxy. v8.0.14 (#4711)
 * v8.0, 2026-08-10, Merge [#4708](https://github.com/ossrs/srs/pull/4708): Codex: Fix duplicated RTMP HTTP callback parameters. v8.0.13 (#4708)
 * v8.0, 2026-08-09, Merge [#4706](https://github.com/ossrs/srs/pull/4706): RTC2RTMP: Deduplicate AVC and HEVC sequence headers. v8.0.12 (#4706)
 * v8.0, 2026-08-09, Merge [#4704](https://github.com/ossrs/srs/pull/4704): Codex: Fix MP4 DVR timing for repeated DTS samples. v8.0.11 (#4704)

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -694,8 +694,12 @@ srs_error_t SrsLiveStream::serve_http_impl(ISrsHttpResponseWriter *w, ISrsHttpMe
     // remove the extension of stream if have. for instance, test.flv -> test
     req->stream_ = path.filepath_filename(req->stream_);
 
-    // update client ip
+    // Update client IP, preferring the original address forwarded by a proxy.
     req->ip_ = hc->remote_ip();
+    string original_ip = srs_get_original_ip(r);
+    if (!original_ip.empty()) {
+        req->ip_ = original_ip;
+    }
 
     // We must do stat the client before hooks, because hooks depends on it.
     if ((err = stat_->on_client(_srs_context->get_id().c_str(), req.get(), hc, SrsFlvPlay)) != srs_success) {

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 13
+#define VERSION_REVISION 14
 
 #endif

--- a/trunk/src/utest/srs_utest_workflow_http_conn.cpp
+++ b/trunk/src/utest/srs_utest_workflow_http_conn.cpp
@@ -37,6 +37,19 @@
 #include <srs_utest_manual_mock.hpp>
 #include <srs_utest_manual_service.hpp>
 
+class MockIssue4621Statistic : public MockAppStatistic
+{
+public:
+    std::string client_ip_;
+
+public:
+    virtual srs_error_t on_client(std::string id, ISrsRequest *req, ISrsExpire *conn, SrsRtmpConnType type)
+    {
+        client_ip_ = req->ip_;
+        return srs_error_new(ERROR_SOCKET_READ, "stop after capturing HTTP-FLV client IP");
+    }
+};
+
 // This test is used to verify the basic workflow of the HTTP connection.
 // It's finished with the help of AI, but each step is manually designed
 // and verified. So this is not dominated by AI, but by humanbeing.
@@ -324,4 +337,42 @@ VOID TEST(BasicWorkflowHttpConnTest, ManuallyVerifyForHttpStream)
     cond->wait();
     EXPECT_EQ(ERROR_SOCKET_READ, srs_error_code(r0));
     srs_freep(r0);
+}
+
+VOID TEST(ReproduceIssue4621, PreserveForwardedIpForHttpFlvClient)
+{
+    SrsUniquePtr<MockRequest> mock_request(new MockRequest("test.vhost", "live", "livestream"));
+    SrsUniquePtr<MockBufferCache> mock_cache(new MockBufferCache());
+    SrsUniquePtr<SrsLiveStream> live_stream(new SrsLiveStream(mock_request.get(), mock_cache.get()));
+
+    SrsUniquePtr<MockAppConfig> mock_config(new MockAppConfig());
+    SrsUniquePtr<MockLiveSourceManager> mock_live_sources(new MockLiveSourceManager());
+    SrsUniquePtr<MockIssue4621Statistic> mock_stat(new MockIssue4621Statistic());
+    SrsUniquePtr<MockHttpHooks> mock_hooks(new MockHttpHooks());
+    SrsUniquePtr<MockResponseWriter> mock_writer(new MockResponseWriter());
+    SrsUniquePtr<MockHttpMessage> mock_message(new MockHttpMessage());
+    SrsUniquePtr<SrsHttpMuxEntry> mock_entry(new SrsHttpMuxEntry());
+    MockProtocolReadWriter *mock_io = new MockProtocolReadWriter();
+    SrsUniquePtr<MockHttpServeMux> mock_http_mux(new MockHttpServeMux());
+    SrsUniquePtr<MockConnectionManager> mock_manager(new MockConnectionManager());
+    SrsUniquePtr<SrsHttpxConn> connx(new SrsHttpxConn(mock_manager.get(), mock_io, mock_http_mux.get(), "192.168.1.100", 8080, "", ""));
+    SrsHttpConn *conn = new SrsHttpConn(connx.get(), mock_io, mock_http_mux.get(), "192.168.1.100", 8080);
+
+    live_stream->config_ = mock_config.get();
+    live_stream->live_sources_ = mock_live_sources.get();
+    live_stream->stat_ = mock_stat.get();
+    live_stream->hooks_ = mock_hooks.get();
+    mock_entry->enabled = true;
+    live_stream->entry_ = mock_entry.get();
+
+    connx->config_ = mock_config.get();
+    srs_freep(connx->conn_);
+    connx->conn_ = conn;
+    mock_message->set_connection(conn);
+    mock_message->header()->set("X-Forwarded-For", "203.0.113.42");
+
+    srs_error_t err = live_stream->serve_http(mock_writer.get(), mock_message.get());
+    EXPECT_EQ(ERROR_SOCKET_READ, srs_error_code(err));
+    EXPECT_STREQ("203.0.113.42", mock_stat->client_ip_.c_str());
+    srs_freep(err);
 }


### PR DESCRIPTION
## Summary

Preserve the original HTTP-FLV viewer address supplied by a reverse proxy instead of replacing it with the proxy's TCP peer address.

## Problem

SRS already parses `X-Forwarded-For` and `X-Real-IP`, but `SrsLiveStream::serve_http_impl()` unconditionally replaced the parsed address with `hc->remote_ip()`. As a result, HTTP-FLV client statistics and the SRS console displayed the reverse proxy address rather than the viewer address.

## Changes

- Prefer the original address from `X-Forwarded-For` or `X-Real-IP` for HTTP-FLV viewers.
- Fall back to the TCP peer address when neither header is present.
- Add regression test `ReproduceIssue4621.PreserveForwardedIpForHttpFlvClient`.
