### PR TITLE
CI: Modernize GitHub Actions. v8.0.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: "Release"
 on:
   push:
     tags:
-      - v7*
+      - v8*
 
 # For draft, need write permission.
 permissions:
@@ -17,7 +17,7 @@ jobs:
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # The github.ref is, for example, refs/tags/v6.0.145 or refs/tags/v6.0-r8
       # Generate variables like:
       #   SRS_TAG=v6.0-r8
@@ -35,7 +35,7 @@ jobs:
           echo "SRS_VERSION=$SRS_VERSION" >> $GITHUB_ENV
           SRS_MAJOR=$(echo $SRS_TAG| cut -c 2)
           echo "SRS_MAJOR=$SRS_MAJOR" >> $GITHUB_ENV
-          VFILE="trunk/src/core/srs_core_version6.hpp"
+          VFILE="trunk/src/core/srs_core_version8.hpp"
           SRS_X=$(cat $VFILE |grep VERSION_MAJOR |awk '{print $3}')
           SRS_Y=$(cat $VFILE |grep VERSION_MINOR |awk '{print $3}')
           SRS_Z=$(cat $VFILE |grep VERSION_REVISION |awk '{print $3}')
@@ -63,7 +63,7 @@ jobs:
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       ##################################################################################################################
       # Tests
       - name: Build test image
@@ -85,8 +85,7 @@ jobs:
       - envs
     steps:
       - name: Create release draft
-        id: create_draft
-        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -94,9 +93,6 @@ jobs:
           tag: ${{ github.ref }}
           draft: true
           prerelease: true
-    # Map a step output to a job output, see https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
-    outputs:
-      SRS_RELEASE_ID: ${{ steps.create_draft.outputs.id }}
     runs-on: ubuntu-22.04
 
 
@@ -113,11 +109,10 @@ jobs:
           echo "SRS_TAG=${{ needs.envs.outputs.SRS_TAG }}" >> $GITHUB_ENV
           echo "SRS_VERSION=${{ needs.envs.outputs.SRS_VERSION }}" >> $GITHUB_ENV
           echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
-          echo "SRS_RELEASE_ID=${{ needs.draft.outputs.SRS_RELEASE_ID }}" >> $GITHUB_ENV
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       ##################################################################################################################
       # Create source tar for release. Note that it's for OpenWRT package srs-server, so the filename MUST be
       # srs-server-xxx.tar.gz, because the package is named srs-server.
@@ -147,22 +142,13 @@ jobs:
           echo "SRS_PACKAGE_ZIP=$SRS_PACKAGE_ZIP" >> $GITHUB_ENV &&
           echo "SRS_PACKAGE_MD5=$(md5sum $SRS_PACKAGE_ZIP| awk '{print $1}')" >> $GITHUB_ENV
       ##################################################################################################################
-      - name: Upload Release Assets Packager
-        id: upload-release-assets-packager
-        uses: dwenegar/upload-release-assets@5bc3024cf83521df8ebfadf00ad0c4614fd59148 # v1
+      - name: Upload release assets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          release_id: ${{ env.SRS_RELEASE_ID }}
-          assets_path: ${{ env.SRS_PACKAGE_ZIP }}
-      - name: Upload Release Assets Source
-        id: upload-release-assets-source
-        uses: dwenegar/upload-release-assets@5bc3024cf83521df8ebfadf00ad0c4614fd59148 # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          release_id: ${{ env.SRS_RELEASE_ID }}
-          assets_path: ${{ env.SRS_SOURCE_TAR }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$GITHUB_REF" \
+            "$SRS_PACKAGE_ZIP" "$SRS_SOURCE_TAR" \
+            --clobber --repo "$GITHUB_REPOSITORY"
     # Map a step output to a job output, see https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
     outputs:
       SRS_PACKAGE_ZIP: ${{ env.SRS_PACKAGE_ZIP }}
@@ -186,18 +172,18 @@ jobs:
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # See https://github.com/crazy-max/ghaction-docker-buildx#moved-to-docker-organization
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       ##################################################################################################################
       # Create main images for Docker
       - name: Login to docker hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: "${{ secrets.DOCKER_USERNAME }}"
           password: "${{ secrets.DOCKER_PASSWORD }}"
@@ -207,7 +193,7 @@ jobs:
         run: |
           echo "Release ossrs/srs:$SRS_TAG"
           docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 \
-            --output "type=image,push=true" \
+            --output "type=image,push=true,oci-artifact=false" \
             -t ossrs/srs:$SRS_TAG \
             --build-arg SRS_AUTO_PACKAGER=$PACKAGER \
             --build-arg IMAGE=ossrs/srs:ubuntu20 \
@@ -216,7 +202,7 @@ jobs:
       # Docker alias images
       # TODO: FIXME: If stable, please set the latest from 5.0 to 6.0
       - name: Docker alias images for ossrs/srs
-        uses: akhilerm/tag-push-action@85bf542f43f5f2060ef76262a67ee3607cb6db37 # v2.1.0
+        uses: akhilerm/tag-push-action@eadeefebd39db8a47e146115649adae1fce576a6 # v2.3.0
         with:
           src: ossrs/srs:${{ env.SRS_TAG }}
           dst: |
@@ -227,11 +213,13 @@ jobs:
             ossrs/srs:v${{ env.SRS_XYZ }}
     runs-on: ubuntu-22.04
 
-  aliyun-srs:
-    name: aliyun-srs
+  release:
+    name: release
     needs:
-      - envs
       - docker-srs
+      - envs
+      - draft
+      - linux
       - test
     steps:
       ##################################################################################################################
@@ -241,108 +229,6 @@ jobs:
           echo "SRS_VERSION=${{ needs.envs.outputs.SRS_VERSION }}" >> $GITHUB_ENV
           echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
           echo "SRS_XYZ=${{ needs.envs.outputs.SRS_XYZ }}" >> $GITHUB_ENV
-      # Aliyun ACR
-      # TODO: FIXME: If stable, please set the latest from 5.0 to 6.0
-      - name: Login aliyun hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
-        with:
-          registry: registry.cn-hangzhou.aliyuncs.com
-          username: "${{ secrets.ACR_USERNAME }}"
-          password: "${{ secrets.ACR_PASSWORD }}"
-      - name: Push to Aliyun registry for ossrs/srs
-        uses: akhilerm/tag-push-action@85bf542f43f5f2060ef76262a67ee3607cb6db37 # v2.1.0
-        with:
-          src: ossrs/srs:${{ env.SRS_TAG }}
-          dst: |
-            registry.cn-hangzhou.aliyuncs.com/ossrs/srs:${{ env.SRS_TAG }}
-            registry.cn-hangzhou.aliyuncs.com/ossrs/srs:${{ env.SRS_VERSION }}
-            registry.cn-hangzhou.aliyuncs.com/ossrs/srs:${{ env.SRS_MAJOR }}
-            registry.cn-hangzhou.aliyuncs.com/ossrs/srs:v${{ env.SRS_MAJOR }}
-            registry.cn-hangzhou.aliyuncs.com/ossrs/srs:${{ env.SRS_XYZ }}
-            registry.cn-hangzhou.aliyuncs.com/ossrs/srs:v${{ env.SRS_XYZ }}
-    runs-on: ubuntu-22.04
-
-  update:
-    name: update
-    needs:
-      - aliyun-srs
-      - envs
-    steps:
-      ##################################################################################################################
-      - name: Covert output to env
-        run: |
-          echo "SRS_TAG=${{ needs.envs.outputs.SRS_TAG }}" >> $GITHUB_ENV
-          echo "SRS_VERSION=${{ needs.envs.outputs.SRS_VERSION }}" >> $GITHUB_ENV
-          echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
-      ##################################################################################################################
-      # Git checkout
-      - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      ##################################################################################################################
-      # Generate variables like:
-      #   SRS_LH_OSSRS_NET=1.2.3.4
-      - name: Build variables for lh.ossrs.net
-        run: |
-          SRS_LH_OSSRS_NET=$(dig +short lh.ossrs.net)
-          SRS_D_OSSRS_NET=$(dig +short d.ossrs.net)
-          echo "SRS_LH_OSSRS_NET=$SRS_LH_OSSRS_NET" >> $GITHUB_ENV
-          echo "SRS_D_OSSRS_NET=$SRS_D_OSSRS_NET" >> $GITHUB_ENV
-      - name: Release to lh.ossrs.net
-        uses: appleboy/ssh-action@c1965ddd2563844fddc1ec01cafc798365706143 # master
-        with:
-          host: ${{ env.SRS_LH_OSSRS_NET }}
-          username: root
-          key: ${{ secrets.DIGITALOCEAN_SSHKEY }}
-          port: 22
-          envs: SRS_MAJOR
-          timeout: 60s
-          command_timeout: 30m
-          script: |
-            docker pull registry.cn-hangzhou.aliyuncs.com/ossrs/srs:$SRS_MAJOR
-            docker rm -f srs-dev
-            #
-            # Cleanup old docker images.
-            for image in $(docker images |grep '<none>' |awk '{print $3}'); do
-              docker rmi -f $image
-              echo "Remove image $image, r0=$?"
-            done
-      - name: Release to d.ossrs.net
-        uses: appleboy/ssh-action@c1965ddd2563844fddc1ec01cafc798365706143 # master
-        with:
-          host: ${{ env.SRS_D_OSSRS_NET }}
-          username: root
-          key: ${{ secrets.DIGITALOCEAN_SSHKEY }}
-          port: 22
-          envs: SRS_MAJOR
-          timeout: 60s
-          command_timeout: 30m
-          script: |
-            docker pull ossrs/srs:$SRS_MAJOR
-            docker rm -f srs-dev
-            #
-            # Cleanup old docker images.
-            for image in $(docker images |grep '<none>' |awk '{print $3}'); do
-              docker rmi -f $image
-              echo "Remove image $image, r0=$?"
-            done
-    runs-on: ubuntu-22.04
-
-  release:
-    name: release
-    needs:
-      - update
-      - envs
-      - draft
-      - linux
-    steps:
-      ##################################################################################################################
-      - name: Covert output to env
-        run: |
-          echo "SRS_TAG=${{ needs.envs.outputs.SRS_TAG }}" >> $GITHUB_ENV
-          echo "SRS_VERSION=${{ needs.envs.outputs.SRS_VERSION }}" >> $GITHUB_ENV
-          echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
-          echo "SRS_XYZ=${{ needs.envs.outputs.SRS_XYZ }}" >> $GITHUB_ENV
-          echo "SRS_RELEASE_ID=${{ needs.draft.outputs.SRS_RELEASE_ID }}" >> $GITHUB_ENV
           echo "SRS_PACKAGE_ZIP=${{ needs.linux.outputs.SRS_PACKAGE_ZIP }}" >> $GITHUB_ENV
           echo "SRS_PACKAGE_MD5=${{ needs.linux.outputs.SRS_PACKAGE_MD5 }}" >> $GITHUB_ENV
           echo "SRS_SOURCE_TAR=${{ needs.linux.outputs.SRS_SOURCE_TAR }}" >> $GITHUB_ENV
@@ -350,13 +236,13 @@ jobs:
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # Create release.
       # TODO: FIXME: Refine the release when 6.0 released
       # TODO: FIXME: Change prerelease to false and makeLatest to true when 6.0 released
       - name: Update release
         id: update_release
-        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -373,29 +259,13 @@ jobs:
             * Source: ${{ env.SRS_SOURCE_MD5 }} [${{ env.SRS_SOURCE_TAR }}](https://github.com/ossrs/srs/releases/download/${{ env.SRS_TAG }}/${{ env.SRS_SOURCE_TAR }})
             * Binary: ${{ env.SRS_PACKAGE_MD5 }} [${{ env.SRS_PACKAGE_ZIP }}](https://github.com/ossrs/srs/releases/download/${{ env.SRS_TAG }}/${{ env.SRS_PACKAGE_ZIP }})
 
-            ## Resource Mirror: gitee.com
-            * Source: ${{ env.SRS_SOURCE_MD5 }} [${{ env.SRS_SOURCE_TAR }}](https://gitee.com/ossrs/srs/releases/download/${{ env.SRS_TAG }}/${{ env.SRS_SOURCE_TAR }})
-            * Binary: ${{ env.SRS_PACKAGE_MD5 }} [${{ env.SRS_PACKAGE_ZIP }}](https://gitee.com/ossrs/srs/releases/download/${{ env.SRS_TAG }}/${{ env.SRS_PACKAGE_ZIP }})
-            
             ## Docker
             * [docker pull ossrs/srs:${{ env.SRS_MAJOR }}](https://ossrs.io/lts/en-us/docs/v7/doc/getting-started)
             * [docker pull ossrs/srs:${{ env.SRS_TAG }}](https://ossrs.io/lts/en-us/docs/v7/doc/getting-started)
             * [docker pull ossrs/srs:${{ env.SRS_XYZ }}](https://ossrs.io/lts/en-us/docs/v7/doc/getting-started)
             
-            ## Docker Mirror: aliyun.com
-            * [docker pull registry.cn-hangzhou.aliyuncs.com/ossrs/srs:${{ env.SRS_MAJOR }}](https://ossrs.net/lts/zh-cn/docs/v7/doc/getting-started)
-            * [docker pull registry.cn-hangzhou.aliyuncs.com/ossrs/srs:${{ env.SRS_TAG }}](https://ossrs.net/lts/zh-cn/docs/v7/doc/getting-started)
-            * [docker pull registry.cn-hangzhou.aliyuncs.com/ossrs/srs:${{ env.SRS_XYZ }}](https://ossrs.net/lts/zh-cn/docs/v7/doc/getting-started)
-            
-            ## Doc: ossrs.io
-            * [Getting Started](https://ossrs.io/lts/en-us/docs/v7/doc/getting-started)
-            * [Wiki home](https://ossrs.io/lts/en-us/docs/v7/doc/introduction)
-            * [FAQ](https://ossrs.io/lts/en-us/faq), [Features](https://github.com/ossrs/srs/blob/${{ github.sha }}/trunk/doc/Features.md#features) or [ChangeLogs](https://github.com/ossrs/srs/blob/${{ github.sha }}/trunk/doc/CHANGELOG.md#changelog)
-            
-            ## Doc: ossrs.net
-            * [快速入门](https://ossrs.net/lts/zh-cn/docs/v7/doc/getting-started)
-            * [中文Wiki首页](https://ossrs.net/lts/zh-cn/docs/v7/doc/introduction)
-            * [中文FAQ](https://ossrs.net/lts/zh-cn/faq), [功能列表](https://github.com/ossrs/srs/blob/${{ github.sha }}/trunk/doc/Features.md#features) 或 [修订历史](https://github.com/ossrs/srs/blob/${{ github.sha }}/trunk/doc/CHANGELOG.md#changelog)
+            ## Usage
+            * [AI Guide](https://github.com/ossrs/srs#ai-agent)
           draft: false
           prerelease: true
           makeLatest: false
@@ -404,7 +274,6 @@ jobs:
   release-done:
     runs-on: ubuntu-22.04
     needs:
-      - update
       - release
     steps:
       - run: echo 'All done'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     name: build-centos7
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # Build for CentOS 7
       - name: Build on CentOS7, baseline
         run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target centos7-baseline .
@@ -44,7 +44,7 @@ jobs:
     name: build-ubuntu16
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # Build for Ubuntu16
       - name: Build on Ubuntu16, baseline
         run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target ubuntu16-baseline .
@@ -56,7 +56,7 @@ jobs:
     name: build-ubuntu18
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # Build for Ubuntu18
       - name: Build on Ubuntu18, baseline
         run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target ubuntu18-baseline .
@@ -68,7 +68,7 @@ jobs:
     name: build-ubuntu20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # Build for Ubuntu20
       - name: Build on Ubuntu20, default
         run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target ubuntu20-default .
@@ -82,7 +82,7 @@ jobs:
     name: build-cross-arm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Cross Build for ARMv7 on Ubuntu16
         run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target ubuntu16-cache-cross-armv7 .
       - name: Cross Build for ARMv7 on Ubuntu20
@@ -93,7 +93,7 @@ jobs:
     name: build-cross-aarch64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Cross Build for AARCH64 on Ubuntu16
         run: DOCKER_BUILDKIT=1 docker build -f trunk/Dockerfile.builds --target ubuntu16-cache-cross-aarch64 .
       - name: Cross Build for AARCH64 on Ubuntu20
@@ -104,13 +104,13 @@ jobs:
     name: utest-regression-blackbox-test
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # Tests
       - name: Build test image
         run: docker build --tag srs:test --build-arg MAKEARGS='-j2' -f trunk/Dockerfile.test .
       # For blackbox-test
       - name: Run SRS blackbox-test
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 60
           max_attempts: 3
@@ -137,7 +137,7 @@ jobs:
     name: coverage
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # Tests
       - name: Build coverage image
         run: docker build --tag srs:cov --build-arg MAKEARGS='-j2' -f trunk/Dockerfile.cov .
@@ -168,14 +168,14 @@ jobs:
     name: multiple-arch-armv7
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # See https://github.com/crazy-max/ghaction-docker-buildx#moved-to-docker-organization
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build multiple archs image
         run: |
           docker buildx build --platform linux/arm/v7 \
@@ -190,14 +190,14 @@ jobs:
     name: multiple-arch-aarch64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # See https://github.com/crazy-max/ghaction-docker-buildx#moved-to-docker-organization
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build multiple archs image
         run: |
           docker buildx build --platform linux/arm64/v8 \
@@ -212,14 +212,14 @@ jobs:
     name: multiple-arch-amd64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # See https://github.com/crazy-max/ghaction-docker-buildx#moved-to-docker-organization
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build multiple archs image
         run: |
           docker buildx build --platform linux/amd64 \
@@ -245,4 +245,3 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - run: echo 'All done'
-

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ To learn more about RTMP, HLS, HTTP-FLV, SRT, MPEG-DASH, WebRTC protocols, clust
 HTTP API, DVR, and transcoding, please check the documents in [English](https://ossrs.io) 
 or [Chinese](https://ossrs.net).
 
+<a name="ai-agent"></a>
+
+## AI Agent
+
 I recommend to use AI to understand and maintain your SRS, please follow the wiki
 [AI Agent](skills/internal-docs-for-srs/references/cpp-docs/doc/getting-started-ai.md) for details.
 
@@ -107,6 +111,8 @@ distributed under their [licenses](https://ossrs.io/lts/en-us/license).
 
 ## Releases
 
+* 2026-08-12, [Release v7.0-d0](https://github.com/ossrs/srs/releases/tag/v7.0-d0), v7.0-d0, 7.0 dev0, v7.0.157, 313784 lines.
+* 2026-08-12, [Release v6.0-r1](https://github.com/ossrs/srs/releases/tag/v6.0-r1), v6.0-r1, 6.0 release1, v6.0.191, 171396 lines.
 * 2025-12-03, [Release v6.0-r0](https://github.com/ossrs/srs/releases/tag/v6.0-r0), v6.0-r0, 6.0 release0, v6.0.184, 170962 lines.
 * 2025-11-03, [Release v6.0-b3](https://github.com/ossrs/srs/releases/tag/v6.0-b3), v6.0-b3, 6.0 beta3, v6.0.183, 170957 lines.
 * 2025-10-16, [Release v6.0-b2](https://github.com/ossrs/srs/releases/tag/v6.0-b2), v6.0-b2, 6.0 beta2, v6.0.181, 170948 lines.
@@ -189,4 +195,3 @@ Please read [MIRRORS](trunk/doc/Resources.md#mirrors).
 ## Dockers
 
 Please read [DOCKERS](trunk/doc/Dockers.md).
-

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 16
+	return 17
 }
 
 func Version() string {

--- a/skills/srs-develop/references/develop-code.md
+++ b/skills/srs-develop/references/develop-code.md
@@ -14,7 +14,6 @@
 | **SRS player** | → [SRS Player](#srs-player) | ✅ Supported |
 | **Dev Docker** | → [Dev Docker](#dev-docker) | ✅ Supported |
 | **Oryx** | → [Oryx](#oryx) | ✅ Supported |
-| **Project or skill documentation** | → [Project or Skill Documentation](#project-or-skill-documentation) | ✅ Supported |
 | **Origin server** | → [Origin Server](#origin-server) | ❌ Not yet supported |
 | **Edge server** | → [Edge Server](#edge-server) | ❌ Not yet supported |
 

--- a/skills/srs-develop/references/srs-issues.md
+++ b/skills/srs-develop/references/srs-issues.md
@@ -1079,3 +1079,17 @@ The confirmed bug is fixed and merged in SRS 8.0.14. Only trusted reverse proxie
 The supplied MPEG-TS contains H.264, AAC LATM (`0x11`), and SCTE-35 (`0x86`). Current SRS produced H.264-only RTMP in reproduction: it has no SCTE-35 mapping and supports ADTS AAC (`0x0f`), not the sample's LATM audio. The original total-output failure and related 100% CPU claim were not reproduced, although unsupported repeated PMT entries caused warning and parsing overhead.
 
 SRS will not implement or maintain SCTE-35 support or forwarding through RTMP. Preserve SCTE-35 in an MPEG-TS/SRT workflow or process/remove it externally; convert LATM to ADTS AAC when RTMP audio is required.
+
+## #4410 [LIMITATION] HEVC snapshot requires FFmpeg 8
+
+- **Issue:** https://github.com/ossrs/srs/issues/4410
+- **Truth Record:** https://github.com/ossrs/srs/issues/4410#issuecomment-5261035872
+- **Verified:** 2026-08-11
+- **Toolchain branch/commit:** `ossrs/dev-docker:ubuntu20` at `75327dc6cd4d9c517e65a51798195e8053c16a98`
+- **FFmpeg:** 8.1.2 with NASM 2.16.03
+- **Environment:** GitHub Actions Ubuntu 22.04; linux/amd64, linux/arm64, and linux/arm/v7
+- **Closure:** Toolchain updated and verified; issue closed as completed
+
+SRS 6.0.166 packaged FFmpeg 5.0.2, which could not correctly recognize the HEVC signaling in the reporter's OBS RTMP/FLV stream. `iformat hevc` was also incorrect because the input remained FLV-wrapped; snapshot transcoding should use `iformat flv`.
+
+The Ubuntu 20 toolchain now selects FFmpeg 8.1.2 by default. Its multi-architecture release workflow passed, including Enhanced FLV HEVC encode, probe, and snapshot decode verification on amd64 and arm64; armv7 retains native HEVC decoding without the libx265 encoding test. The SRS Dockerfile copies this default FFmpeg into `objs/ffmpeg/bin/ffmpeg`, so newly built SRS images receive the fix. Previously published images such as `6.0.166` remain affected unless rebuilt.

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-12, Merge [#4715](https://github.com/ossrs/srs/pull/4715): CI: Modernize GitHub Actions for SRS 8.0. v8.0.17 (#4715)
 * v8.0, 2026-08-11, Merge [#4714](https://github.com/ossrs/srs/pull/4714): Skills: Expand development workflows and add Oryx support. v8.0.16 (#4714)
 * v8.0, 2026-08-10, Merge [#4712](https://github.com/ossrs/srs/pull/4712): Codex: Fix graceful disconnect client error metrics and update issue records. v8.0.15 (#4712)
 * v8.0, 2026-08-10, Merge [#4711](https://github.com/ossrs/srs/pull/4711): Codex: Preserve forwarded HTTP-FLV client IP behind a reverse proxy. v8.0.14 (#4711)

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 16
+#define VERSION_REVISION 17
 
 #endif


### PR DESCRIPTION
## Summary

- Upgrade pinned GitHub, Docker, release, and retry actions.
- Upload release assets with the GitHub CLI and configure releases for SRS 8.0.
- Remove Aliyun image publishing and the legacy server-update jobs while preserving test and Docker release gating.
- Add the README AI Agent section and list the v7.0-d0 and v6.0-r1 releases.
- Record the verified resolution and FFmpeg 8 limitation for #4410, and remove the unsupported documentation entry from the development router.
