### PR TITLE
HTTP: Return HTTP status for rejected playback hooks

### DIFF
--- a/skills/internal-docs-for-srs/references/cpp-docs/doc/http-callback.md
+++ b/skills/internal-docs-for-srs/references/cpp-docs/doc/http-callback.md
@@ -425,6 +425,22 @@ Content-Length: 11
 {"code": 0}
 ```
 
+### HTTP Live Playback Errors
+
+When an `on_play` callback rejects HTTP live playback (HTTP-FLV, HTTP-TS, AAC, or
+MP3 through `http_remux`), SRS sends an HTTP error response to the player:
+
+* A callback HTTP status in the `400`-`599` range is passed through.
+* For callback HTTP `200` or `201`, an integer JSON `code` in the `400`-`599`
+  range becomes the playback HTTP status. For example, `{"code":401}` returns
+  HTTP `401 Unauthorized` to the player.
+* Other application error codes, invalid or empty responses, and transport
+  failures return HTTP `500 Internal Server Error`.
+
+The response body contains only the standard HTTP status text. Callback URLs,
+request parameters, and backend error messages are not included. Successful
+callbacks and rejection handling for other playback protocols are unchanged.
+
 You could run the example HTTP callback server by:
 
 ```

--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -45,6 +45,14 @@ ISrsHttpHooks::~ISrsHttpHooks()
 {
 }
 
+srs_error_t ISrsHttpHooks::on_play(string url, ISrsRequest *req, int *http_status)
+{
+    if (http_status) {
+        *http_status = SRS_CONSTS_HTTP_InternalServerError;
+    }
+    return on_play(url, req);
+}
+
 SrsHttpHooks::SrsHttpHooks()
 {
     factory_ = _srs_app_factory;
@@ -219,6 +227,11 @@ void SrsHttpHooks::on_unpublish(string url, ISrsRequest *req)
 
 srs_error_t SrsHttpHooks::on_play(string url, ISrsRequest *req)
 {
+    return on_play(url, req, NULL);
+}
+
+srs_error_t SrsHttpHooks::on_play(string url, ISrsRequest *req, int *http_status)
+{
     srs_error_t err = srs_success;
 
     SrsContextId cid = _srs_context->get_id();
@@ -246,10 +259,10 @@ srs_error_t SrsHttpHooks::on_play(string url, ISrsRequest *req)
 
     std::string data = obj->dumps();
     std::string res;
-    int status_code;
+    int status_code = 0;
 
     SrsUniquePtr<ISrsHttpClient> http(factory_->create_http_client());
-    if ((err = do_post(http.get(), url, data, status_code, res)) != srs_success) {
+    if ((err = do_post(http.get(), url, data, status_code, res, http_status)) != srs_success) {
         return srs_error_wrap(err, "http: on_play failed, client_id=%s, url=%s, request=%s, response=%s, status=%d",
                               cid.c_str(), url.c_str(), data.c_str(), res.c_str(), status_code);
     }
@@ -598,9 +611,13 @@ srs_error_t SrsHttpHooks::on_forward_backend(string url, ISrsRequest *req, std::
     return err;
 }
 
-srs_error_t SrsHttpHooks::do_post(ISrsHttpClient *hc, std::string url, std::string req, int &code, string &res)
+srs_error_t SrsHttpHooks::do_post(ISrsHttpClient *hc, std::string url, std::string req, int &code, string &res, int *http_status)
 {
     srs_error_t err = srs_success;
+
+    if (http_status) {
+        *http_status = SRS_CONSTS_HTTP_InternalServerError;
+    }
 
     SrsHttpUri uri;
     if ((err = uri.initialize(url)) != srs_success) {
@@ -623,6 +640,9 @@ srs_error_t SrsHttpHooks::do_post(ISrsHttpClient *hc, std::string url, std::stri
     SrsUniquePtr<ISrsHttpMessage> msg(msg_raw);
 
     code = msg->status_code();
+    if (http_status && code >= 400 && code < 600) {
+        *http_status = code;
+    }
     if ((err = msg->body_read_all(res)) != srs_success) {
         return srs_error_wrap(err, "http: body read");
     }
@@ -659,6 +679,11 @@ srs_error_t SrsHttpHooks::do_post(ISrsHttpClient *hc, std::string url, std::stri
     }
 
     if ((res_code->to_integer()) != ERROR_SUCCESS) {
+        // Application error codes outside the HTTP error range remain internal errors.
+        int64_t hook_code = res_code->to_integer();
+        if (http_status && hook_code >= 400 && hook_code < 600) {
+            *http_status = (int)hook_code;
+        }
         return srs_error_new(ERROR_RESPONSE_CODE, "http: response object code %" PRId64 " %s", res_code->to_integer(), res.c_str());
     }
 

--- a/trunk/src/app/srs_app_http_hooks.hpp
+++ b/trunk/src/app/srs_app_http_hooks.hpp
@@ -62,6 +62,10 @@ public:
     // @return srs_success if playing is allowed, error otherwise to reject playing.
     virtual srs_error_t on_play(std::string url, ISrsRequest *req) = 0;
 
+    // As above, optionally returning a 4xx/5xx HTTP status on failure, or 500 if unavailable.
+    // The default implementation preserves existing hook implementations.
+    virtual srs_error_t on_play(std::string url, ISrsRequest *req, int *http_status);
+
     // Stream stop playing notification hook.
     // Called when a client stops playing/subscribing to a stream.
     // This is a notification-only hook that cannot prevent the stop operation.
@@ -169,6 +173,7 @@ public:
     srs_error_t on_publish(std::string url, ISrsRequest *req);
     void on_unpublish(std::string url, ISrsRequest *req);
     srs_error_t on_play(std::string url, ISrsRequest *req);
+    srs_error_t on_play(std::string url, ISrsRequest *req, int *http_status);
     void on_stop(std::string url, ISrsRequest *req);
     srs_error_t on_dvr(SrsContextId cid, std::string url, ISrsRequest *req, std::string file);
     srs_error_t on_hls(SrsContextId cid, std::string url, ISrsRequest *req, std::string file, std::string ts_url,
@@ -179,7 +184,7 @@ public:
 
 // clang-format off
 SRS_DECLARE_PRIVATE: // clang-format on
-    srs_error_t do_post(ISrsHttpClient *hc, std::string url, std::string req, int &code, std::string &res);
+    srs_error_t do_post(ISrsHttpClient *hc, std::string url, std::string req, int &code, std::string &res, int *http_status = NULL);
 };
 
 // Global HTTP hooks instance

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -711,8 +711,12 @@ srs_error_t SrsLiveStream::serve_http_impl(ISrsHttpResponseWriter *w, ISrsHttpMe
     }
 
     // We must do hook after stat, because depends on it.
-    if ((err = http_hooks_on_play(r)) != srs_success) {
-        return srs_error_wrap(err, "http hook");
+    int http_status = SRS_CONSTS_HTTP_InternalServerError;
+    if ((err = http_hooks_on_play(r, &http_status)) != srs_success) {
+        srs_warn("http hook: %s", srs_error_desc(err).c_str());
+        srs_freep(err);
+        // Hook errors can contain credentials and internal URLs. Return only the status text.
+        return srs_go_http_error(w, http_status);
     }
 
     // Fast check whether stream is still available.
@@ -922,7 +926,7 @@ srs_error_t SrsLiveStream::do_serve_http(SrsLiveSource *source, ISrsLiveConsumer
     return srs_error_new(ERROR_HTTP_STREAM_EOF, "Stream EOF");
 }
 
-srs_error_t SrsLiveStream::http_hooks_on_play(ISrsHttpMessage *r)
+srs_error_t SrsLiveStream::http_hooks_on_play(ISrsHttpMessage *r, int *http_status)
 {
     srs_error_t err = srs_success;
 
@@ -951,7 +955,7 @@ srs_error_t SrsLiveStream::http_hooks_on_play(ISrsHttpMessage *r)
 
     for (int i = 0; i < (int)hooks.size(); i++) {
         std::string url = hooks.at(i);
-        if ((err = hooks_->on_play(url, nreq.get())) != srs_success) {
+        if ((err = hooks_->on_play(url, nreq.get(), http_status)) != srs_success) {
             return srs_error_wrap(err, "http on_play %s", url.c_str());
         }
     }

--- a/trunk/src/app/srs_app_http_stream.hpp
+++ b/trunk/src/app/srs_app_http_stream.hpp
@@ -298,7 +298,7 @@ public:
 // clang-format off
 SRS_DECLARE_PRIVATE: // clang-format on
     virtual srs_error_t do_serve_http(SrsLiveSource *source, ISrsLiveConsumer *consumer, ISrsHttpResponseWriter *w, ISrsHttpMessage *r);
-    virtual srs_error_t http_hooks_on_play(ISrsHttpMessage *r);
+    virtual srs_error_t http_hooks_on_play(ISrsHttpMessage *r, int *http_status = NULL);
     virtual void http_hooks_on_stop(ISrsHttpMessage *r);
     virtual srs_error_t streaming_send_messages(ISrsBufferEncoder *enc, SrsMediaPacket **msgs, int nb_msgs);
 };

--- a/trunk/src/utest/srs_utest_ai17.cpp
+++ b/trunk/src/utest/srs_utest_ai17.cpp
@@ -11,6 +11,7 @@ using namespace std;
 #include <srs_app_config.hpp>
 #include <srs_app_dash.hpp>
 #include <srs_app_http_hooks.hpp>
+#include <srs_app_http_stream.hpp>
 #include <srs_app_rtc_api.hpp>
 #include <srs_app_rtc_server.hpp>
 #include <srs_app_statistic.hpp>
@@ -20,6 +21,7 @@ using namespace std;
 #include <srs_kernel_utility.hpp>
 #include <srs_protocol_json.hpp>
 #include <srs_utest_ai13.hpp>
+#include <srs_utest_ai14.hpp>
 #include <srs_utest_ai15.hpp>
 #include <srs_utest_ai16.hpp>
 #include <srs_utest_ai23.hpp>
@@ -4222,6 +4224,120 @@ VOID TEST(HttpHooksTest, OnPlaySuccess)
     // Clean up - set injected fields to NULL to avoid double-free
     hooks->factory_ = NULL;
     hooks->stat_ = NULL;
+}
+
+VOID TEST(HttpHooksTest, PlaybackHttpErrorResponse)
+{
+    struct TestCase {
+        int hook_status;
+        const char *body;
+        int player_status;
+    } cases[] = {
+        {200, "{\"code\":0}", 0},
+        {200, "0", 0},
+        {201, "{\"code\":0}", 0},
+        {201, "0", 0},
+        {401, "private backend response", 401},
+        {403, "{\"code\":401}", 403},
+        {503, "", 503},
+        {200, "{\"code\":401,\"message\":\"private backend response\"}", 401},
+        {201, "{\"code\":403}", 403},
+        {200, "{\"code\":503}", 503},
+        {200, "{\"code\":400}", 400},
+        {200, "{\"code\":599}", 599},
+        {200, "{\"code\":399}", 500},
+        {200, "{\"code\":600}", 500},
+        {200, "{\"code\":4294967697}", 500},
+        {200, "{\"code\":-1}", 500},
+        {200, "{\"code\":\"401\"}", 500},
+        {200, "{\"message\":\"private backend response\"}", 500},
+        {200, "invalid JSON", 500},
+        {200, "", 500},
+        {302, "{\"code\":401}", 500},
+        {0, "", 500}, // Transport failure before receiving an HTTP response.
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        SCOPED_TRACE(i);
+        srs_error_t err = srs_success;
+        SrsUniquePtr<MockHttpMessageForLiveStream> message(new MockHttpMessageForLiveStream());
+        MockResponseWriter writer;
+        MockRequest request("test.vhost", "live", "stream1");
+        MockBufferCache cache;
+        MockStatisticForLiveStream stat;
+        MockSecurity security;
+        MockAppConfigForLiveStreamHooks config;
+        config.http_hooks_enabled_ = true;
+        config.on_play_directive_ = new SrsConfDirective();
+        config.on_play_directive_->args_.push_back("http://127.0.0.1:8085/private-hook?token=secret");
+        if (cases[i].player_status) {
+            config.on_play_directive_->args_.push_back("http://127.0.0.1:8085/second-hook");
+        }
+
+        MockAppFactoryForHooksTest factory;
+        MockStatisticForHooks hook_stat;
+        SrsHttpHooks hooks;
+        hooks.factory_ = &factory;
+        hooks.stat_ = &hook_stat;
+
+        srs_error_t post_error = srs_success;
+        factory.mock_http_client_ = new MockHttpClientForHooks();
+        if (cases[i].hook_status == 0) {
+            post_error = srs_error_new(ERROR_SOCKET_TIMEOUT, "private transport failure");
+            factory.mock_http_client_->post_error_ = post_error;
+        } else {
+            MockHttpMessageForHooks *response = new MockHttpMessageForHooks();
+            response->status_code_ = cases[i].hook_status;
+            response->body_content_ = cases[i].body;
+            factory.mock_http_client_->mock_response_ = response;
+        }
+
+        SrsLiveStream stream(&request, &cache);
+        stream.stat_ = &stat;
+        srs_freep(stream.security_);
+        stream.security_ = &security;
+        stream.config_ = &config;
+        stream.hooks_ = &hooks;
+        stream.entry_ = new SrsHttpMuxEntry();
+        stream.entry_->enabled = false;
+
+        err = stream.serve_http(&writer, message.get());
+        if (cases[i].player_status) {
+            EXPECT_TRUE(err == srs_success);
+            string response(writer.io.out_buffer.bytes(), writer.io.out_buffer.length());
+            char expected[32];
+            snprintf(expected, sizeof(expected), "HTTP/1.1 %d ", cases[i].player_status);
+            EXPECT_EQ(0, response.find(expected));
+            EXPECT_EQ(string::npos, response.find("private"));
+            EXPECT_EQ(string::npos, response.find("secret"));
+            EXPECT_EQ(string::npos, response.find("127.0.0.1"));
+        } else {
+            EXPECT_EQ(ERROR_RTMP_STREAM_NOT_FOUND, srs_error_code(err));
+            EXPECT_EQ(0, writer.io.out_buffer.length());
+        }
+        EXPECT_TRUE(stream.viewers_.empty());
+        srs_freep(err);
+        srs_freep(post_error);
+        stream.stat_ = NULL;
+        stream.security_ = NULL;
+        stream.config_ = NULL;
+        stream.hooks_ = NULL;
+        srs_freep(stream.entry_);
+    }
+}
+
+VOID TEST(HttpHooksTest, ExistingOnPlayImplementation)
+{
+    srs_error_t err = srs_success;
+    MockHttpHooksForLiveStream hooks;
+    MockRequest request("test.vhost", "live", "stream1");
+    ISrsHttpHooks *existing_hooks = &hooks;
+    int http_status = 0;
+
+    hooks.on_play_error_ = srs_error_new(ERROR_RESPONSE_CODE, "rejected");
+    HELPER_EXPECT_FAILED(existing_hooks->on_play("http://localhost/on_play", &request, &http_status));
+    EXPECT_EQ(500, http_status);
+    EXPECT_EQ(1, hooks.on_play_count_);
 }
 
 VOID TEST(HttpHooksTest, OnStopSuccess)


### PR DESCRIPTION
Currently, SRS does not propagate an `on_play` hook's error to the HTTP status sent to the HTTP-FLV client. For example, a hook returning HTTP 200 with `{"code":401}` does not result in HTTP 401 for the client.

This change makes SRS return the corresponding HTTP error status to the client: hook HTTP 4xx/5xx statuses are preserved, and JSON `code` values in the 400-599 range from HTTP 200/201 hook responses become the client's HTTP status. Other hook failures return HTTP 500. In the example above, the client now receives HTTP 401.

Validation: all 2,381 C++ unit tests and real HTTP-FLV playback checks pass. The edge test fails on FFmpeg's log format; WHIP media testing is blocked by a missing muxer.
