### PR TITLE
Backport #4712: Do not count graceful disconnects as client errors. v7.0.157

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2026-08-10, Merge [#4713](https://github.com/ossrs/srs/pull/4713): Codex: Do not count graceful disconnects as client errors. v7.0.157 (#4713)
 * v7.0, 2026-08-10, Merge [#4708](https://github.com/ossrs/srs/pull/4708): Codex: Fix duplicated RTMP HTTP callback parameters. v7.0.156 (#4708)
 * v7.0, 2026-08-09, Merge [#4706](https://github.com/ossrs/srs/pull/4706): RTC2RTMP: Deduplicate AVC and HEVC sequence headers. v7.0.155 (#4706)
 * v7.0, 2026-08-09, Merge [#4704](https://github.com/ossrs/srs/pull/4704): Codex: Fix MP4 DVR timing for repeated DTS samples. v7.0.154 (#4704)

--- a/trunk/src/app/srs_app_statistic.cpp
+++ b/trunk/src/app/srs_app_statistic.cpp
@@ -14,6 +14,7 @@ using namespace std;
 #include <srs_protocol_conn.hpp>
 
 #include <srs_app_utility.hpp>
+#include <srs_kernel_error.hpp>
 #include <srs_kernel_kbps.hpp>
 #include <srs_kernel_utility.hpp>
 #include <srs_protocol_amf0.hpp>
@@ -493,7 +494,8 @@ void SrsStatistic::on_disconnect(std::string id, srs_error_t err)
     stream->nb_clients_--;
     vhost->nb_clients_--;
 
-    if (srs_error_code(err) != ERROR_SUCCESS) {
+    bool is_graceful_close = srs_is_client_gracefully_close(err) || srs_is_server_gracefully_close(err);
+    if (srs_error_code(err) != ERROR_SUCCESS && !is_graceful_close) {
         nb_errs_++;
     }
 

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 156
+#define VERSION_REVISION 157
 
 #endif

--- a/trunk/src/utest/srs_utest_ai17.cpp
+++ b/trunk/src/utest/srs_utest_ai17.cpp
@@ -3517,9 +3517,13 @@ VOID TEST(StatisticTest, DumpsMetrics)
     stat->kbps_->add_delta(1024 * 100, 1024 * 200); // 100KB recv, 200KB send
     stat->kbps_->sample();
 
-    // Simulate some client disconnections with errors to increment nb_errs_
-    stat->on_disconnect("client1", srs_error_new(ERROR_SOCKET_READ, "test error 1"));
-    stat->on_disconnect("client2", srs_error_new(ERROR_SOCKET_WRITE, "test error 2"));
+    // Simulate some client disconnections with genuine errors to increment nb_errs_.
+    err = srs_error_new(ERROR_SYSTEM_CLIENT_INVALID, "test error 1");
+    stat->on_disconnect("client1", err);
+    srs_freep(err);
+    err = srs_error_new(ERROR_RTMP_HANDSHAKE, "test error 2");
+    stat->on_disconnect("client2", err);
+    srs_freep(err);
 
     // Test dumps_metrics() - major use scenario
     int64_t send_bytes = 0;
@@ -3547,6 +3551,49 @@ VOID TEST(StatisticTest, DumpsMetrics)
 
     // nerrs should be 2 (client1 and client2 disconnected with errors)
     EXPECT_EQ(2, nerrs);
+}
+
+VOID TEST(ReproduceIssue4609, GracefulDisconnectsDoNotIncrementErrors)
+{
+    srs_error_t err = srs_success;
+
+    SrsUniquePtr<SrsStatistic> stat(new SrsStatistic());
+
+    SrsUniquePtr<MockSrsRequest> req(new MockSrsRequest("test.vhost", "live", "livestream"));
+    MockExpire conn;
+
+    int graceful_codes[] = {
+        ERROR_SOCKET_READ,
+        ERROR_SOCKET_READ_FULLY,
+        ERROR_SOCKET_WRITE,
+        ERROR_SRT_IO,
+        ERROR_HTTP_STREAM_EOF,
+    };
+    int nb_graceful_codes = sizeof(graceful_codes) / sizeof(int);
+
+    for (int i = 0; i < nb_graceful_codes; i++) {
+        stringstream ss;
+        ss << "client-" << i;
+        string client_id = ss.str();
+        HELPER_EXPECT_SUCCESS(stat->on_client(client_id, req.get(), &conn, SrsRtmpConnPlay));
+
+        srs_error_t graceful_close = srs_error_new(graceful_codes[i], "gracefully closed");
+        EXPECT_TRUE(srs_is_client_gracefully_close(graceful_close) || srs_is_server_gracefully_close(graceful_close));
+        stat->on_disconnect(client_id, graceful_close);
+        srs_freep(graceful_close);
+    }
+
+    int64_t send_bytes = 0;
+    int64_t recv_bytes = 0;
+    int64_t nstreams = 0;
+    int64_t nclients = 0;
+    int64_t total_nclients = 0;
+    int64_t nerrs = 0;
+    HELPER_EXPECT_SUCCESS(stat->dumps_metrics(send_bytes, recv_bytes, nstreams, nclients, total_nclients, nerrs));
+
+    EXPECT_EQ(0, nclients);
+    EXPECT_EQ(nb_graceful_codes, total_nclients);
+    EXPECT_EQ(0, nerrs);
 }
 
 // Mock ISrsHttpResponseReader implementation for SrsHttpHooks testing


### PR DESCRIPTION
## Summary

- Backport #4712 to SRS 7.0 for issue #4609.
- Prevent graceful client and server disconnects from incrementing the Prometheus `srs_clients_errs_total` counter.
- Add regression coverage for the existing graceful-close classifications while preserving genuine-error coverage.
- Limit the backport to the statistic implementation and its C++ unit tests.

## Root cause

Connection processing uses nonzero internal errors to end its cycle when a peer closes the connection. SRS later recognizes several of these errors as graceful termination, but `SrsStatistic::on_disconnect()` previously counted every nonzero error before that lifecycle classification.

Normal client exits were therefore successful operationally but recorded as failures statistically.

## Fix

Exclude errors recognized by `srs_is_client_gracefully_close()` or `srs_is_server_gracefully_close()` from the client error counter. The regression test covers:

- `ERROR_SOCKET_READ`
- `ERROR_SOCKET_READ_FULLY`
- `ERROR_SOCKET_WRITE`
- `ERROR_SRT_IO`
- `ERROR_HTTP_STREAM_EOF`

Genuine disconnect failures continue to increment `srs_clients_errs_total`.

## Verification

- `make -C trunk utest -j4`
- `ASAN_OPTIONS=detect_leaks=0 ./trunk/objs/srs_utest --gtest_filter='ReproduceIssue4609.GracefulDisconnectsDoNotIncrementErrors:StatisticTest.DumpsMetrics'` — 2 tests passed

## Links

- Original fix PR: https://github.com/ossrs/srs/pull/4712
- Issue: https://github.com/ossrs/srs/issues/4609
- Approved Truth Record: https://github.com/ossrs/srs/issues/4609#issuecomment-5247423361
