### PR TITLE
Proxy: Preserve HTTP response headers and safely rewrite HLS. v8.0.20

### DIFF
--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -44,6 +44,60 @@ func buildBackendHTTPURL(ip string, port int, path string) string {
 	return fmt.Sprintf("http://%v:%v%s", ip, port, path)
 }
 
+// copyBackendResponseHeaders copies end-to-end response headers while dropping
+// fields that apply only to the backend connection. Connection can nominate
+// additional hop-by-hop fields, so collect those names before copying.
+func copyBackendResponseHeaders(dst, src http.Header) {
+	hopByHop := map[string]bool{
+		"Connection":          true,
+		"Proxy-Connection":    true,
+		"Keep-Alive":          true,
+		"Proxy-Authenticate":  true,
+		"Proxy-Authorization": true,
+		"Te":                  true,
+		"Trailer":             true,
+		"Transfer-Encoding":   true,
+		"Upgrade":             true,
+	}
+	for _, value := range src.Values("Connection") {
+		for _, name := range strings.Split(value, ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				hopByHop[http.CanonicalHeaderKey(name)] = true
+			}
+		}
+	}
+
+	for name, values := range src {
+		name = http.CanonicalHeaderKey(name)
+		if hopByHop[name] {
+			continue
+		}
+
+		dst.Del(name)
+		for _, value := range values {
+			dst.Add(name, value)
+		}
+	}
+}
+
+// repairRewrittenResponseHeaders removes backend representation metadata that
+// no longer describes a rewritten response body, then publishes its new size.
+func repairRewrittenResponseHeaders(header http.Header, contentLength int) {
+	for _, name := range []string{
+		"Accept-Ranges",
+		"Content-Digest",
+		"Content-Encoding",
+		"Content-MD5",
+		"Content-Range",
+		"Digest",
+		"ETag",
+		"Repr-Digest",
+	} {
+		header.Del(name)
+	}
+	header.Set("Content-Length", strconv.Itoa(contentLength))
+}
+
 type httpStreamProxyServer struct {
 	// The environment interface.
 	environment env.ProxyEnvironment
@@ -347,13 +401,10 @@ func (v *httpFlvTsConnection) serveByBackend(ctx context.Context, w http.Respons
 		return errors.Errorf("proxy stream to %v failed, status=%v", backendURL, resp.Status)
 	}
 
-	// Copy all headers from backend to client.
+	// Copy end-to-end headers before committing the response. Headers changed
+	// after WriteHeader are not sent by net/http.
+	copyBackendResponseHeaders(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
-	for k, v := range resp.Header {
-		for _, vv := range v {
-			w.Header().Add(k, vv)
-		}
-	}
 
 	logger.Debug(ctx, "HTTP start streaming")
 
@@ -476,16 +527,11 @@ func (v *hlsPlayStream) serveByBackend(ctx context.Context, w http.ResponseWrite
 		return errors.Errorf("proxy stream to %v failed, status=%v", backendURL, resp.Status)
 	}
 
-	// Copy all headers from backend to client.
-	w.WriteHeader(resp.StatusCode)
-	for k, v := range resp.Header {
-		for _, vv := range v {
-			w.Header().Add(k, vv)
-		}
-	}
-
 	// For TS file, directly copy it.
 	if !strings.HasSuffix(r.URL.Path, ".m3u8") {
+		copyBackendResponseHeaders(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+
 		if _, err := io.Copy(w, resp.Body); err != nil {
 			return errors.Wrapf(err, "copy stream to client, backend=%v", backendURL)
 		}
@@ -500,12 +546,19 @@ func (v *hlsPlayStream) serveByBackend(ctx context.Context, w http.ResponseWrite
 		return errors.Wrapf(err, "read stream from %v", backendURL)
 	}
 
-	m3u8 := string(b)
+	backendM3U8 := string(b)
+	m3u8 := backendM3U8
 	if strings.Contains(m3u8, ".ts?") {
-		m3u8 = strings.ReplaceAll(m3u8, ".ts?", fmt.Sprintf(".ts?spbhid=%v&&", v.SRSProxyBackendHLSID))
+		m3u8 = strings.ReplaceAll(m3u8, ".ts?", fmt.Sprintf(".ts?spbhid=%v&", v.SRSProxyBackendHLSID))
 	} else {
 		m3u8 = strings.ReplaceAll(m3u8, ".ts", fmt.Sprintf(".ts?spbhid=%v", v.SRSProxyBackendHLSID))
 	}
+
+	copyBackendResponseHeaders(w.Header(), resp.Header)
+	if m3u8 != backendM3U8 {
+		repairRewrittenResponseHeaders(w.Header(), len(m3u8))
+	}
+	w.WriteHeader(resp.StatusCode)
 
 	if _, err := io.Copy(w, strings.NewReader(m3u8)); err != nil {
 		return errors.Wrapf(err, "proxy m3u8 client to %v", backendURL)

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -370,8 +370,107 @@ func TestHLSPlayStream_ServeByBackend_M3U8RewritesTSWithQuery(t *testing.T) {
 		&lb.OriginServer{IP: host, HTTP: []string{port}}); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if want := "live-0.ts?spbhid=ABC&&token=foo"; !strings.Contains(rec.Body.String(), want) {
+	if want := "live-0.ts?spbhid=ABC&token=foo"; !strings.Contains(rec.Body.String(), want) {
 		t.Fatalf("missing %q in body: %q", want, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "&&") {
+		t.Fatalf("rewritten query contains an empty parameter: %q", rec.Body.String())
+	}
+}
+
+func TestHLSPlayStream_ServeByBackend_PreservesEndToEndHeaders(t *testing.T) {
+	backendM3U8 := "#EXTM3U\n"
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Last-Modified", "Wed, 12 Aug 2026 12:00:00 GMT")
+		w.Header().Set("Vary", "Origin")
+		w.Header().Set("X-Origin", "srs")
+		_, _ = io.WriteString(w, backendM3U8)
+	}))
+	defer backend.Close()
+	host, port := httptestHostPort(t, backend)
+
+	stream := newHLSPlayStream(func(s *hlsPlayStream) { s.SRSProxyBackendHLSID = "ABC" })
+	proxyErr := make(chan error, 1)
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyErr <- stream.serveByBackend(context.Background(), w, r,
+			&lb.OriginServer{IP: host, HTTP: []string{port}})
+	}))
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/live.m3u8")
+	if err != nil {
+		t.Fatalf("request proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read playlist: %v", err)
+	}
+	if got, want := string(body), backendM3U8; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+	for name, want := range map[string]string{
+		"Content-Type":  "application/vnd.apple.mpegurl",
+		"Cache-Control": "no-cache",
+		"Last-Modified": "Wed, 12 Aug 2026 12:00:00 GMT",
+		"Vary":          "Origin",
+		"X-Origin":      "srs",
+	} {
+		if got := resp.Header.Get(name); got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+	if err := <-proxyErr; err != nil {
+		t.Errorf("proxy response failed: %v", err)
+	}
+}
+
+func TestHLSPlayStream_ServeByBackend_RewrittenBodyUsesValidFraming(t *testing.T) {
+	backendM3U8 := "#EXTM3U\nlive-0.ts\n"
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(backendM3U8)))
+		w.Header().Set("ETag", `"origin-playlist-v1"`)
+		_, _ = io.WriteString(w, backendM3U8)
+	}))
+	defer backend.Close()
+	host, port := httptestHostPort(t, backend)
+
+	stream := newHLSPlayStream(func(s *hlsPlayStream) { s.SRSProxyBackendHLSID = "ABC" })
+	proxyErr := make(chan error, 1)
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyErr <- stream.serveByBackend(context.Background(), w, r,
+			&lb.OriginServer{IP: host, HTTP: []string{port}})
+	}))
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/live.m3u8")
+	if err != nil {
+		t.Fatalf("request proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+
+	if readErr != nil {
+		t.Errorf("read complete rewritten playlist: %v", readErr)
+	}
+	if got, want := string(body), "#EXTM3U\nlive-0.ts?spbhid=ABC\n"; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+	// A correct implementation may recompute Content-Length or omit it and use
+	// chunked framing. It must never expose the backend length for a body that
+	// was enlarged by playlist rewriting.
+	if resp.ContentLength >= 0 && resp.ContentLength != int64(len(body)) {
+		t.Errorf("Content-Length = %d, delivered body length = %d", resp.ContentLength, len(body))
+	}
+	// A strong validator for the backend bytes is stale after the proxy
+	// rewrites those bytes. The proxy may remove it or generate a new value.
+	if got := resp.Header.Get("ETag"); got == `"origin-playlist-v1"` {
+		t.Errorf("forwarded stale backend ETag %q for rewritten playlist", got)
+	}
+	if err := <-proxyErr; err != nil {
+		t.Errorf("proxy response failed: %v", err)
 	}
 }
 
@@ -619,6 +718,100 @@ func TestHTTPFlvTsConn_ServeByBackend_BodyPassthrough(t *testing.T) {
 	}
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestHTTPFlvTsConn_ServeByBackend_PreservesEndToEndHeaders(t *testing.T) {
+	payload := []byte{0x46, 0x4c, 0x56, 0x01, 0x05, 0x00, 0x00, 0x00}
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "video/x-flv")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("ETag", `"flv-v1"`)
+		w.Header().Set("Last-Modified", "Wed, 12 Aug 2026 12:00:00 GMT")
+		w.Header().Set("Vary", "Origin")
+		w.Header().Set("X-Origin", "srs")
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		_, _ = w.Write(payload)
+	}))
+	defer backend.Close()
+	host, port := httptestHostPort(t, backend)
+
+	conn := newHTTPFlvTsConnection()
+	proxyErr := make(chan error, 1)
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyErr <- conn.serveByBackend(context.Background(), w, r,
+			&lb.OriginServer{IP: host, HTTP: []string{port}})
+	}))
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/live.flv")
+	if err != nil {
+		t.Fatalf("request proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+
+	if readErr != nil {
+		t.Errorf("read complete FLV response: %v", readErr)
+	}
+	if !bytes.Equal(body, payload) {
+		t.Errorf("body = %v, want %v", body, payload)
+	}
+	for name, want := range map[string]string{
+		"Content-Type":  "video/x-flv",
+		"Cache-Control": "no-store",
+		"ETag":          `"flv-v1"`,
+		"Last-Modified": "Wed, 12 Aug 2026 12:00:00 GMT",
+		"Vary":          "Origin",
+		"X-Origin":      "srs",
+	} {
+		if got := resp.Header.Get(name); got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+	if resp.ContentLength >= 0 && resp.ContentLength != int64(len(body)) {
+		t.Errorf("Content-Length = %d, delivered body length = %d", resp.ContentLength, len(body))
+	}
+	if err := <-proxyErr; err != nil {
+		t.Errorf("proxy response failed: %v", err)
+	}
+}
+
+func TestHTTPFlvTsConn_ServeByBackend_DropsHopByHopHeaders(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "X-Backend-Hop")
+		w.Header().Set("X-Backend-Hop", "secret")
+		w.Header().Set("Keep-Alive", "timeout=5")
+		w.Header().Set("Proxy-Connection", "keep-alive")
+		_, _ = io.WriteString(w, "FLV")
+	}))
+	defer backend.Close()
+	host, port := httptestHostPort(t, backend)
+
+	conn := newHTTPFlvTsConnection()
+	proxyErr := make(chan error, 1)
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyErr <- conn.serveByBackend(context.Background(), w, r,
+			&lb.OriginServer{IP: host, HTTP: []string{port}})
+	}))
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/live.flv")
+	if err != nil {
+		t.Fatalf("request proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("read FLV response: %v", err)
+	}
+
+	for _, name := range []string{"Connection", "X-Backend-Hop", "Keep-Alive", "Proxy-Connection"} {
+		if got := resp.Header.Values(name); len(got) != 0 {
+			t.Errorf("hop-by-hop header %s was forwarded: %q", name, got)
+		}
+	}
+	if err := <-proxyErr; err != nil {
+		t.Errorf("proxy response failed: %v", err)
 	}
 }
 

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	stdSync "sync"
@@ -50,6 +51,122 @@ func reservedClosedPort(t *testing.T) (string, string) {
 		t.Fatalf("close listener: %v", err)
 	}
 	return addr.IP.String(), strconv.Itoa(addr.Port)
+}
+
+// =============================================================================
+// HTTP response header helpers
+// =============================================================================
+
+func TestCopyBackendResponseHeaders(t *testing.T) {
+	dst := http.Header{
+		"Cache-Control": {"old-value"},
+		"X-Proxy":       {"preserved"},
+	}
+	src := http.Header{}
+	src.Set("Cache-Control", "no-cache")
+	src.Set("Content-Type", "application/vnd.apple.mpegurl")
+	src.Add("X-Multi-Value", "first")
+	src.Add("X-Multi-Value", "second")
+
+	// Connection nominates extra fields that are hop-by-hop even when their
+	// names are otherwise unknown to the proxy.
+	src.Add("Connection", "X-Backend-Hop, X-Backend-Second")
+	src.Set("X-Backend-Hop", "secret")
+	src.Set("X-Backend-Second", "secret-2")
+
+	for _, name := range []string{
+		"Proxy-Connection",
+		"Keep-Alive",
+		"Proxy-Authenticate",
+		"Proxy-Authorization",
+		"TE",
+		"Trailer",
+		"Transfer-Encoding",
+		"Upgrade",
+	} {
+		src.Set(name, "must-not-pass")
+	}
+
+	copyBackendResponseHeaders(dst, src)
+
+	for name, want := range map[string][]string{
+		"Cache-Control": {"no-cache"},
+		"Content-Type":  {"application/vnd.apple.mpegurl"},
+		"X-Multi-Value": {"first", "second"},
+		"X-Proxy":       {"preserved"},
+	} {
+		if got := dst.Values(name); !slices.Equal(got, want) {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+
+	for _, name := range []string{
+		"Connection",
+		"X-Backend-Hop",
+		"X-Backend-Second",
+		"Proxy-Connection",
+		"Keep-Alive",
+		"Proxy-Authenticate",
+		"Proxy-Authorization",
+		"TE",
+		"Trailer",
+		"Transfer-Encoding",
+		"Upgrade",
+	} {
+		if got := dst.Values(name); len(got) != 0 {
+			t.Errorf("hop-by-hop header %s was copied: %q", name, got)
+		}
+	}
+}
+
+func TestRepairRewrittenResponseHeaders(t *testing.T) {
+	header := http.Header{
+		"Accept-Ranges":    {"bytes"},
+		"Content-Digest":   {"sha-256=:digest:"},
+		"Content-Encoding": {"gzip"},
+		"Content-Length":   {"18", "stale-duplicate"},
+		"Content-Md5":      {"md5"},
+		"Content-Range":    {"bytes 0-17/18"},
+		"Digest":           {"sha-256=digest"},
+		"Etag":             {`"origin-playlist-v1"`},
+		"Repr-Digest":      {"sha-256=:digest:"},
+		"Cache-Control":    {"no-cache"},
+		"Content-Type":     {"application/vnd.apple.mpegurl"},
+		"Last-Modified":    {"Wed, 12 Aug 2026 12:00:00 GMT"},
+		"Vary":             {"Origin"},
+		"X-Origin":         {"srs"},
+	}
+
+	repairRewrittenResponseHeaders(header, 39)
+
+	for _, name := range []string{
+		"Accept-Ranges",
+		"Content-Digest",
+		"Content-Encoding",
+		"Content-MD5",
+		"Content-Range",
+		"Digest",
+		"ETag",
+		"Repr-Digest",
+	} {
+		if got := header.Values(name); len(got) != 0 {
+			t.Errorf("stale representation header %s remains: %q", name, got)
+		}
+	}
+	if got := header.Values("Content-Length"); !slices.Equal(got, []string{"39"}) {
+		t.Errorf("Content-Length = %q, want [39]", got)
+	}
+	for name, want := range map[string]string{
+		"Cache-Control": "no-cache",
+		"Content-Type":  "application/vnd.apple.mpegurl",
+		"Last-Modified": "Wed, 12 Aug 2026 12:00:00 GMT",
+		"Vary":          "Origin",
+		"X-Origin":      "srs",
+	} {
+		if got := header.Get(name); got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
 }
 
 // =============================================================================

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 19
+	return 20
 }
 
 func Version() string {

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v8-changes"></a>
 
 ## SRS 8.0 Changelog
+* v8.0, 2026-08-12, Merge [#4718](https://github.com/ossrs/srs/pull/4718): Proxy: Preserve HTTP response headers and safely rewrite HLS. v8.0.20 (#4718)
 * v8.0, 2026-08-12, Merge [#4717](https://github.com/ossrs/srs/pull/4717): Codex: Correct RTC frame statistics. v8.0.19 (#4717)
 * v8.0, 2026-08-12, Merge [#4716](https://github.com/ossrs/srs/pull/4716): JSON: Update vendored json-parser library. v8.0.18 (#4716)
 * v8.0, 2026-08-12, Merge [#4715](https://github.com/ossrs/srs/pull/4715): CI: Modernize GitHub Actions for SRS 8.0. v8.0.17 (#4715)

--- a/trunk/src/core/srs_core_version8.hpp
+++ b/trunk/src/core/srs_core_version8.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 8
 #define VERSION_MINOR 0
-#define VERSION_REVISION 19
+#define VERSION_REVISION 20
 
 #endif


### PR DESCRIPTION
## Summary

- Preserve end-to-end backend response headers for HTTP-FLV, HTTP-TS, and HLS responses.
- Remove standard hop-by-hop headers and additional fields nominated by `Connection`.
- Rewrite HLS segment URLs with a canonical single `&` when the original URL already has query parameters.
- Repair response metadata after modifying an m3u8 body, and add wire-level regression coverage.

## Problem

The HTTP proxy called `WriteHeader` before copying headers from the backend. Go commits the response at that point, so later additions such as `Content-Type`, `Cache-Control`, `ETag`, `Last-Modified`, `Vary`, and custom origin metadata never reached the downstream client.

HLS playlist rewriting also generated segment URLs containing an unnecessary empty query component:

```text
segment.ts?spbhid=xxx&&token=abc
```

Moving header copying before `WriteHeader` is not sufficient by itself. An m3u8 playlist is modified when the proxy inserts `spbhid`, so the backend's original `Content-Length`, strong `ETag`, digest, content encoding, and range metadata no longer describe the downstream representation. Forwarding the stale length can make Go reject the enlarged response with `http: wrote more than the declared Content-Length`.

A proxy must also avoid forwarding connection-specific headers to the next hop.

## Changes

- Copy backend end-to-end headers before committing HTTP-FLV, HTTP-TS, and HLS responses.
- Strip `Connection`, its nominated fields, and the standard proxy/connection-specific header set.
- Keep byte-transparent FLV and TS representation metadata unchanged.
- Read and rewrite m3u8 playlists before sending response headers.
- Recompute `Content-Length` and remove stale validators, digests, encodings, and range metadata when the playlist body changes.
- Generate existing-query segment URLs as:

  ```text
  segment.ts?spbhid=xxx&token=abc
  ```

- Add real HTTP-boundary tests for header preservation, hop-by-hop removal, query rewriting, complete playlist delivery, and rewritten-body metadata.
