### PR TITLE
Backport #4659: Fix resource leak in ParseBody. v7.0.159

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -69,11 +69,12 @@ func ApiCORS(ctx context.Context, w http.ResponseWriter, r *http.Request) bool {
 
 // ParseBody read the body from r, and unmarshal JSON to v.
 func ParseBody(r io.ReadCloser, v interface{}) error {
+	defer r.Close()
+
 	b, err := io.ReadAll(r)
 	if err != nil {
 		return errors.Wrapf(err, "read body")
 	}
-	defer r.Close()
 
 	if len(b) == 0 {
 		return nil

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -121,6 +121,19 @@ func TestParseBody_ReadError(t *testing.T) {
 	}
 }
 
+// TestParseBody_CloseCalledOnReadError verifies that r.Close() is called even
+// when ReadAll fails - this prevents the resource leak fixed by moving defer
+// to the top of the function.
+func TestParseBody_CloseCalledOnReadError(t *testing.T) {
+	rc := &errReadCloser{}
+	if err := ParseBody(rc, &struct{}{}); err == nil {
+		t.Fatal("want error")
+	}
+	if !rc.closed {
+		t.Fatal("Close() was not called on read error - resource leak")
+	}
+}
+
 func TestParseBody_UnmarshalError(t *testing.T) {
 	var v struct{ Name string }
 	err := ParseBody(io.NopCloser(strings.NewReader("not json")), &v)
@@ -141,6 +154,8 @@ func TestBuildStreamURL(t *testing.T) {
 		{"rtmp://127.0.0.1/live/stream", "__defaultVhost__/live/stream"},
 		{"rtmp://localhost/live/stream", "__defaultVhost__/live/stream"},
 		{"rtmp://localhost:1935/live/stream", "__defaultVhost__/live/stream"},
+		{"rtmp://[::1]/live/stream", "__defaultVhost__/live/stream"},
+		{"rtmp://[2001:db8::1]:1935/live/stream", "__defaultVhost__/live/stream"},
 	}
 	for _, c := range cases {
 		got, err := BuildStreamURL(c.in)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ func VersionMinor() int {
 }
 
 func VersionRevision() int {
-	return 158
+	return 159
 }
 
 func Version() string {

--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2026-08-18, Merge [#4659](https://github.com/ossrs/srs/pull/4659): Proxy: Fix resource leak in ParseBody. v7.0.159 (#4659)
 * v7.0, 2026-08-17, Merge [#4724](https://github.com/ossrs/srs/pull/4724): Codex: Backport preferred RTMP chunk stream IDs to SRS 7. v7.0.158 (#4724)
 * v7.0, 2026-08-10, Merge [#4713](https://github.com/ossrs/srs/pull/4713): Codex: Do not count graceful disconnects as client errors. v7.0.157 (#4713)
 * v7.0, 2026-08-10, Merge [#4708](https://github.com/ossrs/srs/pull/4708): Codex: Fix duplicated RTMP HTTP callback parameters. v7.0.156 (#4708)

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR 7
 #define VERSION_MINOR 0
-#define VERSION_REVISION 158
+#define VERSION_REVISION 159
 
 #endif


### PR DESCRIPTION
Backports #4659 (`69cbfe5e9`) to the SRS 7.0 release branch.

`ParseBody` deferred `r.Close()` only after `io.ReadAll(r)` succeeded. When `io.ReadAll` returned an error, the function returned before registering the deferred close, leaving the request/body reader open.
