### PR TITLE
Codex: Correct RTC frame statistics. v8.0.19

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 18
+	return 19
 }
 
 func Version() string {

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-12, Merge [#4717](https://github.com/ossrs/srs/pull/4717): Codex: Correct RTC frame statistics. v8.0.19 (#4717)
 * v8.0, 2026-08-12, Merge [#4716](https://github.com/ossrs/srs/pull/4716): JSON: Update vendored json-parser library. v8.0.18 (#4716)
 * v8.0, 2026-08-12, Merge [#4715](https://github.com/ossrs/srs/pull/4715): CI: Modernize GitHub Actions for SRS 8.0. v8.0.17 (#4715)
 * v8.0, 2026-08-11, Merge [#4714](https://github.com/ossrs/srs/pull/4714): Skills: Expand development workflows and add Oryx support. v8.0.16 (#4714)

--- a/trunk/src/app/srs_app_rtc_conn.cpp
+++ b/trunk/src/app/srs_app_rtc_conn.cpp
@@ -1686,8 +1686,11 @@ srs_error_t SrsRtcPublishStream::do_on_rtp_plaintext(SrsRtpPacket *&pkt, SrsBuff
         srs_freep(err);
     }
 
-    // Update RTP packet statistics.
-    update_rtp_packet_stats(is_audio);
+    // Update media-frame statistics. The receive track owns the decision because
+    // it knows which SSRC is primary and how its media marks a frame boundary.
+    if (track->is_media_frame(pkt)) {
+        update_rtp_frame_stats(is_audio);
+    }
 
     // Consume packet by track.
     if ((err = track->on_rtp(source_, pkt)) != srs_success) {
@@ -1709,18 +1712,18 @@ srs_error_t SrsRtcPublishStream::do_on_rtp_plaintext(SrsRtpPacket *&pkt, SrsBuff
     return err;
 }
 
-void SrsRtcPublishStream::update_rtp_packet_stats(bool is_audio)
+void SrsRtcPublishStream::update_rtp_frame_stats(bool is_audio)
 {
     srs_error_t err = srs_success;
 
-    // Count RTP packets for statistics.
+    // Count media-frame observations accepted by the receive track.
     if (is_audio) {
         ++nn_audio_frames_;
     } else {
         ++nn_video_frames_;
     }
 
-    // Update the stat for video frames, counting RTP packets as frames.
+    // Update the stat for video frames periodically.
     if (nn_video_frames_ > 288) {
         if ((err = stat_->on_video_frames(req_, nn_video_frames_)) != srs_success) {
             srs_warn("RTC: stat video frames err %s", srs_error_desc(err).c_str());

--- a/trunk/src/app/srs_app_rtc_conn.hpp
+++ b/trunk/src/app/srs_app_rtc_conn.hpp
@@ -622,7 +622,7 @@ public:
 // clang-format off
 SRS_DECLARE_PRIVATE: // clang-format on
     srs_error_t do_on_rtp_plaintext(SrsRtpPacket *&pkt, SrsBuffer *buf);
-    void update_rtp_packet_stats(bool is_audio);
+    void update_rtp_frame_stats(bool is_audio);
 
 public:
     srs_error_t check_send_nacks();

--- a/trunk/src/app/srs_app_rtc_source.cpp
+++ b/trunk/src/app/srs_app_rtc_source.cpp
@@ -3199,6 +3199,16 @@ uint32_t SrsRtcRecvTrack::get_ssrc()
     return track_desc_->ssrc_;
 }
 
+bool SrsRtcRecvTrack::is_primary_rtp(SrsRtpPacket *pkt)
+{
+    return pkt && pkt->header_.get_ssrc() == track_desc_->ssrc_;
+}
+
+bool SrsRtcRecvTrack::is_media_frame(SrsRtpPacket *pkt)
+{
+    return is_primary_rtp(pkt);
+}
+
 void SrsRtcRecvTrack::update_rtt(int rtt)
 {
     nack_receiver_->update_rtt(rtt);
@@ -3374,6 +3384,13 @@ SrsRtcAudioRecvTrack::~SrsRtcAudioRecvTrack()
 {
 }
 
+bool SrsRtcAudioRecvTrack::is_media_frame(SrsRtpPacket *pkt)
+{
+    // Audio statistics historically count one frame observation per primary RTP
+    // packet. RTX and FEC packets belong to the track but are transport overhead.
+    return is_primary_rtp(pkt);
+}
+
 void SrsRtcAudioRecvTrack::on_before_decode_payload(SrsRtpPacket *pkt, SrsBuffer *buf, ISrsRtpPayloader **ppayload, SrsRtpPacketPayloadType *ppt)
 {
     // No payload, ignore.
@@ -3420,6 +3437,13 @@ SrsRtcVideoRecvTrack::SrsRtcVideoRecvTrack(ISrsRtcPacketReceiver *receiver, SrsR
 
 SrsRtcVideoRecvTrack::~SrsRtcVideoRecvTrack()
 {
+}
+
+bool SrsRtcVideoRecvTrack::is_media_frame(SrsRtpPacket *pkt)
+{
+    // The marker bit identifies the final RTP packet of a video frame. Only the
+    // primary stream describes source frames; RTX and FEC packets do not.
+    return is_primary_rtp(pkt) && pkt->header_.get_marker();
 }
 
 void SrsRtcVideoRecvTrack::on_before_decode_payload(SrsRtpPacket *pkt, SrsBuffer *buf, ISrsRtpPayloader **ppayload, SrsRtpPacketPayloadType *ppt)

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -914,11 +914,15 @@ public:
     srs_error_t on_nack(SrsRtpPacket **ppkt);
 
 public:
+    // Whether this RTP packet represents one media-frame observation for
+    // statistics. Auxiliary transport packets such as RTX and FEC are excluded.
+    virtual bool is_media_frame(SrsRtpPacket *pkt);
     virtual srs_error_t on_rtp(SrsSharedPtr<SrsRtcSource> &source, SrsRtpPacket *pkt) = 0;
     virtual srs_error_t check_send_nacks() = 0;
 
 // clang-format off
 SRS_DECLARE_PROTECTED: // clang-format on
+    bool is_primary_rtp(SrsRtpPacket *pkt);
     virtual srs_error_t do_check_send_nacks(uint32_t &timeout_nacks);
 };
 
@@ -932,6 +936,7 @@ public:
     virtual void on_before_decode_payload(SrsRtpPacket *pkt, SrsBuffer *buf, ISrsRtpPayloader **ppayload, SrsRtpPacketPayloadType *ppt);
 
 public:
+    virtual bool is_media_frame(SrsRtpPacket *pkt);
     virtual srs_error_t on_rtp(SrsSharedPtr<SrsRtcSource> &source, SrsRtpPacket *pkt);
     virtual srs_error_t check_send_nacks();
 };
@@ -946,6 +951,7 @@ public:
     virtual void on_before_decode_payload(SrsRtpPacket *pkt, SrsBuffer *buf, ISrsRtpPayloader **ppayload, SrsRtpPacketPayloadType *ppt);
 
 public:
+    virtual bool is_media_frame(SrsRtpPacket *pkt);
     virtual srs_error_t on_rtp(SrsSharedPtr<SrsRtcSource> &source, SrsRtpPacket *pkt);
     virtual srs_error_t check_send_nacks();
 };

--- a/trunk/src/app/srs_app_statistic.cpp
+++ b/trunk/src/app/srs_app_statistic.cpp
@@ -81,6 +81,7 @@ SrsStatisticStream::SrsStatisticStream()
     id_ = srs_generate_stat_vid();
     vhost_ = NULL;
     active_ = false;
+    create_ = srs_time_now_cached();
 
     has_video_ = false;
     vcodec_ = SrsVideoCodecIdReserved;
@@ -120,6 +121,7 @@ srs_error_t SrsStatisticStream::dumps(SrsJsonObject *obj)
     obj->set("tcUrl", SrsJsonAny::str(tcUrl_.c_str()));
     obj->set("url", SrsJsonAny::str(url_.c_str()));
     obj->set("live_ms", SrsJsonAny::integer(srsu2ms(srs_time_now_cached())));
+    obj->set("alive", SrsJsonAny::number(srsu2ms(srs_time_now_cached() - create_) / 1000.0));
     obj->set("clients", SrsJsonAny::integer(nb_clients_));
     obj->set("frames", SrsJsonAny::integer(video_frames_->sugar_ + audio_frames_->sugar_));
     obj->set("audio_frames", SrsJsonAny::integer(audio_frames_->sugar_));

--- a/trunk/src/app/srs_app_statistic.hpp
+++ b/trunk/src/app/srs_app_statistic.hpp
@@ -59,6 +59,8 @@ public:
     // The publisher connection id.
     std::string publisher_id_;
     int nb_clients_;
+    // The time when this stream statistic was created.
+    srs_utime_t create_;
 
 public:
     // The stream total kbps.

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 18
+#define VERSION_REVISION 19
 
 #endif

--- a/trunk/src/utest/srs_utest_ai17.cpp
+++ b/trunk/src/utest/srs_utest_ai17.cpp
@@ -3315,6 +3315,31 @@ VOID TEST(StatisticTest, AudioSampleRateAAC48000Hz)
     EXPECT_EQ(48000, sample_rate_any->to_integer());
 }
 
+// Verify that stream statistics expose their age in seconds, matching the
+// floating-point "alive" field provided by the clients API.
+VOID TEST(StatisticTest, StreamAliveDuration)
+{
+    srs_error_t err = srs_success;
+
+    SrsUniquePtr<SrsStatistic> stat(new SrsStatistic());
+    SrsUniquePtr<MockSrsRequest> req(new MockSrsRequest("test.vhost", "live", "stream-alive"));
+
+    stat->on_stream_publish(req.get(), "publisher-alive");
+    SrsStatisticStream *stream = stat->find_stream_by_url(req->get_stream_url());
+    ASSERT_TRUE(stream != NULL);
+
+    // Use the cached clock to make this test deterministic without sleeping.
+    stream->create_ = srs_time_now_cached() - 2345 * SRS_UTIME_MILLISECONDS;
+
+    SrsUniquePtr<SrsJsonObject> obj(SrsJsonAny::object());
+    HELPER_EXPECT_SUCCESS(stream->dumps(obj.get()));
+
+    SrsJsonAny *alive = obj->get_property("alive");
+    ASSERT_TRUE(alive != NULL);
+    EXPECT_TRUE(alive->is_number());
+    EXPECT_DOUBLE_EQ(2.345, alive->to_number());
+}
+
 // Test SrsStatistic dumps methods: dumps_streams, dumps_clients, and dumps_hints_kv
 // This test covers the major use scenario for dumping statistics to JSON and hints
 VOID TEST(StatisticTest, DumpsStreamsClientsAndHints)

--- a/trunk/src/utest/srs_utest_workflow_rtc_publishstream.cpp
+++ b/trunk/src/utest/srs_utest_workflow_rtc_publishstream.cpp
@@ -29,6 +29,62 @@
 #include <srs_utest_ai11.hpp>
 #include <srs_utest_manual_mock.hpp>
 
+namespace
+{
+
+class MockRtcFrameStatistic : public MockAppStatistic
+{
+public:
+    int video_frame_calls_;
+    int audio_frame_calls_;
+    int video_frames_;
+    int audio_frames_;
+
+public:
+    MockRtcFrameStatistic()
+    {
+        video_frame_calls_ = 0;
+        audio_frame_calls_ = 0;
+        video_frames_ = 0;
+        audio_frames_ = 0;
+    }
+
+    virtual srs_error_t on_video_frames(ISrsRequest *req, int nb_frames)
+    {
+        ++video_frame_calls_;
+        video_frames_ += nb_frames;
+        return srs_success;
+    }
+
+    virtual srs_error_t on_audio_frames(ISrsRequest *req, int nb_frames)
+    {
+        ++audio_frame_calls_;
+        audio_frames_ += nb_frames;
+        return srs_success;
+    }
+};
+
+srs_error_t send_rtp_packet(SrsRtcPublishStream *publish_stream, uint32_t ssrc, uint16_t sequence, uint32_t timestamp, uint8_t payload_type, bool marker)
+{
+    SrsRtpPacket pkt;
+    pkt.header_.set_ssrc(ssrc);
+    pkt.header_.set_sequence(sequence);
+    pkt.header_.set_timestamp(timestamp);
+    pkt.header_.set_payload_type(payload_type);
+    pkt.header_.set_marker(marker);
+
+    char data[1500];
+    SrsBuffer buf(data, sizeof(data));
+    srs_error_t err = pkt.encode(&buf);
+    if (err != srs_success) {
+        return srs_error_wrap(err, "encode RTP packet");
+    }
+
+    return publish_stream->on_rtp_plaintext(data, buf.pos());
+}
+
+} // namespace
+
 // This test is used to verify the basic workflow of the RTC publish stream.
 // It's finished with the help of AI, but each step is manually designed
 // and verified. So this is not dominated by AI, but by humanbeing.
@@ -104,5 +160,111 @@ VOID TEST(BasicWorkflowRtcPublishStreamTest, ManuallyVerify)
 
     // Before destroying publish_stream, set format_ to NULL to prevent double-free
     // since mock_format is a stack variable
+    publish_stream->format_ = NULL;
+}
+
+// Verify frame statistics from the RTP behavior exposed by a publish stream:
+// audio uses primary RTP packets, while video uses the marker that closes a frame.
+// Auxiliary RTX and FEC streams do not represent additional media frames.
+VOID TEST(BasicWorkflowRtcPublishStreamTest, CountPrimaryRtcMediaFrames)
+{
+    srs_error_t err;
+
+    MockAppConfig mock_config;
+    MockRtcSourceManager mock_rtc_sources;
+    MockRtcFrameStatistic mock_stat;
+    MockRtcAsyncCallRequest mock_request("test.vhost", "live", "frame-counting");
+    MockRtcAsyncTaskExecutor mock_exec;
+    MockExpire mock_expire;
+    MockRtcPacketReceiver mock_receiver;
+    MockRtcTrackDescriptionFactory track_factory;
+    MockRtcFormat mock_format;
+    MockCircuitBreaker mock_circuit_breaker;
+    SrsContextId cid;
+    cid.set_value("test-frame-counting-cid");
+
+    // Keep transport recovery outside this behavioral test. Duplicate primary
+    // packets are intentionally accepted as additional observations below.
+    mock_config.set_rtc_nack_enabled(false);
+
+    SrsUniquePtr<SrsRtcPublishStream> publish_stream(new SrsRtcPublishStream(&mock_exec, &mock_expire, &mock_receiver, cid));
+    publish_stream->config_ = &mock_config;
+    publish_stream->rtc_sources_ = &mock_rtc_sources;
+    publish_stream->stat_ = &mock_stat;
+    publish_stream->circuit_breaker_ = &mock_circuit_breaker;
+    srs_freep(publish_stream->format_);
+    publish_stream->format_ = &mock_format;
+
+    uint32_t audio_rtx_ssrc = track_factory.audio_ssrc_ + 1;
+    uint32_t audio_fec_ssrc = track_factory.audio_ssrc_ + 2;
+    uint32_t video_rtx_ssrc = track_factory.video_ssrc_ + 1;
+    uint32_t video_fec_ssrc = track_factory.video_ssrc_ + 2;
+
+    SrsUniquePtr<SrsRtcSourceDescription> stream_desc(track_factory.create_stream_description());
+    stream_desc->audio_track_desc_->set_rtx_ssrc(audio_rtx_ssrc);
+    stream_desc->audio_track_desc_->set_fec_ssrc(audio_fec_ssrc);
+    stream_desc->video_track_descs_.at(0)->set_rtx_ssrc(video_rtx_ssrc);
+    stream_desc->video_track_descs_.at(0)->set_fec_ssrc(video_fec_ssrc);
+    HELPER_EXPECT_SUCCESS(publish_stream->initialize(&mock_request, stream_desc.get()));
+
+    // Send complete three-packet video frames until statistics are reported.
+    // The reported value must equal the number of primary marker packets, not
+    // the number of RTP packets used to carry those frames.
+    int primary_video_frames = 0;
+    uint16_t video_sequence = 100;
+    uint32_t video_timestamp = 90000;
+    for (; primary_video_frames < 1000 && mock_stat.video_frame_calls_ == 0; ++primary_video_frames) {
+        HELPER_EXPECT_SUCCESS(send_rtp_packet(publish_stream.get(), track_factory.video_ssrc_, video_sequence++, video_timestamp, track_factory.video_pt_, false));
+        HELPER_EXPECT_SUCCESS(send_rtp_packet(publish_stream.get(), track_factory.video_ssrc_, video_sequence++, video_timestamp, track_factory.video_pt_, false));
+        HELPER_EXPECT_SUCCESS(send_rtp_packet(publish_stream.get(), track_factory.video_ssrc_, video_sequence++, video_timestamp, track_factory.video_pt_, true));
+        video_timestamp += 3000;
+    }
+    EXPECT_GT(mock_stat.video_frame_calls_, 0);
+    EXPECT_EQ(primary_video_frames, mock_stat.video_frames_);
+
+    // Auxiliary marker packets do not describe new source frames and must not
+    // cause another video statistics report.
+    int video_calls_before_auxiliary = mock_stat.video_frame_calls_;
+    int video_frames_before_auxiliary = mock_stat.video_frames_;
+    for (int i = 0; i < 400; ++i) {
+        uint32_t ssrc = i % 2 ? video_rtx_ssrc : video_fec_ssrc;
+        HELPER_EXPECT_SUCCESS(send_rtp_packet(publish_stream.get(), ssrc, video_sequence++, video_timestamp, track_factory.video_pt_, true));
+    }
+    EXPECT_EQ(video_calls_before_auxiliary, mock_stat.video_frame_calls_);
+    EXPECT_EQ(video_frames_before_auxiliary, mock_stat.video_frames_);
+
+    // A duplicate primary marker is acceptable for these approximate statistics.
+    // Count every observation until the next report without deduplicating it.
+    int duplicate_video_packets = 0;
+    int video_calls_before_duplicates = mock_stat.video_frame_calls_;
+    int video_frames_before_duplicates = mock_stat.video_frames_;
+    for (; duplicate_video_packets < 1000 && mock_stat.video_frame_calls_ == video_calls_before_duplicates; ++duplicate_video_packets) {
+        HELPER_EXPECT_SUCCESS(send_rtp_packet(publish_stream.get(), track_factory.video_ssrc_, 65000, video_timestamp, track_factory.video_pt_, true));
+    }
+    EXPECT_GT(mock_stat.video_frame_calls_, video_calls_before_duplicates);
+    EXPECT_EQ(video_frames_before_duplicates + duplicate_video_packets, mock_stat.video_frames_);
+
+    // Each primary audio RTP packet is an audio frame observation.
+    int primary_audio_frames = 0;
+    uint16_t audio_sequence = 1000;
+    uint32_t audio_timestamp = 48000;
+    for (; primary_audio_frames < 1000 && mock_stat.audio_frame_calls_ == 0; ++primary_audio_frames) {
+        HELPER_EXPECT_SUCCESS(send_rtp_packet(publish_stream.get(), track_factory.audio_ssrc_, audio_sequence++, audio_timestamp, track_factory.audio_pt_, false));
+        audio_timestamp += 960;
+    }
+    EXPECT_GT(mock_stat.audio_frame_calls_, 0);
+    EXPECT_EQ(primary_audio_frames, mock_stat.audio_frames_);
+
+    // RTX and FEC audio packets are transport data rather than media frames.
+    int audio_calls_before_auxiliary = mock_stat.audio_frame_calls_;
+    int audio_frames_before_auxiliary = mock_stat.audio_frames_;
+    for (int i = 0; i < 400; ++i) {
+        uint32_t ssrc = i % 2 ? audio_rtx_ssrc : audio_fec_ssrc;
+        HELPER_EXPECT_SUCCESS(send_rtp_packet(publish_stream.get(), ssrc, audio_sequence++, audio_timestamp, track_factory.audio_pt_, false));
+    }
+    EXPECT_EQ(audio_calls_before_auxiliary, mock_stat.audio_frame_calls_);
+    EXPECT_EQ(audio_frames_before_auxiliary, mock_stat.audio_frames_);
+
+    // mock_format is stack-owned.
     publish_stream->format_ = NULL;
 }


### PR DESCRIPTION
Count primary media-frame observations instead of every RTP packet, exclude RTX and FEC traffic, and expose stream lifetime for FPS calculation. Add regression coverage for frame classification and the stream alive field.